### PR TITLE
:broom: Linux Services: added `systemctl mask <service>` to remediations

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -418,6 +418,11 @@ queries:
         systemctl stop avahi-daemon
         systemctl disable avahi-daemon
         ```
+
+        Note: Since the `avahi-daemon` service is often interdependent with other services, it might not be enough to disable the service because other services will likely restart the service automatically.
+        To make the service `avahi-daemon` invisible to other services run the following command :
+
+        `systemctl mask avahi-daemon`
   - uid: mondoo-linux-security-cups-is-not-enabled
     title: Ensure CUPS is stopped and not enabled
     impact: 100
@@ -433,6 +438,11 @@ queries:
         systemctl stop cups
         systemctl disable cups
         ```
+
+        Note: Since the `cups` service is often interdependent with other services, it might not be enough to disable the service because other services such as `cups-browsed` will likely restart the service automatically.
+        To make the service `cups` invisible to other services run the following command :
+
+        `systemctl mask cups`
 
         **Impact:**
 


### PR DESCRIPTION
Added a small block to services which are likely to be restarted by interdependant services when disabled. 