### PR TITLE
🐛 Fix application of probe controls

### DIFF
--- a/core/mondoo-kubernetes-best-practices.mql.yaml
+++ b/core/mondoo-kubernetes-best-practices.mql.yaml
@@ -52,8 +52,6 @@ policies:
     scoring_queries:
       mondoo-kubernetes-best-practices-cronjob-requestcpu:
       mondoo-kubernetes-best-practices-cronjob-requestmemory:
-      mondoo-kubernetes-best-practices-cronjob-livenessprobe:
-      mondoo-kubernetes-best-practices-cronjob-readinessProbe:
       mondoo-kubernetes-best-practices-cronjob-hostalias:
       mondoo-kubernetes-best-practices-cronjob-default-namespace:
       mondoo-kubernetes-best-practices-cronjob-ports-hostport:
@@ -85,8 +83,6 @@ policies:
     scoring_queries:
       mondoo-kubernetes-best-practices-job-requestcpu:
       mondoo-kubernetes-best-practices-job-requestmemory:
-      mondoo-kubernetes-best-practices-job-livenessprobe:
-      mondoo-kubernetes-best-practices-job-readinessProbe:
       mondoo-kubernetes-best-practices-job-hostalias:
       mondoo-kubernetes-best-practices-job-default-namespace:
       mondoo-kubernetes-best-practices-job-ports-hostport:
@@ -850,42 +846,14 @@ queries:
               periodSeconds: 5
       ```
   query: |
-    k8s.pod {
-      containers { 
-        probeSpecified = livenessProbe['httpGet'] != null || livenessProbe['tcpSocket'] != null || livenessProbe['exec'] != null
+    if (k8s.pod.manifest['metadata']['ownerReferences'].none(_['kind'] == 'Job')) {
+      k8s.pod {
+        containers { 
+          probeSpecified = livenessProbe['httpGet'] != null || livenessProbe['tcpSocket'] != null || livenessProbe['exec'] != null
 
-        # @msg Container ${ _.name  } should set a livenessProbe
-        probeSpecified == true
-      }
-    }
-- uid: mondoo-kubernetes-best-practices-cronjob-livenessprobe
-  title: Container should configure a livenessProbe
-  severity: 20
-  docs:
-    audit: |
-      Check for the existence of `livenessProbe`:
-      
-      ```yaml
-      ---
-      apiVersion: v1
-      kind: Pod
-      spec:
-        containers:
-          - name: container-name
-            image: index.docker.io/yournamespace/repository
-            livenessProbe: # <--- Set a livenessProbe like this
-              tcpSocket:
-                port: 8080
-              initialDelaySeconds: 5
-              periodSeconds: 5
-      ```
-  query: |
-    k8s.cronjob {
-      containers { 
-        probeSpecified = livenessProbe['httpGet'] != null || livenessProbe['tcpSocket'] != null || livenessProbe['exec'] != null
-
-        # @msg Container ${ _.name  } should set a livenessProbe
-        probeSpecified == true
+          # @msg Container ${ _.name  } should set a livenessProbe
+          probeSpecified == true
+        }
       }
     }
 - uid: mondoo-kubernetes-best-practices-statefulset-livenessprobe
@@ -942,36 +910,6 @@ queries:
   query: |
     k8s.deployment {
       containers {
-        probeSpecified = livenessProbe['httpGet'] != null || livenessProbe['tcpSocket'] != null || livenessProbe['exec'] != null
-
-        # @msg Container ${ _.name  } should set a livenessProbe
-        probeSpecified == true
-      }
-    }
-- uid: mondoo-kubernetes-best-practices-job-livenessprobe
-  title: Container should configure a livenessProbe
-  severity: 20
-  docs:
-    audit: |
-      Check for the existence of `livenessProbe`:
-      
-      ```yaml
-      ---
-      apiVersion: v1
-      kind: Pod
-      spec:
-        containers:
-          - name: container-name
-            image: index.docker.io/yournamespace/repository
-            livenessProbe: # <--- Set a livenessProbe like this
-              tcpSocket:
-                port: 8080
-              initialDelaySeconds: 5
-              periodSeconds: 5
-      ```
-  query: |
-    k8s.job {
-      containers { 
         probeSpecified = livenessProbe['httpGet'] != null || livenessProbe['tcpSocket'] != null || livenessProbe['exec'] != null
 
         # @msg Container ${ _.name  } should set a livenessProbe
@@ -1060,42 +998,14 @@ queries:
               periodSeconds: 5
       ```
   query: |
-    k8s.pod {
-      containers { 
-        probeSpecified = readinessProbe['httpGet'] != null || readinessProbe['tcpSocket'] != null || readinessProbe['exec'] != null
+    if (k8s.pod.manifest['metadata']['ownerReferences'].none(_['kind'] == 'Job')) {
+      k8s.pod {
+        containers { 
+          probeSpecified = readinessProbe['httpGet'] != null || readinessProbe['tcpSocket'] != null || readinessProbe['exec'] != null
 
-        # @msg Container ${ _.name  } should set a readinessProbe
-        probeSpecified == true
-      }
-    }
-- uid: mondoo-kubernetes-best-practices-cronjob-readinessProbe
-  title: Container should configure a readinessProbe
-  severity: 20
-  docs:
-    audit: |
-      Check for the existence of `readinessProbe`:
-      
-      ```yaml
-      ---
-      apiVersion: v1
-      kind: Pod
-      spec:
-        containers:
-          - name: container-name
-            image: index.docker.io/yournamespace/repository
-            readinessProbe: # <--- Set a readinessProbe like this
-              tcpSocket:
-                port: 8080
-              initialDelaySeconds: 5
-              periodSeconds: 5
-      ```
-  query: |
-    k8s.cronjob {
-      containers { 
-        probeSpecified = readinessProbe['httpGet'] != null || readinessProbe['tcpSocket'] != null || readinessProbe['exec'] != null
-
-        # @msg Container ${ _.name  } should set a readinessProbe
-        probeSpecified == true
+          # @msg Container ${ _.name  } should set a readinessProbe
+          probeSpecified == true
+        }
       }
     }
 - uid: mondoo-kubernetes-best-practices-statefulset-readinessProbe
@@ -1152,36 +1062,6 @@ queries:
   query: |
     k8s.deployment {
       containers {
-        probeSpecified = readinessProbe['httpGet'] != null || readinessProbe['tcpSocket'] != null || readinessProbe['exec'] != null
-
-        # @msg Container ${ _.name  } should set a readinessProbe
-        probeSpecified == true
-      }
-    }
-- uid: mondoo-kubernetes-best-practices-job-readinessProbe
-  title: Container should configure a readinessProbe
-  severity: 20
-  docs:
-    audit: |
-      Check for the existence of `readinessProbe`:
-      
-      ```yaml
-      ---
-      apiVersion: v1
-      kind: Pod
-      spec:
-        containers:
-          - name: container-name
-            image: index.docker.io/yournamespace/repository
-            readinessProbe: # <--- Set a readinessProbe like this
-              tcpSocket:
-                port: 8080
-              initialDelaySeconds: 5
-              periodSeconds: 5
-      ```
-  query: |
-    k8s.job {
-      containers { 
         probeSpecified = readinessProbe['httpGet'] != null || readinessProbe['tcpSocket'] != null || readinessProbe['exec'] != null
 
         # @msg Container ${ _.name  } should set a readinessProbe


### PR DESCRIPTION
CronJobs and Jobs do not necessarily have probes.
The same applies to the Pods they create.

Signed-off-by: Christian Zunker <christian@mondoo.com>