### PR TITLE
:broom: Restore v8 compatibility for `core/mondoo-linux-security.mql.yaml`

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -4,7 +4,7 @@
 policies:
   - uid: mondoo-linux-security
     name: Linux Security
-    version: 3.0.0
+    version: 2.3.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -59,8 +59,6 @@ policies:
         ```
 
         ### Prerequisites
-
-        This policy depends on `cnspec` v9+.  See [documentation](https://mondoo.com/docs/cnspec/) for more information.
 
         Remote scans of Linux hosts requires authentication such as SSH keys.
 
@@ -2525,10 +2523,12 @@ queries:
     title: Ensure SSH access is limited
     impact: 60
     mql: |
-      sshd.config.params["AllowUsers"] != empty ||
-       sshd.config.params["AllowGroups"] != empty ||
-        sshd.config.params["DenyUsers"] != empty ||
-         sshd.config.params["DenyGroups"] != empty
+      sshd.config.params["AllowUsers"] != null || sshd.config.params["AllowGroups"] != null || sshd.config.params["DenyUsers"] != null || sshd.config.params["DenyGroups"] != null
+
+      if (sshd.config.params["AllowUsers"] != null) { sshd.config.params["AllowUsers"] != "" }
+      if (sshd.config.params["AllowGroups"] != null) { sshd.config.params["AllowGroups"] != "" }
+      if (sshd.config.params["DenyUsers"] != null) { sshd.config.params["DenyUsers"] != "" }
+      if (sshd.config.params["DenyGroups"] != null) { sshd.config.params["DenyGroups"] != "" }
     docs:
       desc: |-
         There are several options available to limit which users and groups can access the system via SSH. It is recommended that at least one of the following options be leveraged: `AllowUsers`


### PR DESCRIPTION
- Restores `core/mondoo-linux-security.mql.yaml` to be v8 compatible 
- `Ensure SSH access is limited` rolled back to old syntax
- Restore Versioning to v2.3.0