### PR TITLE
🐛 Update SQL servers to latest resource fields

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,0 +1,1 @@
+postgreSql

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,1 +1,0 @@
-postgreSql

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -52,3 +52,6 @@ uid:\s.*$
 
 # ARN values
 \barn:\S*
+
+# Azure postgreSql resource
+postgreSql

--- a/core/mondoo-azure-security.mql.yaml
+++ b/core/mondoo-azure-security.mql.yaml
@@ -1,7 +1,7 @@
 policies:
   - uid: mondoo-azure-security
     name: Microsoft Azure Security
-    version: 1.2.0
+    version: 1.2.1
     license: MPL-2.0
     tags:
       mondoo.com/category: security
@@ -402,19 +402,19 @@ queries:
           startIpAddress != '0.0.0.0'
         }
       }
-      azure.postgresql.servers {
+      azure.postgreSql.servers {
         firewallRules.length >= 1
         firewallRules {
           startIpAddress != '0.0.0.0'
         }
       }
-      azure.mysql.servers {
+      azure.mySql.servers {
         firewallRules.length >= 1
         firewallRules {
           startIpAddress != '0.0.0.0'
         }
       }
-      azure.mariadb.servers {
+      azure.mariaDb.servers {
         firewallRules.length >= 1
         firewallRules {
           startIpAddress != '0.0.0.0'
@@ -422,7 +422,7 @@ queries:
       }
     docs:
       desc: "This check ensures that no SQL databases allow ingress connections from \"0.0.0.0\". \n"
-      audit: "__cnspec run__\n\nTo audit Microsoft Azure with `cnspec run`:\n\n1. Run `az login` to authenticate with the correct Azure subscription and tenant.\n2. Run the following query:\n\n  ```bash\n  cnspec run azure -c \"azure.sql.servers { firewallRules { startIpAddress } }\"\n  cnspec run azure -c \"azure.postgresql.servers { firewallRules { startIpAddress } }\"\n  cnspec run azure -c \"azure.mariadb.servers { firewallRules { startIpAddress } }\"\n  cnspec run azure -c \"azure.mysql.servers { firewallRules { startIpAddress } }\"\n  ```\n\n__cnspec shell__\n\nTo audit Microsoft Azure with `cnspec shell`:\n\n1. Run `az login` to authenticate with the correct Azure subscription and tenant. \n2. Launch `cnspec shell`:\n\n  ```bash\n  cnspec shell azure\n  ```\n\n3. Run the following query:\n\n  ```mql\n  azure.sql.servers { firewallRules { startIpAddress } }\n  azure.postgresql.servers { firewallRules { startIpAddress } }\n  azure.mariadb.servers { firewallRules { startIpAddress } } \n  azure.mysql.servers { firewallRules { startIpAddress } } \n  ```\n"
+      audit: "__cnspec run__\n\nTo audit Microsoft Azure with `cnspec run`:\n\n1. Run `az login` to authenticate with the correct Azure subscription and tenant.\n2. Run the following query:\n\n  ```bash\n  cnspec run azure -c \"azure.sql.servers { firewallRules { startIpAddress } }\"\n  cnspec run azure -c \"azure.postgreSql.servers { firewallRules { startIpAddress } }\"\n  cnspec run azure -c \"azure.mariaDb.servers { firewallRules { startIpAddress } }\"\n  cnspec run azure -c \"azure.mySql.servers { firewallRules { startIpAddress } }\"\n  ```\n\n__cnspec shell__\n\nTo audit Microsoft Azure with `cnspec shell`:\n\n1. Run `az login` to authenticate with the correct Azure subscription and tenant. \n2. Launch `cnspec shell`:\n\n  ```bash\n  cnspec shell azure\n  ```\n\n3. Run the following query:\n\n  ```mql\n  azure.sql.servers { firewallRules { startIpAddress } }\n  azure.postgreSql.servers { firewallRules { startIpAddress } }\n  azure.mariaDb.servers { firewallRules { startIpAddress } } \n  azure.mySql.servers { firewallRules { startIpAddress } } \n  ```\n"
       remediation: "###Terraform\n\n__mySQL__\n\n```hcl\n# Ensure `start_ip_address` is not configured to `0.0.0.0`\n\nresource \"azure_mysql_firewall_rule\" \"example\" {\n  ...\n  start_ip_address    = \"192.168.2.22\"\n  end_ip_address      = \"255.255.255.255\"\n}\n``` \n\n__MariaDB__\n\n```hcl\n# Ensure `start_ip_address` is not configured to `0.0.0.0`\n\nresource \"azure_mariadb_firewall_rule\" \"example\" {\n  ...\n  start_ip_address    = \"192.168.2.22\"\n  end_ip_address      = \"255.255.255.255\"\n}\n``` \n\n__SQL__\n\n```hcl\n# Ensure `start_ip_address` is not configured to `0.0.0.0`\n\nresource \"azure_sql_firewall_rule\" \"example\" {\n  ...\n  start_ip_address    = \"192.168.2.22\"\n  end_ip_address      = \"255.255.255.255\"\n}\n```\n\n__Postgres__\n\n```hcl\n# Ensure `start_ip_address` is not configured to `0.0.0.0`\n\nresource \"azure_postgresql_firewall_rule\" \"example\" {\n  ...\n  start_ip_address    = \"192.168.2.22\"\n  end_ip_address      = \"255.255.255.255\"\n}\n``` \n"
   - uid: mondoo-azure-security-ensure-register-with-ad-is-enabled-on-app-service
     title: Ensure that App Services can authenticate with Active Directory
@@ -667,7 +667,7 @@ queries:
     title: Ensure SSL connection enabled for PostgreSQL Database Server
     impact: 80
     mql: |
-      azure.postgresql.servers.all( properties["sslEnforcement"] == "Enabled" )
+      azure.postgreSql.servers.all( properties["sslEnforcement"] == "Enabled" )
     docs:
       desc: |
         All communications between the clients and the PostgreSQL server should be through SSL/TLS to add a layer of encryption to prevent any man in the middle attacks.
@@ -681,7 +681,7 @@ queries:
         Run the following query:
 
           ```bash
-          cnspec run azure -c "azure.postgresql.servers.all( properties["sslEnforcement"] == "Enabled" )" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
+          cnspec run azure -c "azure.postgreSql.servers.all( properties["sslEnforcement"] == "Enabled" )" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
           ```
 
         __cnspec shell__
@@ -697,7 +697,7 @@ queries:
         2. Run the following query:
 
           ```mql
-          azure.postgresql.servers.all( properties["sslEnforcement"] == "Enabled" )
+          azure.postgreSql.servers.all( properties["sslEnforcement"] == "Enabled" )
           ```
       remediation: "### Microsoft Azure Portal\n\nTo update using the Microsoft Azure portal:\n1. Log in to the Microsoft Azure portal at https://portal.azure.com \n2. Go to Azure Database for `PostgreSQL server`\n3. For each database, click on `Connection security`\n4. In `SSL` settings, click on `ENABLED` to enforce SSL connections\n"
   - uid: mondoo-azure-security-ensure-that-ssl-enabled-latest-version-mariadb


### PR DESCRIPTION
This fixes issues we saw in the resource explorer, where fields couldn't be found. E.g., 'postgresql' worked because of some alias chaining. But these aliases will be removed in some later version.

So, to fix the issues, use the current fields.