### PR TITLE
quick fix to solve the alias problem which makes the time-out problem…

### DIFF
--- a/core/mondoo-azure-security.mql.yaml
+++ b/core/mondoo-azure-security.mql.yaml
@@ -68,7 +68,7 @@ queries:
         2. Run the following query:
 
           ```mql
-          cnquery run azure -c "azurerm.compute.vms { osDisk { properties['encryption'] } }"
+          cnquery run azure -c "azure.compute.vms { osDisk { properties['encryption'] } }"
           ```
 
         __cnquery shell__
@@ -85,7 +85,7 @@ queries:
         3. Run the following query:
 
           ```mql
-          azurerm.compute.vms { osDisk { properties['encryption'] } }
+          azure.compute.vms { osDisk { properties['encryption'] } }
           ```
       remediation: |
         ###Terraform
@@ -94,10 +94,10 @@ queries:
 
         ```hcl
         # Encrypt Linux OS disk with Terraform
-        resource "azurerm_linux_virtual_machine" "example" {
+        resource "azure_linux_virtual_machine" "example" {
           name                = "example-linux-machine"
-          resource_group_name = azurerm_resource_group.example.name
-          location            = azurerm_resource_group.example.location
+          resource_group_name = azure_resource_group.example.name
+          location            = azure_resource_group.example.location
           
           ... 
 
@@ -110,10 +110,10 @@ queries:
         __Encrypt disks Windows VM__
 
         ```hcl
