### PR TITLE
Fixes asset filtering on Terraform policies

### DIFF
--- a/core/mondoo-terraform-aws-security.mql.yaml
+++ b/core/mondoo-terraform-aws-security.mql.yaml
@@ -34,14 +34,14 @@ policies:
         asset_filter:
           query: |
             platform.name == "terraform"
-            terraform.providers { nameLabel == "aws" }
+            terraform.providers.one(nameLabel == "aws")
         scoring_queries:
           terraform-aws-security-no-static-credentials-in-providers: null 
       - title: Amazon API Gateway
         asset_filter:
           query: |
             platform.name == "terraform"
-            terraform.providers { nameLabel == "aws" }
+            terraform.providers.one(nameLabel == "aws") 
         scoring_queries:
           terraform-aws-security-api-gw-cache-enabled-and-encrypted:
           terraform-aws-security-api-gw-execution-logging-enabled:
@@ -52,7 +52,7 @@ policies:
         asset_filter:
           query: |
             platform.name == "terraform"
-            terraform.providers { nameLabel == "aws" }
+            terraform.providers.one(nameLabel == "aws")
         scoring_queries:
           terraform-aws-security-ec2-ebs-encryption-by-default:
           terraform-aws-security-ec2-imdsv2:
@@ -61,14 +61,14 @@ policies:
         asset_filter:
           query: |
             platform.name == "terraform"
-            terraform.providers { nameLabel == "aws" }
+            terraform.providers.one(nameLabel == "aws")
         scoring_queries:
           terraform-aws-security-iam-no-wildcards-policies:
       - title: Amazon Simple Storage Service (Amazon S3)
         asset_filter:
           query: |
             platform.name == "terraform"
-            terraform.providers { nameLabel == "aws" }
+            terraform.providers.one(nameLabel == "aws")
         scoring_queries:
           terraform-aws-security-s3-bucket-versioning-enabled:
           terraform-aws-security-s3-bucket-public-read-and-write-prohibited:
@@ -79,7 +79,7 @@ policies:
         asset_filter:
           query: |
             platform.name == "terraform"
-            terraform.providers { nameLabel == "aws" }
+            terraform.providers.one(nameLabel == "aws")
         scoring_queries:
           terraform-aws-security-eks-encrypt-secrets:
           terraform-aws-security-eks-no-public-cluster-access-to-cidr:

--- a/core/mondoo-terraform-gcp-security.mql.yaml
+++ b/core/mondoo-terraform-gcp-security.mql.yaml
@@ -34,14 +34,14 @@ policies:
         asset_filter:
           query: |
             platform.name == "terraform"
-            terraform.providers { nameLabel == "google" }
+            terraform.providers.one( nameLabel == "google" )
         scoring_queries:
           terraform-gcp-security-bigquery-no-public-access: null
       - title: GCP Identity and Access Management (IAM)
         asset_filter:
           query: |
             platform.name == "terraform"
-            terraform.providers { nameLabel == "google" }
+            terraform.providers.one( nameLabel == "google" )
         scoring_queries:
           terraform-gcp-security-iam-no-folder-level-default-service-account-assignment: null
           terraform-gcp-security-iam-no-folder-level-service-account-impersonation: null
@@ -50,7 +50,7 @@ policies:
         asset_filter:
           query: |
             platform.name == "terraform"
-            terraform.providers { nameLabel == "google" }
+            terraform.providers.one( nameLabel == "google" )
         scoring_queries:
           terraform-gcp-security-storage-no-public-access: null
           terraform-gcp-security-storage-enable-ubla: null
@@ -58,7 +58,7 @@ policies:
         asset_filter:
           query: |
             platform.name == "terraform"
-            terraform.providers { nameLabel == "google" }
+            terraform.providers.one( nameLabel == "google" )
         scoring_queries:
           terraform-gcp-security-compute-no-public-ip: null
           terraform-gcp-security-compute-disk-encryption-customer-key: null
@@ -79,7 +79,7 @@ policies:
         asset_filter:
           query: |
             platform.name == "terraform"
-            terraform.providers { nameLabel == "google" }
+            terraform.providers.one( nameLabel == "google" )
         scoring_queries:
           terraform-gcp-security-dns-enable-dnssec: null
           terraform-gcp-security-dns-no-rsa-sha1: null
@@ -87,7 +87,7 @@ policies:
         asset_filter:
           query: |
             platform.name == "terraform"
-            terraform.providers { nameLabel == "google" }
+            terraform.providers.one( nameLabel == "google" )
         scoring_queries:
           terraform-gcp-security-gke-enable-auto-repair: null
           terraform-gcp-security-gke-enable-auto-upgrade: null


### PR DESCRIPTION
This fixes an issue if there are multiple providers configured, that the `asset_filter` does not match correctly to run Terraform AWS or GCP policies, even if there is a valid configuration for AWS.

```bash
cnspec> terraform.providers { nameLabel == "aws" }
terraform.providers: [
  0: {
    nameLabel == "aws": true
  }
  1: {
    nameLabel == "aws": false
  }
  2: {
    nameLabel == "aws": false
  }
]
cnspec> terraform.providers.one( nameLabel == "aws" )
[ok] value: true
```


Signed-off-by: Scott Ford <scott@scottford.io>