### PR TITLE
🐛 fix yaml issues detected by new linter

### DIFF
--- a/core/mondoo-dns-security.mql.yaml
+++ b/core/mondoo-dns-security.mql.yaml
@@ -35,8 +35,6 @@ policies:
         Our goal is to build policies that are simple to deploy, accurate, and actionable. 
         
         If you have any suggestions on how to improve this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
-    tags:
-      dns:
     specs:
       - policies:
         scoring_queries:

--- a/core/mondoo-tls-security.mql.yaml
+++ b/core/mondoo-tls-security.mql.yaml
@@ -35,9 +35,6 @@ policies:
         Our goal is to build policies that are simple to deploy, accurate, and actionable. 
         
         If you have any suggestions on how to improve this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
-    tags:
-      tls:
-      ssl:
     scoring_system: 2
     specs:
       - title: Secure TLS/SSL connection

--- a/core/mondoo-windows-security.mql.yaml
+++ b/core/mondoo-windows-security.mql.yaml
@@ -150,8 +150,6 @@ policies:
             platform.family.contains(_ == 'windows')
         scoring_queries:
           mondoo-windows-security-2.2.19-l1-ensure-debug-programs-is-empty: null
-    docs:
-      desc: "This policy provides prescriptive guidance for establishing a secure configuration posture for Microsoft Windows. This guide was tested against Microsoft Windows 10 Release 20H2 Enterprise. \n\nIf you have questions, comments, or have identified ways to improve this policy, please write us at hello@mondoo.com, or reach out in [GitHub Discussions](https://github.com/orgs/mondoohq/discussions)."
 queries:
   - uid: mondoo-windows-security-enforce-password-history-is-set-to-24-or-more-passwords
     title: Ensure 'Enforce password history' is set to '24 or more password(s)'


### PR DESCRIPTION
The new linter https://github.com/mondoohq/cnspec/pull/253 found a few issues in the yaml files where tags have been used twice.