### PR TITLE
Aide in Ubuntu 22.04 had a new setting for cronjob

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -336,7 +336,7 @@ queries:
         systemctl --now enable aidecheck.timer
         ```
     query: |
-      command("crontab -u root -l | grep aide").stdout.contains("aide --check") || command("crontab -u root -l | grep aide").stdout.contains("aide.conf --check") || service('aidecheck').enabled
+      command("crontab -u root -l | grep aide").stdout.contains("aide --check") || command("crontab -u root -l | grep aide").stdout.contains("aide.conf --check") || service('aidecheck').enabled  || file("/etc/default/aide").content.contains("CRON_DAILY_RUN=yes")
   - uid: mondoo-linux-security-baseline-core-dumps-are-restricted
     title: Ensure core dumps are restricted
     severity: 100


### PR DESCRIPTION
On Ubuntu 22.04.01 LTS  Aide had a new config file in /etc/default/aide