### PR TITLE
fixes aws.iam check to ensure only one key is active

### DIFF
--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -786,7 +786,7 @@ queries:
       The command output should expose the metadata for each access key associated with the IAM user. If the non-operational key pair(s) Status is set to Inactive, the key has been successfully deactivated and the IAM user access configuration adheres now to this recommendation.
 
       Repeat steps no. 1 - 3 for each IAM user in your AWS account.
-  query: aws.iam.users.all(accessKeys[0].length <= 1)
+  query: aws.iam.credentialReport.none( accessKey1Active == true && accessKey2Active == true )
 - uid: mondoo-aws-security-iam-user-no-inline-policies-check
   title: Ensure IAM Users Receive Permissions Only Through Groups
   docs: 


### PR DESCRIPTION
I found the existing query was returning a false positive...

```bash
cnquery> aws.iam.users.all(accessKeys[0].length <= 1)
[failed] [].all()
  actual:   [
    0: aws.iam.user id = arn:aws:iam::17704375555:user/scottford
  ]
```

Looking at the query it shows one of my keys as inactive...
```bash
    accessKeys[0]: [
      0: {
        AccessKeyId: "AKIASSOFBMF7MFOOBAR"
        CreateDate: "2021-07-23T05:02:55Z"
        Status: "Inactive"
        UserName: "scottford"
      }
      1: {
        AccessKeyId: "AKIASSOFBMF7C6W3FOOBAR"
        CreateDate: "2022-08-25T04:05:18Z"
        Status: "Active"
        UserName: "scottford"
      }
    ]
  }
  ```

This query fixes it...

```bash
cnquery> aws.iam.credentialReport.none( accessKey1Active == true && accessKey2Active == true )
[ok] value: true
```



Signed-off-by: Scott Ford <scott@scottford.io>