### PR TITLE
⭐️ add vulnerability policy for macOS

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -154,6 +154,7 @@ Signin
 sntrup
 socketfilter
 socketfilterfw
+softwareupdate
 srv
 ssldir
 sudolog

--- a/core/mondoo-macos-vulnerability.mql.yaml
+++ b/core/mondoo-macos-vulnerability.mql.yaml
@@ -1,0 +1,90 @@
+policies:
+  - uid: mondoo-macos-vulnerability
+    name: macOS Vulnerability Policy
+    version: 1.0.0
+    license: MPL-2.0
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: macos,host
+    authors:
+      - name: Mondoo, Inc
+        email: hello@mondoo.com
+    docs:
+      desc: |
+        ## Overview
+        
+        Mondoo macOS Vulnerability Policy checks for macOS vulnerabilities. It should be used in combination with the macOS Security Policy.
+        
+        ### Run policy
+        
+        To run this policy against a macOS system:
+        
+        ```bash
+        cnspec scan local -f core/mondoo-macos-vulnerability.mql.yaml
+        ```
+        
+        ## Join the community!
+        
+        Our goal is to build policies that are simple to deploy, accurate, and actionable.
+        
+        If you have any suggestions on how to improve this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
+    groups:
+      - title: macOS Vulnerabilities
+        filters: |
+          asset.platform == "macos"
+        checks:
+          - uid: mondoo-macos-vulnerability-CVE-2023-32434
+queries:
+  - uid: mondoo-macos-vulnerability-CVE-2023-32434
+    title: Ensure macOS Kernel Code Execution Vulnerability CVE-2023-32434 is not on the system
+    impact: 100
+    mql: |
+      version = asset.version.split('.')
+      if (version[0] == 11) {
+        minor = version[1] + "." + version[2]
+        minor >= 7.8
+      } else if (version[0] == 12) {
+        minor = version[1] + "." + version[2]
+        minor >= 6.7
+      } else if (version[0] == 13) {
+        minor = version[1] + "." + version[2]
+        minor >= 4.1
+      } 
+    docs:
+      desc: |
+        Without the latest update, an app may be able to execute arbitrary code with kernel privileges. This issue may have been actively exploited. The update addresses an integer overflow with improved input validation.
+      audit: |
+        ```bash
+        softwareupdate --list
+        Software Update Tool
+
+        Finding available software
+        Software Update found the following new or updated software:
+        * Label: Safari16.5.1MontereyAuto-16.5.1
+          Title: Safari, Version: 16.5.1, Size: 136580KiB, Recommended: YES, 
+        * Label: macOS Monterey 12.6.7-21G651
+          Title: macOS Monterey 12.6.7, Version: 12.6.7, Size: 2870691K, Recommended: YES, Action: restart, 
+        ```
+      remediation: |
+        Please update your macOS installation. To install all available updates, run:
+
+        ```bash
+        softwareupdate -i -a
+        ```
+
+        You can also install individual updates by using the update label:
+
+        ```bash
+        softwareupdate --install 'macOS Monterey 12.6.7-21G651'
+        ```
+        
+        More information can be found at (https://support.apple.com/en-us/HT201222)[https://support.apple.com/en-us/HT201222].
+    refs:
+      - title: CVE-2023-32434
+        url: https://nvd.nist.gov/vuln/detail/CVE-2023-32434
+      - title: macOS Big Sur 11.7.8
+        url: https://support.apple.com/en-us/HT213809
+      - title: macOS Monterey 12.6.7
+        url: https://support.apple.com/en-us/HT213810
+      - title: macOS Ventura 13.4.1
+        url: https://support.apple.com/en-us/HT213813


### PR DESCRIPTION
add macos detection for CVE-2023-32434

```
cnspec scan local -f core/mondoo-macos-vulnerability.mql.yaml
```

<img width="933" alt="Screenshot 2023-06-23 at 16 33 05" src="https://github.com/mondoohq/cnspec-policies/assets/1178413/a153fd88-f210-40a9-a613-b76b2cfb1662">
