### PR TITLE
🧹 owner mrn is not required anymore therefore we can simply remove it

### DIFF
--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
 - uid: mondoo-aws-security
   name: AWS Security by Mondoo

--- a/core/mondoo-azure-security.mql.yaml
+++ b/core/mondoo-azure-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
 - uid: mondoo-azure-security
   name: Microsoft Azure Security by Mondoo

--- a/core/mondoo-dns-security.mql.yaml
+++ b/core/mondoo-dns-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
   - uid: mondoo-dns-security
     name: DNS Security by Mondoo

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
 - uid: mondoo-gcp-security
   name: Google Cloud (GCP) Security by Mondoo

--- a/core/mondoo-github-security.mql.yaml
+++ b/core/mondoo-github-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
   - uid: mondoo-github-organization-security
     name: GitHub Organization Security by Mondoo

--- a/core/mondoo-gitlab-security.mql.yaml
+++ b/core/mondoo-gitlab-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
   - uid: mondoo-gitlab-security
     name: GitLab Security by Mondoo

--- a/core/mondoo-kubernetes-best-practices.mql.yaml
+++ b/core/mondoo-kubernetes-best-practices.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
 - uid: mondoo-kubernetes-best-practices
   name: Kubernetes Best Practices by Mondoo

--- a/core/mondoo-kubernetes-security.mql.yaml
+++ b/core/mondoo-kubernetes-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
 - uid: mondoo-kubernetes-security
   name: Kubernetes Cluster and Workload Security by Mondoo

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
   - uid: mondoo-linux-security
     name: Linux Security by Mondoo

--- a/core/mondoo-linux-workstation-security.mql.yaml
+++ b/core/mondoo-linux-workstation-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
   - uid: mondoo-linux-workstation-security
     name: Linux Workstation Security by Mondoo

--- a/core/mondoo-macos-security.mql.yaml
+++ b/core/mondoo-macos-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
   - uid: mondoo-macos-security
     name: macOS Security by Mondoo

--- a/core/mondoo-terraform-aws-security.mql.yaml
+++ b/core/mondoo-terraform-aws-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
   - uid: mondoo-terraform-aws-security
     name: Terraform HCL Security Static Analysis for AWS by Mondoo

--- a/core/mondoo-terraform-gcp-security.mql.yaml
+++ b/core/mondoo-terraform-gcp-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
   - uid: mondoo-terraform-gcp-security
     name: Terraform HCL Security Static Analysis for Google Cloud 

--- a/core/mondoo-tls-security.mql.yaml
+++ b/core/mondoo-tls-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
   - uid: mondoo-tls-security
     name: Mondoo TLS/SSL Security Baseline

--- a/core/mondoo-windows-security.mql.yaml
+++ b/core/mondoo-windows-security.mql.yaml
@@ -1,4 +1,3 @@
-owner_mrn: //policy.api.mondoo.app
 policies:
   - uid: mondoo-windows-security
     name: Windows Security by Mondoo


### PR DESCRIPTION
The owner mrn is not required anymore, lets clean up the policies since they make it simpler