### PR TITLE
Remove use of --token in GH policy

### DIFF
--- a/core/mondoo-github-security.mql.yaml
+++ b/core/mondoo-github-security.mql.yaml
@@ -26,7 +26,7 @@ policies:
         4. Run a scan:
 
            ```bash
-           cnspec scan github org <ORG_NAME> --token $GITHUB_TOKEN
+           cnspec scan github org <ORG_NAME>
            ```
 
         If you have questions, comments, or have identified ways to improve this policy, please write us at hello@mondoo.io, or reach out in [GitHub Discussions](https://github.com/orgs/mondoohq/discussions).


### PR DESCRIPTION
We look for the env var so there's no need to export the env var and specify it on the CLI.

Signed-off-by: Tim Smith <tsmith84@gmail.com>