### PR TITLE
Add ending slash to match audit rule

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1462,10 +1462,10 @@ queries:
     query: |
       file('/etc/audit/audit.rules').exists
       if (file('/etc/audit/audit.rules').exists) {
-        file('/etc/audit/audit.rules').content.lines.contains(/^(\s+)?\-w\s+\/etc\/selinux\s+\-p\s+\wa\s+\-k\s+MAC\-policy(\s+)?$/)
-          || file('/etc/audit/audit.rules').content.lines.contains(/^(\s+)?\-w\s+\/etc\/apparmor\s+\-p\s+\wa\s+\-k\s+MAC\-policy(\s+)?$/)
-        file('/etc/audit/audit.rules').content.lines.contains(/^(\s+)?\-w\s+\/usr\/share\/selinux\s+\-p\s+\wa\s+\-k\s+MAC\-policy(\s+)?$/)
-          || file('/etc/audit/audit.rules').content.lines.contains(/^(\s+)?\-w\s+\/etc\/apparmor.d\s+\-p\s+\wa\s+\-k\s+MAC\-policy(\s+)?$/)
+        file('/etc/audit/audit.rules').content.lines.contains(/^(\s+)?\-w\s+\/etc\/selinux\/\s+\-p\s+\wa\s+\-k\s+MAC\-policy(\s+)?$/)
+          || file('/etc/audit/audit.rules').content.lines.contains(/^(\s+)?\-w\s+\/etc\/apparmor\/\s+\-p\s+\wa\s+\-k\s+MAC\-policy(\s+)?$/)
+        file('/etc/audit/audit.rules').content.lines.contains(/^(\s+)?\-w\s+\/usr\/share\/selinux\/\s+\-p\s+\wa\s+\-k\s+MAC\-policy(\s+)?$/)
+          || file('/etc/audit/audit.rules').content.lines.contains(/^(\s+)?\-w\s+\/etc\/apparmor.d\/\s+\-p\s+\wa\s+\-k\s+MAC\-policy(\s+)?$/)
       }
   - uid: mondoo-linux-security-events-that-modify-the-systems-network-environment-are-collected
     title: Ensure events that modify the system's network environment are collected


### PR DESCRIPTION
According to CIS, the matching directories for SELinux and AppArmor should end with a slash.

https://www.tenable.com/audits/items/CIS_Distribution_Independent_Linux_Server_L2_v2.0.0.audit:1bc028323ca571eb50ec249948b12714

This MR fixes the regex accordingly.