### PR TITLE
correct the remediation for the ssh private host key it must 600

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1941,7 +1941,7 @@ queries:
         ```
 
         ```
-        find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chmod 0640 {} \;
+        find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chmod 0600 {} \;
         ```
     query: |
       files.


### PR DESCRIPTION
We are testing for 600, that is correct, and the remediation was not right for it


Signed-off-by: Patrick Münch <patrick.muench1111@gmail.com>