### PR TITLE
Adds GitHub best practices and dependabot check to GitHub security

### DIFF
--- a/core/mondoo-github-best-practices.mql.yaml
+++ b/core/mondoo-github-best-practices.mql.yaml
@@ -85,7 +85,7 @@ queries:
       desc: |
         GitHub repositories should include a SUPPORT file to let people know how to get help with the project.
 
-        To direct people to specific support resources, you can add a SUPPORT file to your repository's root, docs, or .github folder. When someone creates an issue in your repository, they will see a link to your project's SUPPORT file.
+        To direct people to specific support resources, you can add a SUPPORT.md file to your repository's root, docs, or .github directory. When someone creates an issue in your repository, they will see a link to your project's SUPPORT.md file.
     refs:
       - title: Adding support resources to your project
         url: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project

--- a/core/mondoo-github-best-practices.mql.yaml
+++ b/core/mondoo-github-best-practices.mql.yaml
@@ -1,0 +1,188 @@
+policies:
+  - uid: mondoo-github-repository-best-practices
+    name: GitHub Repository Best Practices by Mondoo
+    version: 1.0.0
+    authors:
+      - name: Mondoo, Inc
+        email: hello@mondoo.com
+    docs:
+      desc: |
+        # Overview
+
+        GitHub Repository Best Practices by Mondoo provides assessments of public and private GitHub repositories to ensure a minimum recommended operational best practices. 
+
+        ## About remote scanning
+
+        Remote scans with cnspec provide on demand security assessments of infrastructure and services without the need to install any agents or integrations. cnspec comes with a growing list of providers to connect and scan local and remote targets. 
+
+        A complete list of providers can be found by running the following command: 
+        
+        ```bash
+        cnspec scan --help
+        ``` 
+
+        ### cnspec GitHub Provider
+        
+        This policy uses the `github` provider to authenticate with GitHub's API in order to remotely scan GitHub repositories. Additional information on the `github` provider can be found by running the following command: 
+        
+        ```bash
+        cnspec scan github --help
+        ```
+      
+        ## Configuring the GitHub provider
+
+        The `github` provider for cnspec requires a GitHub personal access token to authenticate with GitHub's API. The personal access token is required regardless of whether you are scanning a public or a private repository. Access to private repositories is determined by the level of access the token cnspec is configured with when it runs. 
+
+        ### Create a personal access token
+
+        To create a read-only personal access token, see [Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) on GitHub's documentation site.
+        
+        ### Configure a GITHUB_TOKEN environment variable
+
+        You supply your personal access token to cnspec using the `GITHUB_TOKEN` environment variable. 
+
+        #### Linux / MacOS
+
+        ```bash
+        export GITHUB_TOKEN=<your personal access token>
+        ```
+
+        #### Windows 
+
+        ```powershell
+        $Env:GITHUB_TOKEN = "<personal-access-token>"
+        ```        
+
+        ## Scanning GitHub repositories
+        
+        To scan the configuration of a GitHub repository:  
+
+        ```bash
+        cnspec scan github repo <ORG_NAME/REPO_NAME>
+        ```
+
+        ## Join the community!
+
+        Our goal is to build policies that are simple to deploy, accurate, and actionable. 
+        
+        If you have any suggestions on how to improve this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
+    scoring_system: 2
+    specs:
+      - asset_filter:
+          query: |
+            asset.platform == "github-repo" 
+        scoring_queries:
+          mondoo-github-repository-best-practices-support-resources: null
+          mondoo-github-repository-best-practices-code-of-conduct: null
+          mondoo-github-repository-best-practices-include-authors: null
+          mondoo-github-repository-best-practices-readme-getting-started: null
+          mondoo-github-repository-best-practices-license: null
+queries:
+  - uid: mondoo-github-repository-best-practices-support-resources
+    title: Ensure repository has a support policy
+    severity: 30
+    docs:
+      desc: |
+        GitHub repositories should include a SUPPORT file to let people know how to get help with the project.
+
+        To direct people to specific support resources, you can add a SUPPORT file to your repository's root, docs, or .github folder. When someone creates an issue in your repository, they will see a link to your project's SUPPORT file.
+    refs:
+      - title: Adding support resources to your project
+        url: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project
+    query: |
+      // if a .github repo exists, then check if the SUPPORT.md is there
+      if ( github.organization.repositories.one(name == ".github") ) {
+        github.organization.repositories.where( name == ".github").all( 
+          files.one( name.downcase == "support.md")
+        ) || github.repository.files.one( name.downcase == "support.md")
+      } else {
+          github.repository.files.one( name.downcase == "support.md")
+      }
+  - uid: mondoo-github-repository-best-practices-code-of-conduct
+    title: Ensure repository has a code of conduct policy
+    severity: 30
+    docs:
+      desc: |
+        Open source code repositories should include a code of conduct. Including a code of conduct helps to clarify the project's values and principles.
+      audit: |
+        __cnspec shell__
+
+        1. Open a Terminal.
+        2. Connect cnspec shell to GitHub  `cnspec shell github repo <org/repo_name> --token $GITHUB_TOKEN`
+        3. Run the following query
+
+           ```mql
+           github.repository.files.where( name.downcase == "code_of_conduct.md") 
+           ```
+      remediation: |
+        See [Adding a code of conduct to your project](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project) on the GitHub docs site. 
+    refs:
+      - title: Adding a code of conduct to your project
+        url: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project
+    query: |
+      // if a .github repo exists, then check if the CODE_OF_CONDUCT.md is there
+      if ( github.organization.repositories.one(name == ".github") ) {
+        github.organization.repositories.where( name == ".github").all( 
+          files.one( name.downcase == "code_of_conduct.md")
+        ) || github.repository.files.one( name.downcase == "code_of_conduct.md")
+      } else {
+        github.repository.files.one( name.downcase == "code_of_conduct.md")
+      }
+  - uid: mondoo-github-repository-best-practices-include-authors
+    title: Ensure the README.md includes authors
+    severity: 20
+    docs:
+      desc: |
+        Including the authors in the README provides transparency to the users looking to use the project in their environments. 
+      audit: |
+        __cnspec shell__
+
+        1. Open a Terminal.
+        2. Connect cnspec shell to GitHub  `cnspec shell github repo <org/repo_name> --token $GITHUB_TOKEN`
+        3. Run the following query
+
+           ```mql
+           github.repository.files.where( name.downcase == "code_of_conduct.md") 
+           ```
+      remediation: |
+        Update the `README.md` with information about the project's authors.
+    query: |
+      github.repository.files.where(name.downcase  == "readme.md") {
+        content == /Authors/i
+      }
+  - uid: mondoo-github-repository-best-practices-readme-getting-started
+    title: Ensure the README.md includes getting started guide
+    severity: 30
+    docs:
+      desc: |
+        This check ensures the repository README file contains a getting started guide. 
+      remediation: |
+        Update the repository README file with a section titled "Getting Started" for your users.  
+    query: |
+      github.repository.files.where(name.downcase  == "readme.md") {
+        content == /Getting started/i
+      }      
+  - uid: mondoo-github-repository-best-practices-license
+    title: Ensure repository declares a license
+    severity: 30
+    docs:
+      desc: |
+        Check tries to determine if the project has published a license. It works by checking standard locations for a file named according to common license conventions.
+
+        A license can give users information about how the source code may or may not be used. The lack of a license will impede any kind of security review or audit and creates a legal risk for potential users.
+      audit: |
+        __cnspec shell__
+
+        1. Open a Terminal.
+        2. Connect cnspec shell to GitHub  `cnspec shell github repo <org/repo_name> --token $GITHUB_TOKEN`
+        3. Run the following query
+
+           ```mql
+           github.repository.files.where( name == /LICENSE/ )
+           ```
+      remediation: |
+        See [Adding a license to a repository](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository) on the GitHub documentation site. 
+    refs:
+      - title: "GitHub Docs - Adding a security policy to your repository"
+        url: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository
+    query: github.repository.files.one( name == /LICENSE/ ) 

