### PR TITLE
🧹 Rewrite beast query

### DIFF
--- a/core/mondoo-tls-security.mql.yaml
+++ b/core/mondoo-tls-security.mql.yaml
@@ -128,15 +128,14 @@ queries:
   - uid: mondoo-tls-security-mitigate-beast
     title: Mitigate BEAST attacks on the server-side
     mql: |-
-      switch {
-        case tls.versions.containsOnly(["tls1.2", "tls1.3"]):
-          score(100);
-        case tls.ciphers.all( /rc4/i ):
-          score(100);
-        case tls.ciphers.none( /null|dh_anon|export|des|rc2|idea/ ):
-          score(80);
-        default:
-          score(0);
+      if (tls.versions.containsOnly(["tls1.2", "tls1.3"])) {
+          score(100)
+      } else if (tls.ciphers.all( /rc4/i )) {
+          score(100)
+      } else if (tls.ciphers.none( /null|dh_anon|export|des|rc2|idea/ )) {
+          score(80)
+      } else {
+        score(0)
       }
     refs:
       - url: https://kb.vmware.com/s/article/2008784


### PR DESCRIPTION
The query as its written causes problems during storage. The problem boils down to representing byte data as strings, and types are the culprit there. This particular query gets typed as unset. That turns out to not be storable a string