### PR TITLE
Align extra policy names with our others

### DIFF
--- a/extra/mondoo-google-workspace-security.mql.yaml
+++ b/extra/mondoo-google-workspace-security.mql.yaml
@@ -1,6 +1,6 @@
 policies:
   - uid: mondoo-google-workspace-security
-    name: Google Workspace Security
+    name: Google Workspace Security by Mondoo
     version: 1.0.0
     authors:
       - name: Mondoo, Inc

--- a/extra/mondoo-okta-security.mql.yaml
+++ b/extra/mondoo-okta-security.mql.yaml
@@ -1,6 +1,6 @@
 policies:
   - uid: mondoo-okta-security
-    name: Okta Organization Security
+    name: Okta Organization Security by Mondoo
     version: 1.0.0
     authors:
       - name: Mondoo, Inc

--- a/extra/mondoo-slack-security.mql.yaml
+++ b/extra/mondoo-slack-security.mql.yaml
@@ -1,6 +1,6 @@
 policies:
   - uid: mondoo-slack-security
-    name: Slack Team Security
+    name: Slack Team Security by Mondoo
     version: 1.0.0
     authors:
       - name: Mondoo, Inc


### PR DESCRIPTION
At the moment `by Mondoo` is the only way to signal that a policy is maintained by Mondoo. These names need to match our other Mondoo maintained policies.