### PR TITLE
update readme, and community links & improve wording for extra policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # cnspec-policies
 
-This project contains security and operational best-practice policies (as-code) used with [`cnspec`](https://github.com/mondoohq/cnspec). The policies have been organized into the following directories:
+This project contains security and operational best-practice policies (as code) for use with [`cnspec`](https://github.com/mondoohq/cnspec). We've organized them into these directories:
 
-- [core](core) - Core policies contain baseline security and operational best-practices controls for various scan targets. Core policies are maintained by Mondoo and have strict quality requirements.
-- [extra](extra) Extra policies are for policy bundles that do not fit in core or community policy bundles.
-- [community](community) Community policies are primarily maintained by the community with support of the Mondoo team. Community policies may move to extra or core over time. 
+- [core](core) - Core policies contain baseline security and operational best-practice controls for various scan targets. Core policies are maintained by Mondoo and have strict quality requirements.
+- [extra](extra) - Extra policies are a mix of community- and Mondoo-maintained policy bundles that are outside Mondoo's core support tier.
+- [community](community) - Community policies are primarily maintained by the community with the support of the Mondoo team. Community policies may move to extra or core over time. 
 
-Additional certified security and compliance policies can be found in the Policy Hub in Mondoo Platform. [Sign up for a free account](https://console.mondoo.com/signup) to view the list of policies available.
+### Join the community!
+
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.
+
+### Additional policies
+
+Additional certified security and compliance policies can be found in the Policy Hub on Mondoo Platform. [Sign up for a free account](https://console.mondoo.com/signup) to view the list of policies available.
 
 ## License
 

--- a/community/README.md
+++ b/community/README.md
@@ -8,4 +8,4 @@ We welcome all contributions. For more information on contributing to cnspec-pol
 
 ### Join the community!
 
-Join the [Mondoo Slack Community](https://mondoo.link/slack) to collaborate on policy as code and security automation.
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.

--- a/extra/README.md
+++ b/extra/README.md
@@ -1,6 +1,6 @@
 # Extra Policies
 
-Extra policies are for policy bundles that do not fit in core or community policy bundles.
+Extra policies are a mix of community- and Mondoo-maintained policy bundles that are outside Mondoo's core support tier.
 
 ## Contributing
 
@@ -8,4 +8,4 @@ We welcome all contributions. For more information on contributing to cnspec-pol
 
 ### Join the community!
 
-Join the [Mondoo Slack Community](https://mondoo.link/slack) to collaborate on policy as code and security automation.
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.


### PR DESCRIPTION
In specific it makes the wording for extra policies more clear. Essentially community policies are the ones that do not fit onto core or extra, not the other way.