### PR TITLE
🐛 Fix error when scanning GitHub user repo

### DIFF
--- a/core/mondoo-github-security.mql.yaml
+++ b/core/mondoo-github-security.mql.yaml
@@ -350,7 +350,7 @@ queries:
     title: Ensure repository defines a security policy
     impact: 30
     mql: |
-      "github.repository.files.one( name.downcase == \"security.md\")"
+      github.repository.files.one( name.downcase == "security.md")
     docs:
       desc: |
         This check tries to determine that the repository defines a security policy.
@@ -364,7 +364,7 @@ queries:
         3. Run the following query
 
            ```mql
-           github.repository.files.where( name == /SECURITY.md/ )
+           github.repository.files.one( name.downcase == "security.md")
            ```
       remediation: |
         See [Adding a security policy to your repository](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository#adding-a-security-policy-to-your-repository) on the GitHub documentation site.

--- a/core/mondoo-github-security.mql.yaml
+++ b/core/mondoo-github-security.mql.yaml
@@ -18,6 +18,7 @@ policies:
           - uid: mondoo-github-organization-security-default-permission-level
           - uid: mondoo-github-organization-security-two-factor-auth
           - uid: mondoo-github-organization-security-verified-domain
+          - uid: mondoo-github-organization-security-security-policy
     scoring_system: 2
   - uid: mondoo-github-repository-security
     name: GitHub Repository Security
@@ -116,6 +117,26 @@ queries:
     refs:
       - url: https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization
         title: Setting base permissions for an organization
+  - uid: mondoo-github-organization-security-security-policy
+    title: Ensure repository defines a security policy
+    impact: 30
+    mql: "if ( github.organization.repositories.one(name == \".github\") ) {\n  github.organization.repositories.where( name == \".github\").all( \n    files.one( name.downcase == \"security.md\")\n  ) || github.repository.files.one( name.downcase == \"security.md\")\n} else {\n  github.repository.files.one( name.downcase == \"security.md\")\n}\n"
+    docs:
+      desc: "This check tries to determine that the repository defines a security policy. \n\nIt is recommended projects provide instructions for reporting a security vulnerability in your project by adding a security policy to your repository.\n"
+      audit: |
+        __cnspec shell__
+
+        1. Open a Terminal.
+        2. Connect cnspec shell to GitHub  `cnspec shell github repo <org/repo_name> --token $GITHUB_TOKEN`
+        3. Run the following query
+
+           ```mql
+           github.repository.files.where( name == /SECURITY.md/ )
+           ```
+      remediation: "See [Adding a security policy to your repository](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository#adding-a-security-policy-to-your-repository) on the GitHub documentation site. \n"
+    refs:
+      - url: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository
+        title: GitHub Docs - Adding a security policy to your repository
   - uid: mondoo-github-repository-security-ensure-default-branch-protection
     title: Ensure GitHub repository default branch is protected
     impact: 90
@@ -329,13 +350,7 @@ queries:
     title: Ensure repository defines a security policy
     impact: 30
     mql: |
-      if ( github.organization.repositories.one(name == ".github") ) {
-        github.organization.repositories.where( name == ".github").all(
-          files.one( name.downcase == "security.md")
-        ) || github.repository.files.one( name.downcase == "security.md")
-      } else {
-        github.repository.files.one( name.downcase == "security.md")
-      }
+      "github.repository.files.one( name.downcase == \"security.md\")"
     docs:
       desc: |
         This check tries to determine that the repository defines a security policy.

--- a/core/mondoo-github-security.mql.yaml
+++ b/core/mondoo-github-security.mql.yaml
@@ -120,9 +120,19 @@ queries:
   - uid: mondoo-github-organization-security-security-policy
     title: Ensure repository defines a security policy
     impact: 30
-    mql: "if ( github.organization.repositories.one(name == \".github\") ) {\n  github.organization.repositories.where( name == \".github\").all( \n    files.one( name.downcase == \"security.md\")\n  ) || github.repository.files.one( name.downcase == \"security.md\")\n} else {\n  github.repository.files.one( name.downcase == \"security.md\")\n}\n"
+    mql: |
+      if ( github.organization.repositories.one(name == ".github") ) {
+        github.organization.repositories.where( name == ".github").all(
+          files.one( name.downcase == "security.md")
+        ) || github.repository.files.one( name.downcase == "security.md")
+      } else {
+        github.repository.files.one( name.downcase == "security.md")
+      }
     docs:
-      desc: "This check tries to determine that the repository defines a security policy. \n\nIt is recommended projects provide instructions for reporting a security vulnerability in your project by adding a security policy to your repository.\n"
+      desc: |
+        This check tries to determine that the repository defines a security policy.
+
+        It is recommended projects provide instructions for reporting a security vulnerability in your project by adding a security policy to your repository.
       audit: |
         __cnspec shell__
 
@@ -133,7 +143,8 @@ queries:
            ```mql
            github.repository.files.where( name == /SECURITY.md/ )
            ```
-      remediation: "See [Adding a security policy to your repository](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository#adding-a-security-policy-to-your-repository) on the GitHub documentation site. \n"
+      remediation: |
+        See [Adding a security policy to your repository](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository#adding-a-security-policy-to-your-repository) on the GitHub documentation site.
     refs:
       - url: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository
         title: GitHub Docs - Adding a security policy to your repository


### PR DESCRIPTION
Before, scanning a user repo with this policy resulted in two errors:

```
! resolver.db> failed to store data, types don't match asset=//policy.api.mondoo.com/assets/*** checksum=*** data={"type":"\u001bgithub.organization"} expected=block received=github.organization
x failed to send datapoints error="1 error occurred:\n\t* failed to store data for \"***\", types don't match: expected block, got github.organization\n\n"
```

and

```
cannot convert primitive with NO type information
```

related to https://github.com/mondoohq/cnquery/issues/957