### PR TITLE
:broom: Remove Key Exchange Algorithm: `diffie-hellman-group-exchange-sha256`

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -4,7 +4,7 @@
 policies:
   - uid: mondoo-linux-security
     name: Linux Security
-    version: 2.1.0
+    version: 2.2.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2413,9 +2413,9 @@ queries:
             return ["curve25519-sha256@libssh.org","diffie-hellman-group18-sha512"]
           }
           if( package('openssh-server').version == /8\.[0|1|2|3|4|5]/ ) {
-            return ["sntrup4591761x25519-sha512@tinyssh.org","curve25519-sha256@libssh.org","diffie-hellman-group18-sha512","curve448-sha512"]
+            return ["sntrup4591761x25519-sha512@tinyssh.org","curve25519-sha256@libssh.org","diffie-hellman-group18-sha512"]
           }
-          return ["sntrup761x25519-sha512@openssh.com","curve25519-sha256@libssh.org","diffie-hellman-group18-sha512","curve448-sha512"]
+          return ["sntrup761x25519-sha512@openssh.com","curve25519-sha256@libssh.org","diffie-hellman-group18-sha512"]
     mql: |
       sshd.config.kexs != null
       sshd.config.kexs.containsOnly(props.MondooKexAlgos)
@@ -2433,13 +2433,13 @@ queries:
         openssh-server version 8.0 to 8.5:
 
         ```
-        KexAlgorithms sntrup4591761x25519-sha512@tinyssh.org,curve25519-sha256@libssh.org,diffie-hellman-group18-sha512,curve448-sha512
+        KexAlgorithms sntrup4591761x25519-sha512@tinyssh.org,curve25519-sha256@libssh.org,diffie-hellman-group18-sha512
         ```
 
         openssh-server version 8.6 to 9:
 
         ```
-        KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group18-sha512,curve448-sha512
+        KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group18-sha512
         ```
 
         NOTE:

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2410,12 +2410,12 @@ queries:
         title: Define the hardened key exchange algorithms for all SSH configurations
         mql: |
           if( package('openssh-server').version == /6./ || package('openssh-server').version == /7./ ) {
-            return ["curve25519-sha256@libssh.org"]
+            return ["curve25519-sha256@libssh.org","diffie-hellman-group18-sha512"]
           }
           if( package('openssh-server').version == /8\.[0|1|2|3|4|5]/ ) {
-            return ["sntrup4591761x25519-sha512@tinyssh.org","curve25519-sha256@libssh.org"]
+            return ["sntrup4591761x25519-sha512@tinyssh.org","curve25519-sha256@libssh.org","diffie-hellman-group18-sha512","curve448-sha512"]
           }
-          return ["sntrup761x25519-sha512@openssh.com","curve25519-sha256@libssh.org"]
+          return ["sntrup761x25519-sha512@openssh.com","curve25519-sha256@libssh.org","diffie-hellman-group18-sha512","curve448-sha512"]
     mql: |
       sshd.config.kexs != null
       sshd.config.kexs.containsOnly(props.MondooKexAlgos)
@@ -2427,19 +2427,19 @@ queries:
         openssh-server version 6.x or 7.x:
 
         ```
-        KexAlgorithms curve25519-sha256@libssh.org
+        KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group18-sha512
         ```
 
         openssh-server version 8.0 to 8.5:
 
         ```
-        KexAlgorithms sntrup4591761x25519-sha512@tinyssh.org,curve25519-sha256@libssh.org
+        KexAlgorithms sntrup4591761x25519-sha512@tinyssh.org,curve25519-sha256@libssh.org,diffie-hellman-group18-sha512,curve448-sha512
         ```
 
         openssh-server version 8.6 to 9:
 
         ```
-        KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org
+        KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group18-sha512,curve448-sha512
         ```
 
         NOTE:

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2410,12 +2410,12 @@ queries:
         title: Define the hardened key exchange algorithms for all SSH configurations
         mql: |
           if( package('openssh-server').version == /6./ || package('openssh-server').version == /7./ ) {
-            return ["curve25519-sha256@libssh.org","diffie-hellman-group-exchange-sha256"]
+            return ["curve25519-sha256@libssh.org"]
           }
           if( package('openssh-server').version == /8\.[0|1|2|3|4|5]/ ) {
-            return ["sntrup4591761x25519-sha512@tinyssh.org","curve25519-sha256@libssh.org","diffie-hellman-group-exchange-sha256"]
+            return ["sntrup4591761x25519-sha512@tinyssh.org","curve25519-sha256@libssh.org"]
           }
-          return ["sntrup761x25519-sha512@openssh.com","curve25519-sha256@libssh.org","diffie-hellman-group-exchange-sha256"]
+          return ["sntrup761x25519-sha512@openssh.com","curve25519-sha256@libssh.org"]
     mql: |
       sshd.config.kexs != null
       sshd.config.kexs.containsOnly(props.MondooKexAlgos)
@@ -2427,19 +2427,19 @@ queries:
         openssh-server version 6.x or 7.x:
 
         ```
-        KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+        KexAlgorithms curve25519-sha256@libssh.org
         ```
 
         openssh-server version 8.0 to 8.5:
 
         ```
-        KexAlgorithms sntrup4591761x25519-sha512@tinyssh.org,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+        KexAlgorithms sntrup4591761x25519-sha512@tinyssh.org,curve25519-sha256@libssh.org
         ```
 
         openssh-server version 8.6 to 9:
 
         ```
-        KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+        KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org
         ```
 
         NOTE:

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2409,7 +2409,10 @@ queries:
       - uid: MondooKexAlgos
         title: Define the hardened key exchange algorithms for all SSH configurations
         mql: |
-          if( package('openssh-server').version == /6./ || package('openssh-server').version == /7./ ) {
+          if( package('openssh-server').version == /6./) {
+            return ["curve25519-sha256@libssh.org"]
+          }
+          if( package('openssh-server').version == /7./) {
             return ["curve25519-sha256@libssh.org","diffie-hellman-group18-sha512"]
           }
           if( package('openssh-server').version == /8\.[0|1|2|3|4|5]/ ) {
@@ -2424,7 +2427,13 @@ queries:
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to add or modify the `KexAlgorithms` parameter so that it contains a comma-separated list of the site approved key exchange algorithms
 
-        openssh-server version 6.x or 7.x:
+        openssh-server version 6.x
+
+        ```
+        KexAlgorithms curve25519-sha256@libssh.org
+        ```
+
+        openssh-server version 7.x:
 
         ```
         KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group18-sha512


### PR DESCRIPTION
Removes the following Key Exchange Algorithm:

- `diffie-hellman-group-exchange-sha256`

Reasoning:
Since [RFC4419](https://www.rfc-editor.org/rfc/inline-errata/rfc4419.html) `diffie-hellman-group-exchange-sha256` negotiates a DH group with at least 2048 bits (= group14) and maximum 8192 bits (= group18), since anything below DH group17 is not advisable, we should remove this KexAlgorithm.

Adds the following Kex Algorithm:
- `diffie-hellman-group18-sha512`

Reasoning:
`diffie-hellman-group18-sha512`  has the following chracteristics:

```
Prime Field Size | Estimated Security Strength | Example MODP Group
-- | -- | --
8192-bit | 200 bits | group18
```




