### PR TITLE
Update the Chef Infra Client releases considered EOL

### DIFF
--- a/community/chef-infra-client.mql.yaml
+++ b/community/chef-infra-client.mql.yaml
@@ -181,7 +181,7 @@ queries:
     impact: 70
     mql: |
       command("chef-client -v") {
-        stdout == /^Chef Infra Client: (16|17|18|19|20|21).*/
+        stdout == /^Chef Infra Client: (17|18|19|20|21).*/
       }
     docs:
       desc: Chef Infra Client is released once a year in April and 2 major versions are supported at any time (N-1). Prior releases do not receive security updates and should not be used in production environments. See the [Chef Supported Versions documentation](https://docs.chef.io/versions/) for an up-to-date list of supported Infra Client releases.


### PR DESCRIPTION
There's no EOL and the date can't be relied on anymore so this has to be done by hand based off their supported versions page.