### PR TITLE
:broom: fixed/apt: purge instead of remove

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -382,7 +382,7 @@ queries:
         ```
         prelink -ua
 
-        apt-get remove prelink
+        apt-get purge prelink
         ```
   - uid: mondoo-linux-security--window-system-is-not-installed
     title: Ensure X Window System is not installed
@@ -401,7 +401,7 @@ queries:
 
         ### Debian/Ubuntu and derivatives
         ```
-        apt-get remove xserver-xorg
+        apt-get purge xserver-xorg
         ```
   - uid: mondoo-linux-security-avahi-server-is-not-enabled
     title: Ensure Avahi server is stopped and not enabled


### PR DESCRIPTION
Changed Linux policy to use `apt-get purge <package>` instead of `apt-get remove <package>`.
Reason: `cnspec/cnquery` only accepts fully purged package for the state of package(x).installed, e.g.:

```bash
cnspec> package('bettercap').installed
[failed] package.installed
  expected: == true
  actual:   false
```