### PR TITLE
🐛 use && for kubernetes asset filters where one is linux check

### DIFF
--- a/core/mondoo-kubernetes-security.mql.yaml
+++ b/core/mondoo-kubernetes-security.mql.yaml
@@ -56,8 +56,7 @@ policies:
     groups:
       - title: Kubernetes API Server
         filters: |
-          asset.family.contains(_ == 'linux')
-          processes.where( executable == /kube-apiserver/ ).list != []
+          asset.family.contains(_ == 'linux') && processes.where( executable == /kube-apiserver/ ).list != []
         checks:
           - uid: mondoo-kubernetes-security-api-server-no-anonymous-auth
           - uid: mondoo-kubernetes-security-https-api-server
@@ -69,8 +68,7 @@ policies:
           - uid: mondoo-kubernetes-security-secure-scheduler_conf
       - title: Kubernetes kubelet
         filters: |
-          asset.family.contains(_ == 'linux')
-          processes.where( executable == /kubelet/ ).list != []
+          asset.family.contains(_ == 'linux') && processes.where( executable == /kubelet/ ).list != []
         checks:
           - uid: mondoo-kubernetes-security-kubelet-anonymous-authentication
           - uid: mondoo-kubernetes-security-kubelet-authorization-mode


### PR DESCRIPTION
without this we saw this policy executing on non-k8s related linux assets. they would fail to compile to queries

https://github.com/mondoohq/cnspec/issues/927