### PR TITLE
:sparkles: Preparing and improving asset filters for future root asset changes

### DIFF
--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -61,8 +61,8 @@ policies:
   specs:
   - asset_filter:
       query: |
-        platform.name == "gcp"
-        platform.kind == "api"
+        asset.platform == "gcp" || asset.platform == "gcp-project"
+        asset.kind == "api" || asset.kind == "gcp-object"
     scoring_queries:
           mondoo-gcp-security-instances-are-not-configured-use-default-service-account: null
           mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api: null


### PR DESCRIPTION
- this PR updates the `asset_filter` blocks to match the future root assets while still keeping the old filters:

```
asset.platform == "gcp" || asset.platform == "gcp-project"
asset.kind == "api" || asset.kind == "gcp-object"
```

Signed-off-by: Manuel Weber <manuel@mondoo.com>