--- a/core/mondoo-github-best-practices.mql.yaml
+++ b/core/mondoo-github-best-practices.mql.yaml
@@ -41,7 +41,7 @@ policies:
 
         You supply your personal access token to cnspec using the `GITHUB_TOKEN` environment variable. 
 
-        #### Linux / MacOS
+        #### Linux / macOS
 
         ```bash
         export GITHUB_TOKEN=<your personal access token>

--- a/core/mondoo-github-best-practices.mql.yaml
+++ b/core/mondoo-github-best-practices.mql.yaml
@@ -21,7 +21,7 @@ policies:
         cnspec scan --help
         ``` 
 
-        ### cnspec GitHub Provider
+        ### cnspec GitHub provider
         
         This policy uses the `github` provider to authenticate with GitHub's API in order to remotely scan GitHub repositories. Additional information on the `github` provider can be found by running the following command: 
         

--- a/core/mondoo-github-best-practices.mql.yaml
+++ b/core/mondoo-github-best-practices.mql.yaml
@@ -83,7 +83,7 @@ queries:
     severity: 30
     docs:
       desc: |
-        GitHub repositories should include a SUPPORT file to let people know how to get help with the project.
+        GitHub repositories should include a SUPPORT.md file to let people know how to get help with the project.
 
         To direct people to specific support resources, you can add a SUPPORT.md file to your repository's root, docs, or .github directory. When someone creates an issue in your repository, they will see a link to your project's SUPPORT.md file.
     refs:

