### PR TITLE
Don't error checking /etc/shadow if it's not there

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2363,13 +2363,15 @@ queries:
         chmod 000 /etc/shadow
         ```
     query: |
-      file("/etc/shadow") {
-        permissions.user_executable == false
-        permissions.group_writeable == false
-        permissions.group_executable == false
-        permissions.other_readable == false
-        permissions.other_writeable == false
-        permissions.other_executable == false
+      if (file("/etc/shadow").exists) {
+        file("/etc/shadow") {
+          permissions.user_executable == false
+          permissions.group_writeable == false
+          permissions.group_executable == false
+          permissions.other_readable == false
+          permissions.other_writeable == false
+          permissions.other_executable == false
+        }
       }
   - uid: mondoo-linux-security-baseline-6.1.4_ensure_permissions_on_etcgroup_are_configured
     title: Ensure secure permissions on /etc/group are set


### PR DESCRIPTION
This is not present on some containers. There's no reason to error when we can't find it since there's nothing to secure in that case.

Signed-off-by: Tim Smith <tsmith84@gmail.com>