### PR TITLE
Fix typos in policies

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2596,7 +2596,7 @@ queries:
     title: Ensure secure permissions on /etc/shadow- are set
     severity: 100
     docs:
-      desc: The `/etc/shadow-` file is used to store backup information about user accounts, such as the hashed password and other security information. Only the root user should have read and write permissions on this file so that sensitive user information is not available to non-adminstrative users on the system.
+      desc: The `/etc/shadow-` file is used to store backup information about user accounts, such as the hashed password and other security information. Only the root user should have read and write permissions on this file so that sensitive user information is not available to non-administrative users on the system.
       remediation: |-
         Run the following commands to set permissions on `/etc/shadow-`:
 
@@ -2620,7 +2620,7 @@ queries:
     title: Ensure secure permissions on /etc/group- are set
     severity: 100
     docs:
-      desc: The `/etc/group-` file contains a backup list of all the valid groups defined in the system. Only the root user should have read and write permissions on this file so that group names an user membership is not available to non-adminstrative users on the system.
+      desc: The `/etc/group-` file contains a backup list of all the valid groups defined in the system. Only the root user should have read and write permissions on this file so that group names an user membership is not available to non-administrative users on the system.
       remediation: |-
         Run the following command to set permissions on `/etc/group-` :
 

--- a/core/mondoo-linux-workstation-security.mql.yaml
+++ b/core/mondoo-linux-workstation-security.mql.yaml
@@ -30,9 +30,9 @@ policies:
             platform.family.contains(- == 'linux')
         scoring-queries:
           mondoo-client-linux-security-baseline-root-and-home-are-encrypted: null
-          mondoo-client-linux-security-baseline-aes-encryption-algorithmen: null
+          mondoo-client-linux-security-baseline-aes-encryption-algorithm: null
         data-queries:
-          mondoo-client-linux-security-baseline-disk-encrpytion-metadata: null
+          mondoo-client-linux-security-baseline-disk-encryption-metadata: null
           mondoo-client-linux-security-baseline-aes-encryption-algo-metadata: null
       - title: BIOS Firmware up-to-date
         asset_filter:
@@ -244,7 +244,7 @@ queries:
           lsblkDevice['blockdevices'][0]['children'][0]['type'] == 'crypt' || lsblkDevice['blockdevices'][0]['type'] == 'crypt'
         }
       }
-  - uid: mondoo-client-linux-security-baseline-aes-encryption-algorithmen
+  - uid: mondoo-client-linux-security-baseline-aes-encryption-algorithm
     title: Ensure AES encryption algorithm is used
     severity: 90
     docs:
@@ -288,7 +288,7 @@ queries:
   - uid: mondoo-client-linux-security-baseline-bios-data
     title: Gather BIOS Information
     query: machine.bios { version vendor releaseDate }
-  - uid: mondoo-client-linux-security-baseline-disk-encrpytion-metadata
+  - uid: mondoo-client-linux-security-baseline-disk-encryption-metadata
     title: Gather metadata on disk encryption
     query: |
       command('lsblk').stdout


### PR DESCRIPTION
1 mispelled word in the text and the others are in the UIDs

Signed-off-by: Tim Smith <tsmith84@gmail.com>