### PR TITLE
Support wildcard certs in the TLS policy

### DIFF
--- a/core/mondoo-kubernetes-security.mql.yaml
+++ b/core/mondoo-kubernetes-security.mql.yaml
@@ -2149,7 +2149,7 @@ queries:
     impact: 100
     mql: |
       k8s.deployment.containers.all( securityContext['privileged'] != true )
-      k8s.deployment.initContainers.all( securityContext['privileged'] != true )     
+      k8s.deployment.initContainers.all( securityContext['privileged'] != true )
     docs:
       desc: |
         Running a privileged container means that the container has the host's capabilities including access to all devices and the host's network.
@@ -2478,7 +2478,7 @@ queries:
     impact: 80
     mql: |
       k8s.deployment.containers.all( securityContext['readOnlyRootFilesystem'] == true )
-      k8s.deployment.initContainers.all( securityContext['readOnlyRootFilesystem'] == true )   
+      k8s.deployment.initContainers.all( securityContext['readOnlyRootFilesystem'] == true )
     docs:
       desc: |
         Running a container with an immutable (read-only) file system prevents the modification of running containers.
@@ -2887,7 +2887,7 @@ queries:
     impact: 100
     mql: |
       k8s.deployment.containers.all( securityContext['runAsNonRoot'] == true )
-      k8s.deployment.initContainers.all( securityContext['runAsNonRoot'] == true )   
+      k8s.deployment.initContainers.all( securityContext['runAsNonRoot'] == true )
     docs:
       desc: |
         Set the `runAsNonRoot: true` `securityContext` to ensure containers do not run as the root user.
@@ -5878,7 +5878,7 @@ queries:
   - uid: mondoo-kubernetes-security-deployment-ports-hostport
     title: Deployments should not bind to a host port
     impact: 80
-    mql: | 
+    mql: |
       k8s.deployment.podSpec['containers'].all( _['ports'] == null || _['ports'].none( _['hostPort']))
     docs:
       desc: |
@@ -6239,7 +6239,7 @@ queries:
   - uid: mondoo-kubernetes-security-deployment-hostpath-readonly
     title: Deployments should mount any host path volumes as read-only
     impact: 80
-    mql: | 
+    mql: |
       k8s.deployment.podSpec {
         hostPathVolumes = _['volumes'].where(_['hostPath'] != null).map(_['name'])
         _['containers'] {

--- a/core/mondoo-tls-security.mql.yaml
+++ b/core/mondoo-tls-security.mql.yaml
@@ -72,7 +72,11 @@ queries:
   - uid: mondoo-tls-security-cert-domain-name-match
     title: The certificate's domain name must match
     mql: |
-      tls.certificates.first.subject.commonName == asset.fqdn
+      if(tls.certificates.first.subject.commonName.contains(/^\*/)) {
+        asset.fqdn.contains(tls.certificates.first.subject.commonName.split("*.")[1])
+      } else {
+        tls.certificates.first.subject.commonName == asset.fqdn
+      }
   - uid: mondoo-tls-security-cert-is-valid
     title: The certificate is valid
     mql: |


### PR DESCRIPTION
These are common and we can still validate the names