### PR TITLE
🧹 allow multiple terraform provider eg. alias

### DIFF
--- a/core/mondoo-terraform-aws-security.mql.yaml
+++ b/core/mondoo-terraform-aws-security.mql.yaml
@@ -15,11 +15,11 @@ policies:
       - title: AWS General
         filters: |
           platform.name == "terraform" || platform.name == "terraform-hcl"
-          terraform.providers.one(nameLabel == "aws")
+          terraform.providers.any(nameLabel == "aws")
         checks:
           - uid: terraform-aws-security-no-static-credentials-in-providers
       - title: Amazon API Gateway
-        filters: "platform.name == \"terraform\" || platform.name == \"terraform-hcl\"\nterraform.providers.one(nameLabel == \"aws\") \n"
+        filters: "platform.name == \"terraform\" || platform.name == \"terraform-hcl\"\nterraform.providers.any(nameLabel == \"aws\") \n"
         checks:
           - uid: terraform-aws-security-api-gw-cache-enabled-and-encrypted
           - uid: terraform-aws-security-api-gw-execution-logging-enabled
@@ -29,7 +29,7 @@ policies:
       - title: Amazon Elastic Compute Cloud (Amazon EC2)
         filters: |
           platform.name == "terraform" || platform.name == "terraform-hcl"
-          terraform.providers.one(nameLabel == "aws")
+          terraform.providers.any(nameLabel == "aws")
         checks:
           - uid: terraform-aws-security-ec2-ebs-encryption-by-default
           - uid: terraform-aws-security-ec2-imdsv2
@@ -37,13 +37,13 @@ policies:
       - title: AWS Identity and Access Management (IAM)
         filters: |
           platform.name == "terraform" || platform.name == "terraform-hcl"
-          terraform.providers.one(nameLabel == "aws")
+          terraform.providers.any(nameLabel == "aws")
         checks:
           - uid: terraform-aws-security-iam-no-wildcards-policies
       - title: Amazon Simple Storage Service (Amazon S3)
         filters: |
           platform.name == "terraform" || platform.name == "terraform-hcl"
-          terraform.providers.one(nameLabel == "aws")
+          terraform.providers.any(nameLabel == "aws")
         checks:
           - uid: terraform-aws-security-s3-bucket-level-public-access-prohibited
           - uid: terraform-aws-security-s3-bucket-logging-enabled
@@ -53,7 +53,7 @@ policies:
       - title: AWS Elastic Kubernetes Service (EKS) Security for Terraform
         filters: |
           platform.name == "terraform" || platform.name == "terraform-hcl"
-          terraform.providers.one(nameLabel == "aws")
+          terraform.providers.any(nameLabel == "aws")
         checks:
           - uid: terraform-aws-security-eks-encrypt-secrets
           - uid: terraform-aws-security-eks-no-public-cluster-access-to-cidr

--- a/core/mondoo-terraform-gcp-security.mql.yaml
+++ b/core/mondoo-terraform-gcp-security.mql.yaml
@@ -15,13 +15,13 @@ policies:
       - title: GCP BigQuery
         filters: |
           platform.name == "terraform" || platform.name == "terraform-hcl"
-          terraform.providers.one( nameLabel == "google" )
+          terraform.providers.any( nameLabel == "google" )
         checks:
           - uid: terraform-gcp-security-bigquery-no-public-access
       - title: GCP Identity and Access Management (IAM)
         filters: |
           platform.name == "terraform" || platform.name == "terraform-hcl"
-          terraform.providers.one( nameLabel == "google" )
+          terraform.providers.any( nameLabel == "google" )
         checks:
           - uid: terraform-gcp-security-iam-no-folder-level-default-service-account-assignment
           - uid: terraform-gcp-security-iam-no-folder-level-service-account-impersonation
@@ -29,14 +29,14 @@ policies:
       - title: GCP Cloud Storage
         filters: |
           platform.name == "terraform" || platform.name == "terraform-hcl"
-          terraform.providers.one( nameLabel == "google" )
+          terraform.providers.any( nameLabel == "google" )
         checks:
           - uid: terraform-gcp-security-storage-enable-ubla
           - uid: terraform-gcp-security-storage-no-public-access
       - title: GCP Compute
         filters: |
           platform.name == "terraform" || platform.name == "terraform-hcl"
-          terraform.providers.one( nameLabel == "google" )
+          terraform.providers.any( nameLabel == "google" )
         checks:
           - uid: terraform-gcp-security-compute-disk-encryption-customer-key
           - uid: terraform-gcp-security-compute-disk-encryption-required
@@ -49,14 +49,14 @@ policies:
       - title: GCP DNS
         filters: |
           platform.name == "terraform" || platform.name == "terraform-hcl"
-          terraform.providers.one( nameLabel == "google" )
+          terraform.providers.any( nameLabel == "google" )
         checks:
           - uid: terraform-gcp-security-dns-enable-dnssec
           - uid: terraform-gcp-security-dns-no-rsa-sha1
       - title: GCP Google Kubernetes Engine (GKE)
         filters: |
           platform.name == "terraform" || platform.name == "terraform-hcl"
-          terraform.providers.one( nameLabel == "google" )
+          terraform.providers.any( nameLabel == "google" )
         checks:
           - uid: terraform-gcp-security-gke-enable-auto-repair
           - uid: terraform-gcp-security-gke-enable-auto-upgrade


### PR DESCRIPTION
We used `terraform.providers.one( nameLabel == "google" )` to detect if a provider was loaded. This woks well for cases like:

```
provider "google" {
  project     = "my-project-id"
  region      = "us-central1"
}
```

The query fails for cases where the same provider is imported many times via alias:

```
provider "google" {
  project     = "my-project-id"
  region      = "us-central1"
}

provider "google" {
  alias.        = "dev"
  project     = "my-project-id2"
  region      = "us-central1"
}
```

To allow the policies to run, we need to use the `any` keyword instead:

```coffeescript
terraform.providers.any( nameLabel == "google" )
```