### PR TITLE
deal with empty list handling for k8s-ingress query

### DIFF
--- a/core/mondoo-kubernetes-best-practices.mql.yaml
+++ b/core/mondoo-kubernetes-best-practices.mql.yaml
@@ -1999,10 +1999,15 @@ queries:
     remediation: |
       For all Secrets with expired or soon-to-expire certificates, update the Secret data with refreshed certificates.
   query: |
-    k8s.ingress.tls{
-      certificates {
-        expiresIn.days > 15
-      }
+    len = k8s.ingress.tls.length == 0
+    if( len == 0 ){
+      true
+    } else {
+      k8s.ingress.tls.all(
+        certificates.all(
+          expiresIn.days > 15
+        )
+      )
     }
 # Data Queries
 - uid: mondoo-kubernetes-best-practices-gather-deployment-container

--- a/core/mondoo-kubernetes-best-practices.mql.yaml
+++ b/core/mondoo-kubernetes-best-practices.mql.yaml
@@ -1999,16 +1999,11 @@ queries:
     remediation: |
       For all Secrets with expired or soon-to-expire certificates, update the Secret data with refreshed certificates.
   query: |
-    len = k8s.ingress.tls.length == 0
-    if( len == 0 ){
-      true
-    } else {
-      k8s.ingress.tls.all(
-        certificates.all(
-          expiresIn.days > 15
-        )
+    k8s.ingress.tls.all(
+      certificates.all(
+        expiresIn.days > 15
       )
-    }
+    )
 # Data Queries
 - uid: mondoo-kubernetes-best-practices-gather-deployment-container
   title: Gather all Deployments


### PR DESCRIPTION
Doing a `false || [false]` returns true as a non-empty list is considered a truthy thing.

Update the assertion so that we can explicitly assert the expiration date/time for each element in the returned list of TLS results.

Signed-off-by: Joel Diaz <joel@mondoo.com>