--- a/core/mondoo-github-best-practices.mql.yaml
+++ b/core/mondoo-github-best-practices.mql.yaml
@@ -133,7 +133,7 @@ queries:
     severity: 20
     docs:
       desc: |
-        Including the authors in the README provides transparency to the users looking to use the project in their environments. 
+        Including the authors in the README.md provides transparency to the users looking to use the project in their environments. 
       audit: |
         __cnspec shell__
 

--- a/core/mondoo-github-best-practices.mql.yaml
+++ b/core/mondoo-github-best-practices.mql.yaml
@@ -99,11 +99,13 @@ queries:
           github.repository.files.one( name.downcase == "support.md")
       }
   - uid: mondoo-github-repository-best-practices-code-of-conduct
-    title: Ensure repository has a code of conduct policy
+    title: Ensure repository has a CODE_OF_CONDUCT.md policy
     severity: 30
     docs:
       desc: |
-        Open source code repositories should include a code of conduct. Including a code of conduct helps to clarify the project's values and principles.
+        Open source code repositories should include a CODE_OF_CONDUCT.md. Including a CODE_OF_CONDUCT.md helps to clarify the project's values and principles. 
+
+        You can add a CODE_OF_CONDUCT.md file to your repository's root, docs, or .github directory.
       audit: |
         __cnspec shell__
 
@@ -115,9 +117,9 @@ queries:
            github.repository.files.where( name.downcase == "code_of_conduct.md") 
            ```
       remediation: |
-        See [Adding a code of conduct to your project](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project) on the GitHub docs site. 
+        See [Adding a CODE_OF_CONDUCT.md to your project](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project) on the GitHub docs site. 
     refs:
-      - title: Adding a code of conduct to your project
+      - title: Adding a CODE_OF_CONDUCT.md to your project
         url: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project
     query: |
       // if a .github repo exists, then check if the CODE_OF_CONDUCT.md is there
@@ -142,7 +144,7 @@ queries:
         3. Run the following query
 
            ```mql
