### PR TITLE
Use consistent names in slack policy

### DIFF
--- a/.github/actions/spelling/line_forbidden.patterns
+++ b/.github/actions/spelling/line_forbidden.patterns
@@ -420,8 +420,9 @@
 \bBiz Talk service\b
 \bBiz Talk Service\b
 
+# disabled here due to false positives
 # s.b. Data Box
-\bdata box\b
+# \bdata box\b
 
 # s.b. Database Migration Service
 \bDatabase Migration Service\b

--- a/core/mondoo-slack-security.mql.yaml
+++ b/core/mondoo-slack-security.mql.yaml
@@ -259,7 +259,7 @@ queries:
         Make sure to use a fixed pattern for all externally shared channels. To learn more, read [Create guidelines for channel names](https://slack.com/help/articles/217626408-Create-guidelines-for-channel-names) in the Slack documentation.
 
   - uid: mondoo-slack-security-at-least-one-workspace-internal-channel
-    title: Make sure there is at least one internal channel per workspace
+    title: Ensure there is at least one internal channel per workspace
     mql: |
       slack.conversations.where(isChannel == true)
         .any(
@@ -304,7 +304,7 @@ queries:
         Create at least one channel that is for internal workspace use only. To learn more, read [Slack Connect: Manage channel invitation settings and permissions](https://slack.com/help/articles/1500012572621-Slack-Connect--Manage-channel-invitation-settings-and-permissions-) in the Slack documentation.
 
   - uid: mondoo-slack-security-at-least-one-workspace-internal-channel-no-ext-members
-    title: Make sure there is at least one internal channel in the workspace and there are no external members
+    title: Ensure there is at least one internal channel in the workspace and there are no external members
     mql: |
       slack.conversations.where(isChannel == true)
         .where(
@@ -357,7 +357,7 @@ queries:
         Create at least one channel which is for internal workspace use only. Make sure that no user who does not belong to your organization is in the channel(s).
 
   - uid: mondoo-slack-domain-whitelisting-enforced-on-internal-channels
-    title: Make sure you enforce domain whitelisting on internal channels
+    title: Ensure domain whitelisting is enforced on internal channels
     mql:
       slack.conversations.where(isExtShared == false ).all(
         members.all(
@@ -372,7 +372,7 @@ queries:
     impact: 75
     docs:
       desc: |
-        Make sure there are no users from unwanted domains in your internal channels
+        Ensure there are no users from unwanted domains in your internal channels
       audit: |
         Run this command to verify that all users non-externally shared channels adhere to your whitelisted domains:
 


### PR DESCRIPTION
Ensure everywhere.