### PR TITLE
Updating GCP queries to use .all()

### DIFF
--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -181,11 +181,9 @@ queries:
           gcloud compute instances start INSTANCE_NAME
           ```
     query: |
-      gcloud.compute.instances.where( name != /^gke/ ) {
-        serviceAccounts {
-          email != /^.*compute@developer\.gserviceaccount\.com$/
-        }
-      }
+      gcloud.compute.instances
+        .where( name != /^gke/ )
+        .all( serviceAccounts { email != /^.*compute@developer\.gserviceaccount\.com$/ } )
   - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api
     title: Ensure instances are not configured to use the default service account with full access to all Cloud APIs
     severity: 90
@@ -286,15 +284,9 @@ queries:
           gcloud compute instances start INSTANCE_NAME
           ```
     query: |
-      gcloud.compute.instances.where( name != /^gke/ ) {
-        name
-        serviceAccounts {
-          email
-          scopes {
-            _ != "https://www.googleapis.com/auth/cloud-platform"
-          }
-        }
-      }
+      gcloud.compute.instances
+        .where( name != /^gke/ )
+        .all( serviceAccounts { scopes { _ != "https://www.googleapis.com/auth/cloud-platform" } } )
   - uid: mondoo-gcp-security-block-project-wide-ssh-keys-enabled-vm-instances
     title: Ensure "Block Project-wide SSH keys" is enabled for VM instances
     severity: 70
@@ -383,9 +375,8 @@ queries:
           gcloud compute instances add-metadata INSTANCE_NAME --metadata block-projectssh-keys=TRUE
           ```
     query: |
-      gcloud.compute.instances {
-        metadata['block-project-ssh-keys'] == true
-      }
+      gcloud.compute.instances
+        .all( metadata['block-project-ssh-keys'] == true )
   - uid: mondoo-gcp-security-oslogin-enabled-project
     title: Ensure oslogin is enabled for compute instances
     severity: 70
@@ -489,9 +480,8 @@ queries:
           gcloud compute instances add-metadata INSTANCE_NAME --metadata enable-oslogin=TRUE
           ```
     query: |
-      gcloud.compute.instances {
-        metadata['enable-oslogin'] == true
-      }
+      gcloud.compute.instances
+        .all( metadata['enable-oslogin'] == true )
   - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible
     title: Ensure that Cloud Storage buckets are not anonymously or publicly accessible
     severity: 90
@@ -574,14 +564,15 @@ queries:
         gcloud storage buckets update gs://BUCKET_NAME --no-pap
         ```     
     query: |
-      gcloud.storage.buckets {
-        iamPolicy {
-          members {
-            _ != "allUsers"
-            _ != "allAuthenticatedUsers"
+      gcloud.storage.buckets
+        .all(
+          iamPolicy {
+            members {
+              _ != "allUsers"
+              _ != "allAuthenticatedUsers"
+            }
           }
-        }
-      }
+        )
   - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled
     title: Ensure that Cloud Storage buckets have uniform bucket-level access enabled
     severity: 60
@@ -654,7 +645,6 @@ queries:
         gsutil uniformbucketlevelaccess set STATE gs://BUCKET_NAME
         ```
     query: |
-      gcloud.storage.buckets {
-        iamConfiguration['UniformBucketLevelAccess']['Enabled'] == true
-      }
+      gcloud.storage.buckets
+        .all( iamConfiguration['UniformBucketLevelAccess']['Enabled'] == true )
       


### PR DESCRIPTION
Updates GCP checks to use `.all()` for more actionable results. 


Signed-off-by: Scott Ford <scott@scottford.io>