### PR TITLE
🚤 faster super admin user check

### DIFF
--- a/core/mondoo-okta-security.mql.yaml
+++ b/core/mondoo-okta-security.mql.yaml
@@ -180,7 +180,7 @@ queries:
     title: Limit the number of super admins
     impact: 100
     filters: asset.platform == "okta-org"
-    mql: okta.users.where( roles.map(type).contains("SUPER_ADMIN") ).length < props.maxOktaSuperAdmins
+    mql: okta.groups.where(roles.one(type =="SUPER_ADMIN")).all(members.length < props.maxOktaSuperAdmins )
     docs:
       remediation:
         - id: console


### PR DESCRIPTION
The previous check iterated over all users. This was slow. With the new okta resources we can validate group role memberships a much simpler query.