### PR TITLE
only check SSH server settings if installed

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -135,7 +135,7 @@ policies:
         asset_filter:
           query: |
             platform.family.contains(_ == 'linux')
-            package('openssh').installed || package('openssh-server').installed
+            package('openssh-server').installed
         scoring_queries:
           mondoo-linux-security-baseline-permissions-on-etcsshsshd-config-are-configured: null
           mondoo-linux-security-baseline-permissions-on-ssh-private-host-key-files-are-configured: null


### PR DESCRIPTION
We stumbled upon an issue where SSH server settings where checked on a system that had no SSH server installed.
Turns out that a check condition seems to be incorrect - it checks for `openssh` or `openssh-server`, but should check only for latter.