### PR TITLE
🧹 improve slack policy

### DIFF
--- a/extra/mondoo-slack-security.mql.yaml
+++ b/extra/mondoo-slack-security.mql.yaml
@@ -60,10 +60,20 @@ policies:
         scoring_queries:
           mondoo-slack-security-limit-admins:
           mondoo-slack-security-use-strong-factors:
+          mondoo-slack-security-name-external-channels:
+        data_queries:
+          mondoo-slack-security-list-admins:
 queries:
   - uid: mondoo-slack-security-limit-admins
     title: Ensure fewer than 3 users have Admin Permissions
-    query: slack.users.admins.length < 3
+    query: |
+      slack.users.admins.length < 3
+  - uid: mondoo-slack-security-list-admins
+    title: Ensure fewer than 3 users have Admin Permissions
+    query: slack.users.admins { id name }
   - uid: mondoo-slack-security-use-strong-factors
     title: Ensure 2-Step Verification (Multi-Factor Authentication) is enforced for all users
-    query: slack.users.members.all( has2FA == true)
+    query: slack.users.members.all( has2FA == true || enterpriseUser != null )
+  - uid: mondoo-slack-security-name-external-channels
+    title: Use clear naming for external channels
+    query: slack.conversations.where(isExtShared && isChannel ).all( name == /ext-/)


### PR DESCRIPTION
- collect admin users
- 2fa is not required when Slack Enterprise is used with SSO
- make sure external channels start with "ext-"