### PR TITLE
🧹 improve gitlab mql queries

### DIFF
--- a/core/mondoo-gitlab-security.mql.yaml
+++ b/core/mondoo-gitlab-security.mql.yaml
@@ -74,7 +74,7 @@ queries:
         GitLab offers several options to configure 2FA for your users. To enable MFA in your GitLab, see [Enforce two-factor authentication](https://docs.gitlab.com/ee/security/two_factor_authentication.html) on the GitLab documentation site.
   - uid: mondoo-gitlab-security-private-projects
     title: Ensure all projects are private
-    mql: gitlab.group.projects { visibility != "public" }
+    mql: gitlab.group.projects.none( visibility == "public")
     docs:
       desc: |
         GitLab allows users with the Owner role to set a project's visibility as:
@@ -100,7 +100,7 @@ queries:
         To make the visibility of a GitLab project private, see [Change project visibility](https://docs.gitlab.com/ee/user/public_access.html#change-project-visibility).
   - uid: mondoo-gitlab-security-private-project
     title: Ensure the project is private
-    mql: gitlab.project { visibility != "public" }
+    mql: gitlab.project.visibility != "public"
     docs:
       desc: |
         GitLab allows users with the Owner role to set a project's visibility as:


### PR DESCRIPTION
uses .none instead of block queries