### PR TITLE
⭐️ slack security policy

### DIFF
--- a/extra/mondoo-slack-security.mql.yaml
+++ b/extra/mondoo-slack-security.mql.yaml
@@ -1,0 +1,64 @@
+policies:
+  - uid: mondoo-slack-security
+    name: Slack Security Best Practices by Mondoo
+    version: 1.0.0
+    is_public: true
+    authors:
+      - name: Mondoo, Inc
+        email: hello@mondoo.com
+    docs:
+      desc: |
+        ### Overview
+
+        The Mondoo Slack Security policy ensure best-practice settings for Slack.
+
+        ### Prerequisites
+
+        To run this query pack, you will need access to the Slack API. To get a token, you need to create an App for the Slack workspace 
+        and assign the appropriate permissions:
+
+        1. Sign in to [the Slack website](https://api.slack.com/apps/), and view "Your Apps"
+        2. Click "Create New App"
+        3. Select "From scratch"
+        4. Enter an "App Name" e.g. cnquery and select the workspace, then click "Create App"
+        5. In the section "Add features & functionality" click on "Permissions"
+        6. Scroll to "Scopes" and then "User Token Scopes"
+ 
+        Note: Bots are very limited in their access; therefore we need to set the user scopes
+
+        7. Add the required permissions to "User Token Scopes"
+
+        | OAuth Scope  |
+        | ---- | 
+        | [channels:read](https://api.slack.com/scopes/channels:read) | 
+        | [groups:read](https://api.slack.com/scopes/groups:read) |
+        | [im:read](https://api.slack.com/scopes/im:read) |
+        | [mpim:read](https://api.slack.com/scopes/mpim:read) | 
+        | [team:read](https://api.slack.com/scopes/team:read) | 
+        | [usergroups:read](https://api.slack.com/scopes/usergroups:read) | 
+        | [users:read](https://api.slack.com/scopes/users:read) |
+
+        8. Scroll up to "OAuth Tokens for Your Workspace" and click "Install to Workspace"
+        9. Copy the provided "User OAuth Token", it will look like `xoxp-1234567890123-1234567890123-1234567890123-12345cea5ae0d3bed30dca43cb34c2d1`
+
+        ### Run query pack
+
+        To run this query pack against a GitHub Organization:
+
+        ```bash
+        export SLACK_TOKEN=xoxp-TOKEN
+        cnspec scan slack --policy-bundle mondoo-slack-security
+        ```
+    specs:
+      - asset_filter:
+          query: asset.platform == "slack"
+        scoring_queries:
+          mondoo-slack-security-limit-admins:
+          mondoo-slack-security-use-strong-factors:
+queries:
+  - uid: mondoo-slack-security-limit-admins
+    title: More than three admins
+    query: slack.users.admins.length < 3
+  - uid: mondoo-slack-security-use-strong-factors
+    title: Two factor authentication enabled for all users
+    query: slack.users.members.all( has2FA == true)


### PR DESCRIPTION
The policy checks that all Slack users have 2FA active.

```
cnspec scan slack -f extra/mondoo-slack-security.mql.yaml
! Scanning with local policy bundles will switch into --incognito mode by default. Your results will not be sent upstream.
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1
→ connecting to asset Slack organization test labs (api)


Asset: Slack organization test labs
========================================
Controls:
✓ Pass:  More than 3 admins
✕ Fail:  Strong factors are used by all users


Summary (1 assets)
==================

Target:     Slack organization test labs
Score:      C    50/100     (100% completed)
✓ Passed:   ████████ 50% (1)
✕ Failed:   ████████ 50% (1)
! Errors:   0% (0)
» Skipped:  0% (0)

Policies:
C  50  Slack Security Best Practices by Mondoo


To get more information, please run this scan with "-o full".

```