-           github.repository.files.where( name.downcase == "code_of_conduct.md") 
+           github.repository.files.where( name.downcase == "README.md") { content }
            ```
       remediation: |
         Update the `README.md` with information about the project's authors.

--- a/core/mondoo-github-security.mql.yaml
+++ b/core/mondoo-github-security.mql.yaml
@@ -171,6 +171,8 @@ policies:
           mondoo-github-repository-security-required-signed-commits: null
           mondoo-github-repository-security-binary-artifacts: null
           mondoo-github-repository-security-enforce-branch-protection: null
+          mondoo-github-repository-security-security-policy: null
+          mondoo-github-repository-security-ensure-dependabot-workflow: null
 props:
   - uid: requiredPullRequestReviews
     title: Define the required number of reviewers on pull requests
@@ -465,30 +467,6 @@ queries:
       } else {
         github.repository.files.one( name.downcase == "security.md")
       }
-  - uid: mondoo-github-repository-security-license
-    title: Ensure repository declares a license
-    severity: 30
-    docs:
-      desc: |
-        Check tries to determine if the project has published a license. It works by checking standard locations for a file named according to common license conventions.
-
-        A license can give users information about how the source code may or may not be used. The lack of a license will impede any kind of security review or audit and creates a legal risk for potential users.
-      audit: |
-        __cnspec shell__
-
-        1. Open a Terminal.
-        2. Connect cnspec shell to GitHub  `cnspec shell github repo <org/repo_name> --token $GITHUB_TOKEN`
-        3. Run the following query
-
-           ```mql
-           github.repository.files.where( name == /LICENSE/ )
-           ```
-      remediation: |
-        See [Adding a license to a repository](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository) on the GitHub documentation site. 
-    refs:
-      - title: "GitHub Docs - Adding a security policy to your repository"
-        url: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository
-    query: github.repository.files.one( name == /LICENSE/ )
   - uid: mondoo-github-repository-security-binary-artifacts
     title: Ensure repository does not generate binary artifacts
     severity: 90
@@ -516,87 +494,16 @@ queries:
       github.repository.files
         .where( type == "dir" )
         .all( files.where( type != "dir").all( isBinary == false) )
-  - uid: mondoo-github-repository-security-support-resources
-    title: Ensure repository has a support policy
-    severity: 30
+  - uid: mondoo-github-repository-security-ensure-dependabot-workflow
+    title: Ensure a GitHub Actions workflow exists for dependabot
+    severity: 70
     docs:
       desc: |
-        GitHub repositories should include a SUPPORT file to let people know how to get help with the project.
-
-        To direct people to specific support resources, you can add a SUPPORT file to your repository's root, docs, or .github folder. When someone creates an issue in your repository, they will see a link to your project's SUPPORT file.
-    refs:
-      - title: Adding support resources to your project
-        url: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project
-    query: |
-      // if a .github repo exists, then check if the SUPPORT.md is there
-      if ( github.organization.repositories.one(name == ".github") ) {
-        github.organization.repositories.where( name == ".github").all( 
-          files.one( name.downcase == "support.md")
-        ) || github.repository.files.one( name.downcase == "support.md")
-      } else {
-          github.repository.files.one( name.downcase == "support.md")
-      }
-  - uid: mondoo-github-repository-security-code-of-conduct
-    title: Ensure repository has a code of conduct policy
-    severity: 30
-    docs:
-      desc: |
-        Open source code repositories should include a code of conduct. Including a code of conduct helps to clarify the project's values and principles.
-      audit: |
-        __cnspec shell__
-
-        1. Open a Terminal.
-        2. Connect cnspec shell to GitHub  `cnspec shell github repo <org/repo_name> --token $GITHUB_TOKEN`
-        3. Run the following query
-
-           ```mql
-           github.repository.files.where( name.downcase == "code_of_conduct.md") 
-           ```
+        This check ensures the existence of a GitHub Actions workflow to run Dependabot checks on the repository by looking for the existence of a `.github/dependabot.yml` or `.github/dependabot.yaml` configuration file.
+        Dependabot creates pull requests to keep your dependencies up to date, and you can use GitHub Actions to perform automated tasks when these pull requests are created. For example, fetch additional artifacts, add labels, run tests, or otherwise modifying the pull request.
       remediation: |
-        See [Adding a code of conduct to your project](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project) on the GitHub docs site. 
-    refs:
-      - title: Adding a code of conduct to your project
-        url: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project
+        GitHub Actions provides many different workflows for running Dependabot checks on a project. For more information see [Automating Dependabot with GitHub Actions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions) in the GitHub documentation site.
     query: |
-      // if a .github repo exists, then check if the CODE_OF_CONDUCT.md is there
-      if ( github.organization.repositories.one(name == ".github") ) {
-        github.organization.repositories.where( name == ".github").all( 
-          files.one( name.downcase == "code_of_conduct.md")
-        ) || github.repository.files.one( name.downcase == "code_of_conduct.md")
-      } else {
-        github.repository.files.one( name.downcase == "code_of_conduct.md")
-      }
-  - uid: mondoo-github-repository-security-include-authors
-    title: Ensure the README.md includes authors
-    severity: 20
-    docs:
-      desc: |
-        Including the authors in the README provides transparency to the users looking to use the project in their environments. 
-      audit: |
-        __cnspec shell__
-
-        1. Open a Terminal.
-        2. Connect cnspec shell to GitHub  `cnspec shell github repo <org/repo_name> --token $GITHUB_TOKEN`
-        3. Run the following query
-
-           ```mql
-           github.repository.files.where( name.downcase == "code_of_conduct.md") 
-           ```
-      remediation: |
-        Update the `README.md` with information about the project's authors.
-    query: |
-      github.repository.files.where(name.downcase  == "readme.md") {
-        content == /Authors/i
-      }
-  - uid: mondoo-github-repository-security-readme-getting-started
-    title: Ensure the README.md includes getting started guide
-    severity: 30
-    docs:
-      desc: |
-        This check ensures the repository README file contains a getting started guide. 
-      remediation: |
-        Update the repository README file with a section titled "Getting Started" for your users.  
-    query: |
-      github.repository.files.where(name.downcase  == "readme.md") {
-        content == /Getting started/i
-      }
+      github.repository.files
+        .where( path == ".github" )
+        .all( files.one( name == "dependabot.yaml" || name == "dependabot.yml" ) )

--- a/core/mondoo-github-security.mql.yaml
+++ b/core/mondoo-github-security.mql.yaml
@@ -495,7 +495,7 @@ queries:
         .where( type == "dir" )
         .all( files.where( type != "dir").all( isBinary == false) )
   - uid: mondoo-github-repository-security-ensure-dependabot-workflow
-    title: Ensure a GitHub Actions workflow exists for dependabot
+    title: Ensure a GitHub Actions workflow exists for Dependabot
     severity: 70
     docs:
       desc: |


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/49754039/216122972-b45c148b-22da-4232-aa43-0010bc416cd3.png)

Adds new GitHub Best Practices policy, which contains recommendations that were previously in the GitHub Repository Security policy and @chris-rock and I agreed were not security related. 

This PR also adds a new dependabot workflow check which closes https://github.com/mondoohq/cnspec-policies/issues/89 for @tas50 

<img src="https://media0.giphy.com/media/dVuaiKbihwlS8/giphy.gif"/>

Signed-off-by: Scott Ford <scott@scottford.io>