-        resource "azurerm_windows_virtual_machine" "example" {
+        resource "azure_windows_virtual_machine" "example" {
           name                = "example-windows-machine"
-          resource_group_name = azurerm_resource_group.example.name
-          location            = azurerm_resource_group.example.location
+          resource_group_name = azure_resource_group.example.name
+          location            = azure_resource_group.example.location
           
           ... 
 
@@ -126,7 +126,7 @@ queries:
         __Encrypt disks managed disks__
 
         ```hcl
-        resource "azurerm_managed_disk" "example" {
+        resource "azure_managed_disk" "example" {
           name                 = var.disk_name
           location             = var.location
           resource_group_name  = var.resource_group_name
@@ -164,7 +164,7 @@ queries:
       - title: Overview of managed disk encryption options
         url: Overview of managed disk encryption options
     query: |
-      azurerm.compute.vms {
+      azure.compute.vms {
         osDisk {
           properties['encryption'] != null
         }
@@ -184,7 +184,7 @@ queries:
         2. Run the following query:
 
           ```mql
-          cnquery run azure -c "azurerm.network.securityGroups { securityRules }"
+          cnquery run azure -c "azure.network.securityGroups { securityRules }"
           ```
 
         __cnquery shell__
@@ -201,7 +201,7 @@ queries:
         3. Run the following query:
 
           ```mql
-          azurerm.network.securityGroups { securityRules }
+          azure.network.securityGroups { securityRules }
           ```
       remediation: |
         ###Terraform
@@ -209,10 +209,10 @@ queries:
         ```hcl
         # Ensure the `source_address_prefix` is configured to a restrictive CIDR address
 
-        resource "azurerm_network_security_group" "my_terraform_nsg" {
+        resource "azure_network_security_group" "my_terraform_nsg" {
           name                = "myNetworkSecurityGroup"
-          location            = azurerm_resource_group.rg.location
-          resource_group_name = azurerm_resource_group.rg.name
+          location            = azure_resource_group.rg.location
+          resource_group_name = azure_resource_group.rg.name
 
           security_rule {
             name                       = "SSH"
@@ -228,7 +228,7 @@ queries:
         }
         ```
     query: |
-      azurerm.network.securityGroups {
+      azure.network.securityGroups {
         securityRules.where ( 
           _.properties['access'] == 'Allow' && 
           _.properties['direction'] == 'Inbound' &&
@@ -254,7 +254,7 @@ queries:
         2. Run the following query:
 
           ```mql
-          cnquery run azure -c "azurerm.network.securityGroups { securityRules }"
+          cnquery run azure -c "azure.network.securityGroups { securityRules }"
           ```
 
         __cnquery shell__
@@ -271,7 +271,7 @@ queries:
         3. Run the following query:
 
           ```mql
-          azurerm.network.securityGroups { securityRules }
+          azure.network.securityGroups { securityRules }
           ```
       remediation: |
         ###Terraform
@@ -279,10 +279,10 @@ queries:
         ```hcl
         # Ensure the `source_address_prefix` is configured to a restrictive CIDR address
         
-        resource "azurerm_network_security_group" "example" {
+        resource "azure_network_security_group" "example" {
           name                = "example-rdp-security"
-          location            = azurerm_resource_group.rg.location
-          resource_group_name = azurerm_resource_group.rg.name
+          location            = azure_resource_group.rg.location
+          resource_group_name = azure_resource_group.rg.name
 
           security_rule {
             name                       = "RDP"
@@ -298,7 +298,7 @@ queries:
         }
         ```
     query: |
-      azurerm.network.securityGroups {
+      azure.network.securityGroups {
         securityRules.where ( 
           _.properties['access'] == 'Allow' && 
           _.properties['direction'] == 'Inbound' && 
@@ -325,7 +325,7 @@ queries:
         2. Run the following query:
 
           ```mql
-          cnquery run azure -c "azurerm.storage.accounts { properties['supportsHttpsTrafficOnly'] }"
+          cnquery run azure -c "azure.storage.accounts { properties['supportsHttpsTrafficOnly'] }"
           ```
 
         __cnquery shell__
@@ -342,19 +342,19 @@ queries:
         3. Run the following query:
 
           ```mql
-          azurerm.storage.accounts { properties['supportsHttpsTrafficOnly'] }
+          azure.storage.accounts { properties['supportsHttpsTrafficOnly'] }
           ```
       remediation: |
         ###Terraform
 
         ```hcl
-        resource "azurerm_storage_account" "example_storage_account" {
+        resource "azure_storage_account" "example_storage_account" {
           ...
           enable_https_traffic_only = true
         }
         ```    
     query: |
-      azurerm.storage.accounts {
+      azure.storage.accounts {
         properties['supportsHttpsTrafficOnly'] == true || properties['enableHttpsTrafficOnly'] == true
       }
   - uid: mondoo-azure-security-public-access-level-private-blob-containers
@@ -372,7 +372,7 @@ queries:
         2. Run the following query:
 
           ```mql
-          cnquery run azure -c "azurerm.storage.accounts { containers { properties['publicAccess'] == "None" } }"
+          cnquery run azure -c "azure.storage.accounts { containers { properties['publicAccess'] == "None" } }"
           ```
 
         __cnquery shell__
@@ -389,13 +389,13 @@ queries:
         3. Run the following query:
 
           ```mql
-          azurerm.storage.accounts { containers { properties['publicAccess'] == "None" } }
+          azure.storage.accounts { containers { properties['publicAccess'] == "None" } }
           ```
       remediation: |
         ###Terraform
 
         ```hcl
-        resource "azurerm_storage_container" "example_storage_container" {
+        resource "azure_storage_container" "example_storage_container" {
             ...
           container_access_type = "private"
         }
@@ -423,7 +423,7 @@ queries:
         --account-key <account_key>
         ```
     query: |
-      azurerm.storage.accounts {
+      azure.storage.accounts {
         containers {
           properties['publicAccess'] == "None"
         }
@@ -443,7 +443,7 @@ queries:
         2. Run the following query:
 
           ```mql
-          cnquery run azure -c "azurerm.storage.accounts { containers { properties['publicAccess'] == "None" } }"
+          cnquery run azure -c "azure.storage.accounts { containers { properties['publicAccess'] == "None" } }"
           ```
 
         __cnquery shell__
@@ -460,7 +460,7 @@ queries:
         3. Run the following query:
 
           ```mql
-          azurerm.storage.accounts { containers { properties['publicAccess'] == "None" } }
+          azure.storage.accounts { containers { properties['publicAccess'] == "None" } }
           ```
       remediation: |
         ###Terraform
@@ -468,19 +468,19 @@ queries:
         ```hcl
         # Ensure the `default_action` is set to `Deny`
 
-        resource "azurerm_storage_account_network_rules" "example_storage_account" {
-          resource_group_name  = azurerm_resource_group.example.name
-          storage_account_name = azurerm_storage_account.example.name
+        resource "azure_storage_account_network_rules" "example_storage_account" {
+          resource_group_name  = azure_resource_group.example.name
+          storage_account_name = azure_storage_account.example.name
 
           default_action       = "Deny"
         }
         ```
 
         ```hcl
-        resource "azurerm_storage_account" "example_storage_account" {
+        resource "azure_storage_account" "example_storage_account" {
           name                = "example_storage_account"
-          resource_group_name = azurerm_resource_group.example.name
-          location            = azurerm_resource_group.example.location
+          resource_group_name = azure_resource_group.example.name
+          location            = azure_resource_group.example.location
 
           network_rules {
             default_action = "Deny"
@@ -490,7 +490,7 @@ queries:
         }
         ```      
     query: |
-      azurerm.storage.accounts {
+      azure.storage.accounts {
         properties['networkAcls']['defaultAction'] == "Deny"
       }
   - uid: mondoo-azure-security-trusted-microsoft-services-enabled-for-storage-account-access
@@ -508,7 +508,7 @@ queries:
         2. Run the following query:
 
           ```mql
-          cnquery run azure -c "azurerm.storage.accounts { containers { properties['publicAccess'] == "None" } }"
+          cnquery run azure -c "azure.storage.accounts { containers { properties['publicAccess'] == "None" } }"
           ```
 
         __cnquery shell__
@@ -525,13 +525,13 @@ queries:
         3. Run the following query:
 
           ```mql
-          azurerm.storage.accounts { containers { properties['publicAccess'] == "None" } }
+          azure.storage.accounts { containers { properties['publicAccess'] == "None" } }
           ```
       remediation: |
         ###Terraform
 
         ```hcl
-        resource "azurerm_storage_account" "example" {
+        resource "azure_storage_account" "example" {
             ...
           network_rules {
             ...
@@ -541,7 +541,7 @@ queries:
         }
         ``` 
     query: |
-      azurerm.storage.accounts {
+      azure.storage.accounts {
         properties['networkAcls']['bypass'] == "AzureServices"
       }
   - uid: mondoo-azure-security-ensure-auditing-on
@@ -559,7 +559,7 @@ queries:
         2. Run the following query:
 
           ```mql
-          cnquery run azure -c "azurerm.sql.servers { auditingPolicy['state'] }"
+          cnquery run azure -c "azure.sql.servers { auditingPolicy['state'] }"
           ```
 
         __cnquery shell__
@@ -576,25 +576,25 @@ queries:
         3. Run the following query:
 
           ```mql
-          azurerm.sql.servers { auditingPolicy['state'] }
+          azure.sql.servers { auditingPolicy['state'] }
           ```
       remediation: |
         ###Terraform
 
         ```hcl
-        resource "azurerm_sql_server" "example_sql_server" {
+        resource "azure_sql_server" "example_sql_server" {
           ...
 
           extended_auditing_policy {
-            storage_endpoint                        = azurerm_storage_account.example.primary_blob_endpoint
-            storage_account_access_key              = azurerm_storage_account.example.primary_access_key
+            storage_endpoint                        = azure_storage_account.example.primary_blob_endpoint
+            storage_account_access_key              = azure_storage_account.example.primary_access_key
             storage_account_access_key_is_secondary = true
             retention_in_days                       = 90
           }
         }
         ``` 
     query: |
-      azurerm.sql.servers {
+      azure.sql.servers {
         auditingPolicy['state'] == "Enabled"
       }
   - uid: mondoo-azure-security-ensure-auditing-retention-greater-than-90-days
@@ -612,7 +612,7 @@ queries:
         2. Run the following query:
 
           ```mql
-          cnquery run azure -c "azurerm.sql.servers { auditingPolicy['retentionDays'] }"
+          cnquery run azure -c "azure.sql.servers { auditingPolicy['retentionDays'] }"
           ```
 
         __cnquery shell__
@@ -629,24 +629,24 @@ queries:
         3. Run the following query:
 
           ```mql
-          azurerm.sql.servers { auditingPolicy['retentionDays'] }
+          azure.sql.servers { auditingPolicy['retentionDays'] }
           ```
       remediation: |
         ###Terraform
 
         ```hcl
-        resource "azurerm_sql_server" "example" {
+        resource "azure_sql_server" "example" {
           ...
           extended_auditing_policy {
-            storage_endpoint           = azurerm_storage_account.example.primary_blob_endpoint
-            storage_account_access_key = azurerm_storage_account.example.primary_access_key
+            storage_endpoint           = azure_storage_account.example.primary_blob_endpoint
+            storage_account_access_key = azure_storage_account.example.primary_access_key
             storage_account_access_key_is_secondary = true
             retention_in_days                       = 90
           }
         }
         ```     
     query: |
-      azurerm.sql.servers {
+      azure.sql.servers {
         auditingPolicy['retentionDays'] >= 90
       }
   - uid: mondoo-azure-security-no-sql-databases-allow-ingress-0-0-0-0-0
@@ -664,10 +664,10 @@ queries:
         2. Run the following query:
 
           ```mql
-          cnquery run azure -c "azurerm.sql.servers { firewallRules { startIpAddress } }"
-          cnquery run azure -c "azurerm.postgresql.servers { firewallRules { startIpAddress } }"
-          cnquery run azure -c "azurerm.mariadb.servers { firewallRules { startIpAddress } }"
-          cnquery run azure -c "azurerm.mysql.servers { firewallRules { startIpAddress } }"
+          cnquery run azure -c "azure.sql.servers { firewallRules { startIpAddress } }"
+          cnquery run azure -c "azure.postgresql.servers { firewallRules { startIpAddress } }"
+          cnquery run azure -c "azure.mariadb.servers { firewallRules { startIpAddress } }"
+          cnquery run azure -c "azure.mysql.servers { firewallRules { startIpAddress } }"
           ```
 
         __cnquery shell__
@@ -684,10 +684,10 @@ queries:
         3. Run the following query:
 
           ```mql
-          azurerm.sql.servers { firewallRules { startIpAddress } }
-          azurerm.postgresql.servers { firewallRules { startIpAddress } }
-          azurerm.mariadb.servers { firewallRules { startIpAddress } } 
-          azurerm.mysql.servers { firewallRules { startIpAddress } } 
+          azure.sql.servers { firewallRules { startIpAddress } }
+          azure.postgresql.servers { firewallRules { startIpAddress } }
+          azure.mariadb.servers { firewallRules { startIpAddress } } 
+          azure.mysql.servers { firewallRules { startIpAddress } } 
           ```
       remediation: |
         ###Terraform
@@ -697,7 +697,7 @@ queries:
         ```hcl
         # Ensure `start_ip_address` is not configured to `0.0.0.0`
 
-        resource "azurerm_mysql_firewall_rule" "example" {
+        resource "azure_mysql_firewall_rule" "example" {
           ...
           start_ip_address    = "192.168.2.22"
           end_ip_address      = "255.255.255.255"
@@ -709,7 +709,7 @@ queries:
         ```hcl
         # Ensure `start_ip_address` is not configured to `0.0.0.0`
 
-        resource "azurerm_mariadb_firewall_rule" "example" {
+        resource "azure_mariadb_firewall_rule" "example" {
           ...
           start_ip_address    = "192.168.2.22"
           end_ip_address      = "255.255.255.255"
@@ -721,7 +721,7 @@ queries:
         ```hcl
         # Ensure `start_ip_address` is not configured to `0.0.0.0`
 
-        resource "azurerm_sql_firewall_rule" "example" {
+        resource "azure_sql_firewall_rule" "example" {
           ...
           start_ip_address    = "192.168.2.22"
           end_ip_address      = "255.255.255.255"
@@ -733,32 +733,32 @@ queries:
         ```hcl
         # Ensure `start_ip_address` is not configured to `0.0.0.0`
 
-        resource "azurerm_postgresql_firewall_rule" "example" {
+        resource "azure_postgresql_firewall_rule" "example" {
           ...
           start_ip_address    = "192.168.2.22"
           end_ip_address      = "255.255.255.255"
         }
         ``` 
     query: |
-      azurerm.sql.servers {
+      azure.sql.servers {
         firewallRules.length >= 1
         firewallRules {
           startIpAddress != '0.0.0.0'
         }
       }
-      azurerm.postgresql.servers {
+      azure.postgresql.servers {
         firewallRules.length >= 1
         firewallRules {
           startIpAddress != '0.0.0.0'
         }
       }
-      azurerm.mysql.servers {
+      azure.mysql.servers {
         firewallRules.length >= 1
         firewallRules {
           startIpAddress != '0.0.0.0'
         }
       }
-      azurerm.mariadb.servers {
+      azure.mariadb.servers {
         firewallRules.length >= 1
         firewallRules {
           startIpAddress != '0.0.0.0'


### PR DESCRIPTION
Quick fix to solve the alias problem in case the policies are mixing with each other in azure Policy Hub Console which result in Time-Out! 

Checking with lint/sarif it came out that there are 3 unassigned policies which are not meeting our formatting regulation and it should be removed or being added, which are:

mondoo-azure-security-trusted-microsoft-services-enabled-for-storage-account-access
mondoo-azure-security-ensure-auditing-on
mondoo-azure-security-ensure-auditing-retention-greater-than-90-days

The quality of the queries have not been checked by me yet!!! On the Do-List! 


Signed-off-by: Hossein Rouhani <h_rouhani@hotmail.com>