### PR TITLE
🧹 Remove a trailing slash in a directory check

### DIFF
--- a/core/mondoo-kubernetes-security.mql.yaml
+++ b/core/mondoo-kubernetes-security.mql.yaml
@@ -645,7 +645,7 @@ queries:
           group.name == "root"
         }
       } else {
-        file("/etc/kubernetes/pki/") {
+        file("/etc/kubernetes/pki") {
           user.name == "root"
           group.name == "root"
         }


### PR DESCRIPTION
We should not include the trailing slash here.