### PR TITLE
🐛 Fix check for dashboard in k8s.deployment

### DIFF
--- a/core/mondoo-kubernetes-security.mql.yaml
+++ b/core/mondoo-kubernetes-security.mql.yaml
@@ -7035,8 +7035,8 @@ queries:
     impact: 40
     mql: |
       k8s.deployment.podSpec["containers"].none( _["image"].contains("kubernetes-dashboard") || _["image"].contains("kubernetesui") )
-      k8s.deployment.labels["app"] == null || k8s.pod.labels["app"] != "kubernetes-dashboard"
-      k8s.deployment.labels["k8s-app"] == null || k8s.pod.labels["k8s-app"] != "kubernetes-dashboard"
+      k8s.deployment.labels["app"] == null || k8s.deployment.labels["app"] != "kubernetes-dashboard"
+      k8s.deployment.labels["k8s-app"] == null || k8s.deployment.labels["k8s-app"] != "kubernetes-dashboard"
     docs:
       desc: |
         The Kubernetes dashboard allows browsing through cluster resources such as workloads, configmaps and secrets. In 2019 Tesla was hacked because their Kubernetes dashboard was publicly exposed. This allowed the attackers to extract credentials and deploy Bitcoin miners on the cluster.


### PR DESCRIPTION
Do not try to check k8s.pod for k8s.deployment.

Fixes the underlying issue for https://github.com/mondoohq/cnspec/issues/817