### PR TITLE
Add explicit file checks to macos policy.

### DIFF
--- a/core/mondoo-macos-security.mql.yaml
+++ b/core/mondoo-macos-security.mql.yaml
@@ -194,7 +194,16 @@ queries:
   - uid: mondoo-macos-security-disable-bluetooth-sharing
     title: Disable Bluetooth Sharing
     impact: 50
-    mql: users.where( name != /^_/ && shell != "/usr/bin/false" && name != "root" ).all( parse.plist( home + "/Library/Preferences/ByHost/com.apple.Bluetooth." + os.machineid.upcase + ".plist") { params['PrefKeyServicesEnabled'] !=  true })
+    mql: |
+      users.where( name != /^_/ && shell != "/usr/bin/false" && name != "root" ).list {
+        if (file(home + "/Library/Preferences/ByHost/com.apple.Bluetooth." + os.machineid.upcase + ".plist").exists) {
+          parse.plist( home + "/Library/Preferences/ByHost/com.apple.Bluetooth." + os.machineid.upcase + ".plist") {
+            params['PrefKeyServicesEnabled'] == null || params['PrefKeyServicesEnabled'] == false
+          }
+        } else {
+          true
+        }
+      }
     docs:
       desc: Bluetooth Sharing allows files to be exchanged with Bluetooth-enabled devices.
       remediation: |-
@@ -361,7 +370,14 @@ queries:
   - uid: mondoo-macos-security-ensure-airdrop-is-disabled
     title: Ensure AirDrop Is Disabled
     impact: 50
-    mql: users.where( name != /^_/ && shell != "/usr/bin/false" && name != "root" ).all( parse.plist( home + '/Library/Preferences/com.apple.NetworkBrowser.plist').params['DisableAirDrop'] == true )
+    mql: |
+     users.where( name != /^_/ && shell != "/usr/bin/false" && name != "root" ).list {
+        if (file(home + '/Library/Preferences/com.apple.NetworkBrowser.plist').exists) {
+          parse.plist(home + '/Library/Preferences/com.apple.NetworkBrowser.plist').params['DisableAirDrop'] == true
+        } else {
+          false
+        }
+      }
     docs:
       desc: |-
         AirDrop is Apple's built-in on demand ad hoc file exchange system that is compatible with both macOS and iOS. It uses Bluetooth LE for discovery that limits connectivity to Mac or iOS users that are in close proximity. Depending on the setting it allows everyone or only Contacts to share files when they are nearby to each other.


### PR DESCRIPTION
Add explicit file checks that will prevent `parse.plist` from running on non-existing files.