### PR TITLE
Fixes queries for branch protection and dependabot checks

### DIFF
--- a/core/mondoo-github-security.mql.yaml
+++ b/core/mondoo-github-security.mql.yaml
@@ -306,6 +306,9 @@ queries:
     query: |
       github.repository.branches
         .where( isDefault == true )
+        .all( protected == true )
+      github.repository.branches
+        .where( isDefault == true )
         .all( protectionRules { allowForcePushes['enabled'] == false } )
   - uid: mondoo-github-repository-security-prevent-force-pushes-release-branch
     title: Ensure repository does not allow force pushes to any release branches
@@ -340,6 +343,9 @@ queries:
     query: |
       github.repository.branches
         .where( name == /^release/ )
+        .all( protected == true )
+      github.repository.branches
+        .where( name == /^release/ )
         .all( protectionRules { allowForcePushes['enabled'] == false } )
   - uid: mondoo-github-repository-security-require-conversation-resolution
     title: Ensure branch protection requires conversation resolution before merging 
@@ -355,6 +361,9 @@ queries:
       - title: "GitHub Documentation - Require conversation resolution before merging"
         url: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-conversation-resolution-before-merging
     query: |
+      github.repository.branches
+        .where( isDefault == true )
+        .all( protected == true )
       github.repository.branches
         .where( isDefault == true )
         .all( protectionRules { requiredConversationResolution['enabled'] == true } )
@@ -384,6 +393,9 @@ queries:
     query: |
       github.repository.branches
         .where( isDefault == true )
+        .all( protected == true )
+      github.repository.branches
+        .where( isDefault == true )
         .all( protectionRules { requiredStatusChecks.length > 0 } ) 
   - uid: mondoo-github-repository-security-required-signed-commits
     title: Ensure repository branch protection requires signed commits
@@ -411,6 +423,9 @@ queries:
     query: |
       github.repository.branches
         .where( isDefault == true )
+        .all( protected == true )
+      github.repository.branches
+        .where( isDefault == true )
         .all( protectionRules { requiredSignatures == true } )
   - uid: mondoo-github-repository-security-enforce-branch-protection
     title: Ensure repository does not allow bypassing of branch protections rules
@@ -434,7 +449,11 @@ queries:
       - title: "GitHub Docs - About protected branches"
         url: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches
     query: |
-      github.repository.branches.where( isDefault == true )
+      github.repository.branches
+        .where( isDefault == true )
+        .all( protected == true )
+      github.repository.branches
+        .where( isDefault == true )
         .all( protectionRules.enforceAdmins['enabled'] == true )
   - uid: mondoo-github-repository-security-security-policy
     title: Ensure repository defines a security policy
@@ -504,6 +523,8 @@ queries:
       remediation: |
         GitHub Actions provides many different workflows for running Dependabot checks on a project. For more information see [Automating Dependabot with GitHub Actions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions) in the GitHub documentation site.
     query: |
+      github.repository.files
+        .one( name == ".github" && type == "dir" )
       github.repository.files
         .where( path == ".github" )
         .all( files.one( name == "dependabot.yaml" || name == "dependabot.yml" ) )


### PR DESCRIPTION
This PR fixes mql queries for branch protection to ensure each branch protection first checks if the branch is protected, and then checks the individual rule.

This PR also updates the dependabot check to check that the `.github` folder exists before checking for the `dependabot.yml` file. 

Closes https://github.com/mondoohq/cnspec-policies/issues/116


Signed-off-by: Scott Ford <scott@scottford.io>