### PR TITLE
Updates asset_filter for terraform policies to include terraform-hcl

### DIFF
--- a/core/mondoo-terraform-aws-security.mql.yaml
+++ b/core/mondoo-terraform-aws-security.mql.yaml
@@ -35,14 +35,14 @@ policies:
       - title: AWS General 
         asset_filter:
           query: |
-            platform.name == "terraform"
+            platform.name == "terraform" || platform.name == "terraform-hcl"
             terraform.providers.one(nameLabel == "aws")
         scoring_queries:
           terraform-aws-security-no-static-credentials-in-providers: null 
       - title: Amazon API Gateway
         asset_filter:
           query: |
-            platform.name == "terraform"
+            platform.name == "terraform" || platform.name == "terraform-hcl"
             terraform.providers.one(nameLabel == "aws") 
         scoring_queries:
           terraform-aws-security-api-gw-cache-enabled-and-encrypted:
@@ -53,7 +53,7 @@ policies:
       - title: Amazon Elastic Compute Cloud (Amazon EC2)
         asset_filter:
           query: |
-            platform.name == "terraform"
+            platform.name == "terraform" || platform.name == "terraform-hcl"
             terraform.providers.one(nameLabel == "aws")
         scoring_queries:
           terraform-aws-security-ec2-ebs-encryption-by-default:
@@ -62,14 +62,14 @@ policies:
       - title: AWS Identity and Access Management (IAM)
         asset_filter:
           query: |
-            platform.name == "terraform"
+            platform.name == "terraform" || platform.name == "terraform-hcl"
             terraform.providers.one(nameLabel == "aws")
         scoring_queries:
           terraform-aws-security-iam-no-wildcards-policies:
       - title: Amazon Simple Storage Service (Amazon S3)
         asset_filter:
           query: |
-            platform.name == "terraform"
+            platform.name == "terraform" || platform.name == "terraform-hcl"
             terraform.providers.one(nameLabel == "aws")
         scoring_queries:
           terraform-aws-security-s3-bucket-versioning-enabled:
@@ -80,7 +80,7 @@ policies:
       - title: AWS Elastic Kubernetes Service (EKS) Security for Terraform
         asset_filter:
           query: |
-            platform.name == "terraform"
+            platform.name == "terraform" || platform.name == "terraform-hcl"
             terraform.providers.one(nameLabel == "aws")
         scoring_queries:
           terraform-aws-security-eks-encrypt-secrets:

--- a/core/mondoo-terraform-gcp-security.mql.yaml
+++ b/core/mondoo-terraform-gcp-security.mql.yaml
@@ -35,14 +35,14 @@ policies:
       - title: GCP BigQuery
         asset_filter:
           query: |
-            platform.name == "terraform"
+            platform.name == "terraform" || platform.name == "terraform-hcl"
             terraform.providers.one( nameLabel == "google" )
         scoring_queries:
           terraform-gcp-security-bigquery-no-public-access: null
       - title: GCP Identity and Access Management (IAM)
         asset_filter:
           query: |
-            platform.name == "terraform"
+            platform.name == "terraform" || platform.name == "terraform-hcl"
             terraform.providers.one( nameLabel == "google" )
         scoring_queries:
           terraform-gcp-security-iam-no-folder-level-default-service-account-assignment: null
@@ -51,7 +51,7 @@ policies:
       - title: GCP Cloud Storage
         asset_filter:
           query: |
-            platform.name == "terraform"
+            platform.name == "terraform" || platform.name == "terraform-hcl"
             terraform.providers.one( nameLabel == "google" )
         scoring_queries:
           terraform-gcp-security-storage-no-public-access: null
@@ -59,7 +59,7 @@ policies:
       - title: GCP Compute
         asset_filter:
           query: |
-            platform.name == "terraform"
+            platform.name == "terraform" || platform.name == "terraform-hcl"
             terraform.providers.one( nameLabel == "google" )
         scoring_queries:
           terraform-gcp-security-compute-no-public-ip: null
@@ -80,7 +80,7 @@ policies:
       - title: GCP DNS
         asset_filter:
           query: |
-            platform.name == "terraform"
+            platform.name == "terraform" || platform.name == "terraform-hcl"
             terraform.providers.one( nameLabel == "google" )
         scoring_queries:
           terraform-gcp-security-dns-enable-dnssec: null
@@ -88,7 +88,7 @@ policies:
       - title: GCP Google Kubernetes Engine (GKE)
         asset_filter:
           query: |
-            platform.name == "terraform"
+            platform.name == "terraform" || platform.name == "terraform-hcl"
             terraform.providers.one( nameLabel == "google" )
         scoring_queries:
           terraform-gcp-security-gke-enable-auto-repair: null


### PR DESCRIPTION
This PR updates Terraform policies to include `terraform-hcl` to prepare for https://github.com/mondoohq/cnquery/pull/861. This change is backwards compatible for older clients


Signed-off-by: Scott Ford <scott@scottford.io>