### PR TITLE
Improve /etc/ file docs on Linux

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2272,7 +2272,7 @@ queries:
         ```
         chown root:root /etc/shadow
 
-        chmod 000 /etc/shadow
+        chmod 640 /etc/shadow
         ```
     query: |
       if (file("/etc/shadow").exists) {
@@ -2289,7 +2289,7 @@ queries:
     title: Ensure secure permissions on /etc/group are set
     severity: 100
     docs:
-      desc: The `/etc/group` file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else.
+      desc: The `/etc/group` file contains a list of all the valid groups defined in the system. This file should have read/write access for root and read access for all other users to prevent non-administrative users from modifying groups.
       remediation: |-
         Run the following command to set permissions on `/etc/group` :
 
@@ -2317,7 +2317,7 @@ queries:
         ```
         chown root:root /etc/gshadow
 
-        chmod 000 /etc/gshadow
+        chmod 640 /etc/gshadow
         ```
     query: |
       if (file("/etc/gshadow").exists) {
@@ -2359,14 +2359,14 @@ queries:
     title: Ensure secure permissions on /etc/shadow- are set
     severity: 100
     docs:
-      desc: The `/etc/shadow-` file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information.
+      desc: The `/etc/shadow-` file is used to store backup information about user accounts, such as the hashed password and other security information. Only the root user should have read and write permissions on this file so that sensitive user information is not available to non-adminstrative users on the system.
       remediation: |-
         Run the following commands to set permissions on `/etc/shadow-`:
 
         ```
         chown root:root /etc/shadow-
 
-        chmod o-rwx,g-rw /etc/shadow-
+        chmod 640 /etc/shadow-
         ```
     query: |
       if (file("/etc/shadow-").exists) {
@@ -2383,7 +2383,7 @@ queries:
     title: Ensure secure permissions on /etc/group- are set
     severity: 100
     docs:
-      desc: The `/etc/group-` file contains a backup list of all the valid groups defined in the system.
+      desc: The `/etc/group-` file contains a backup list of all the valid groups defined in the system. Only the root user should have read and write permissions on this file so that group names an user membership is not available to non-adminstrative users on the system.
       remediation: |-
         Run the following command to set permissions on `/etc/group-` :
 
@@ -2415,7 +2415,7 @@ queries:
         ```
         chown root:root /etc/gshadow-
 
-        chmod 000 /etc/gshadow-
+        chmod 640 /etc/gshadow-
         ```
     query: |
       if (file("/etc/gshadow-").exists) {


### PR DESCRIPTION
- The recommended chmod commands did not match the queries
- Some of the others needed to better describe what we were checking for and why it matters

Signed-off-by: Tim Smith <tsmith84@gmail.com>