### PR TITLE
Policy naming + description cleanup

### DIFF
--- a/core/mondoo-dns-security.mql.yaml
+++ b/core/mondoo-dns-security.mql.yaml
@@ -16,7 +16,7 @@ policies:
       desc: |
         ## Overview
 
-        The DNS Security by Mondoo provides baseline checks for assessing the configuration of DNS servers.
+        The DNS Security policy by Mondoo includes checks for assessing the configuration of DNS records.
 
         ## Remote scan
 

--- a/core/mondoo-tls-security.mql.yaml
+++ b/core/mondoo-tls-security.mql.yaml
@@ -3,7 +3,7 @@
 
 policies:
   - uid: mondoo-tls-security
-    name: TLS/SSL Security Baseline
+    name: TLS/SSL Security
     version: 1.3.0
     license: BUSL-1.1
     tags:
@@ -18,7 +18,7 @@ policies:
 
         The Transport Layer Security (TLS) protocol is the primary means of protecting network communications.
 
-        The TLS/SSL Security Baseline by Mondoo includes checks for ensuring the security and configuration of TLS/SSL connections and certificates.
+        The TLS/SSL Security by Mondoo includes checks for ensuring the security and configuration of TLS/SSL connections and certificates.
 
         ## Remote scan
 


### PR DESCRIPTION
- Remove the word baseline from the TLS policy since we're not using this elsewhere anymore
- Cleanup dns policy description