### PR TITLE
Simplify + fix the asset filters

### DIFF
--- a/community/chef-infra-client.mql.yaml
+++ b/community/chef-infra-client.mql.yaml
@@ -20,7 +20,7 @@ policies:
     groups:
       - title: Insecure permissions
         filters: |
-          asset.family.contains(_ == 'unix')
+          asset.family.contains('unix')
           file("/opt/chef").exists
         checks:
           - uid: client-pem-permissions
@@ -30,7 +30,7 @@ policies:
           - uid: var-log-chef-directory-permissions
       - title: Insecure configurations
         filters: |
-          asset.family.contains(_ == 'unix')
+          asset.family.contains('unix')
           file("/opt/chef").exists
         checks:
           - uid: avoid-reporting-tokens-in-config
@@ -38,7 +38,7 @@ policies:
           - uid: validation-pem-not-present
       - title: EOL software
         filters: |
-          asset.family.contains(_ == 'unix')
+          asset.family.contains('unix')
           file("/opt/chef").exists
         checks:
           - uid: non-eol-infra-client

--- a/community/chef-infra-server.mql.yaml
+++ b/community/chef-infra-server.mql.yaml
@@ -23,7 +23,7 @@ policies:
     groups:
       - title: EOL components
         filters: |
-          asset.family.contains(_ == 'linux')
+          asset.family.contains('linux')
           file("/opt/opscode").exists
         checks:
           - uid: eol-analytics-addon
@@ -33,14 +33,14 @@ policies:
           - uid: non-eol-infra-server
       - title: Insecure configurations
         filters: |
-          asset.family.contains(_ == 'linux')
+          asset.family.contains('linux')
           file("/opt/opscode").exists
         checks:
           - uid: disable-insecure-addon-compat
           - uid: secure-tls-only
       - title: Insecure permissions
         filters: |
-          asset.family.contains(_ == 'linux')
+          asset.family.contains('linux')
           file("/opt/opscode").exists
         checks:
           - uid: chef-server-rb-permissions

--- a/community/email-security-spf.mql.yaml
+++ b/community/email-security-spf.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: dns
+      mondoo.com/platform: host
     authors:
       - name: Ben Rockwood
         email: ben@mondoo.com

--- a/community/mondoo-linux-operational-policy.mql.yaml
+++ b/community/mondoo-linux-operational-policy.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: best-practices
-      mondoo.com/platform: linux,host
+      mondoo.com/platform: linux
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com

--- a/community/mondoo-linux-snmp-policy.mql.yaml
+++ b/community/mondoo-linux-snmp-policy.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: best-practices
-      mondoo.com/platform: linux,host
+      mondoo.com/platform: linux
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com
@@ -57,7 +57,6 @@ policies:
       - title: SNMP Server Configuration
         filters: |
           asset.family.contains("linux")
-
           packages.contains(name == /snmpd/)
         checks:
           - uid: linux-snmp-v3-user-file-protected

--- a/core/mondoo-azure-security.mql.yaml
+++ b/core/mondoo-azure-security.mql.yaml
@@ -55,7 +55,6 @@ policies:
       - title: Azure Core
         filters: |
           asset.platform == "azure"
-          asset.kind == "api"
         checks:
           - uid: mondoo-azure-security-default-network-access-rule-storage-accounts-deny
           - uid: mondoo-azure-security-diagnostic-settings-essential-categories

--- a/core/mondoo-dns-security.mql.yaml
+++ b/core/mondoo-dns-security.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: dns
+      mondoo.com/platform: host
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com

--- a/core/mondoo-github-best-practices.mql.yaml
+++ b/core/mondoo-github-best-practices.mql.yaml
@@ -6,6 +6,9 @@ policies:
     name: GitHub Repository Best Practices
     version: 1.1.0
     license: BUSL-1.1
+    tags:
+      mondoo.com/category: best-practices
+      mondoo.com/platform: github
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com

--- a/core/mondoo-github-security.mql.yaml
+++ b/core/mondoo-github-security.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: github,saas
+      mondoo.com/platform: github
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com

--- a/core/mondoo-gitlab-security.mql.yaml
+++ b/core/mondoo-gitlab-security.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: gitlab,saas
+      mondoo.com/platform: gitlab
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com

--- a/core/mondoo-http-security.mql.yaml
+++ b/core/mondoo-http-security.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: network
+      mondoo.com/platform: host
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com
@@ -41,7 +41,7 @@ policies:
         If you have any suggestions for how to improve this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     groups:
       - title: Secure HTTP headers
-        filters: asset.platform == "host"
+        filters: asset.platform == 'host'
         checks:
           - uid: mondoo-http-security-x-content-type-options-nosniff
     scoring_system: 2

--- a/core/mondoo-kubernetes-security.mql.yaml
+++ b/core/mondoo-kubernetes-security.mql.yaml
@@ -56,7 +56,7 @@ policies:
     groups:
       - title: Kubernetes API Server
         filters: |
-          asset.family.contains(_ == 'linux')
+          asset.family.contains('linux')
           processes.where( executable == /kube-apiserver/ ).list != []
         checks:
           - uid: mondoo-kubernetes-security-api-server-no-anonymous-auth
@@ -69,7 +69,7 @@ policies:
           - uid: mondoo-kubernetes-security-secure-scheduler_conf
       - title: Kubernetes kubelet
         filters: |
-          asset.family.contains(_ == 'linux')
+          asset.family.contains('linux')
           processes.where( executable == /kubelet/ ).list != []
         checks:
           - uid: mondoo-kubernetes-security-kubelet-anonymous-authentication

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: linux,host
+      mondoo.com/platform: linux
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com

--- a/core/mondoo-linux-workstation-security.mql.yaml
+++ b/core/mondoo-linux-workstation-security.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: linux,host
+      mondoo.com/platform: linux
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com
@@ -64,7 +64,7 @@ policies:
     groups:
       - title: Secure Boot
         filters: |
-          asset.family.contains(_ == 'linux')
+          asset.family.contains('linux')
           packages.where(name == /xorg|xserver|wayland/i).any(installed)
         checks:
           - uid: mondoo-linux-workstation-security-permissions-on-bootloader-config-are-configured
@@ -74,7 +74,7 @@ policies:
           - uid: mondoo-linux-workstation-security-secure-boot-is-enabled-metadata
       - title: Disk encryption
         filters: |
-          asset.family.contains(_ == 'linux')
+          asset.family.contains('linux')
           packages.where(name == /xorg|xserver|wayland/i).any(installed)
         checks:
           - uid: mondoo-linux-workstation-security-aes-encryption-algorithm
@@ -84,7 +84,7 @@ policies:
           - uid: mondoo-linux-workstation-security-disk-encryption-metadata
       - title: BIOS Firmware up-to-date
         filters: |
-          asset.family.contains(_ == 'linux')
+          asset.family.contains('linux')
           package('fwupd').installed
           packages.where(name == /xorg|xserver|wayland/i).any(installed)
         checks:

--- a/core/mondoo-macos-security.mql.yaml
+++ b/core/mondoo-macos-security.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: macos,host
+      mondoo.com/platform: macos
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com
@@ -57,7 +57,6 @@ policies:
       - title: Core
         filters: |
           asset.platform == "macos"
-          asset.version >= "10"
         checks:
           - uid: mondoo-macos-security-disable-bluetooth-sharing
           - uid: mondoo-macos-security-disable-bonjour-advertising-service
@@ -84,7 +83,6 @@ policies:
       - title: Account Security
         filters: |
           asset.platform == "macos"
-          asset.version >= "10"
         checks:
           - uid: mondoo-macos-security-do-not-enable-the-root-account
           - uid: mondoo-macos-security-password-age
@@ -94,7 +92,6 @@ policies:
       - title: Logging
         filters: |
           asset.platform == "macos"
-          asset.version >= "10"
         checks:
           - uid: mondoo-macos-security-control-access-to-audit-records
           - uid: mondoo-macos-security-enable-security-auditing

--- a/core/mondoo-macos-vulnerability.mql.yaml
+++ b/core/mondoo-macos-vulnerability.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: macos,host
+      mondoo.com/platform: macos
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com

--- a/core/mondoo-microsoft-vulnerability.mql.yaml
+++ b/core/mondoo-microsoft-vulnerability.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: windows,host
+      mondoo.com/platform: windows
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com

--- a/core/mondoo-ms365-security.mql.yaml
+++ b/core/mondoo-ms365-security.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: microsoft365,cloud
+      mondoo.com/platform: microsoft365,saas
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com
@@ -96,7 +96,6 @@ policies:
       - title: Microsoft365
         filters: |
           asset.platform == "microsoft365"
-          asset.kind == "api"
         checks:
           - uid: mondoo-m365-security-enable-azure-ad-identity-protection-sign-in-risk-policies
           - uid: mondoo-m365-security-enable-azure-ad-identity-protection-user-risk-policies

--- a/core/mondoo-openssl-vulnerability.mql.yaml
+++ b/core/mondoo-openssl-vulnerability.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: linux,unix,host
+      mondoo.com/platform: linux,unix
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com

--- a/core/mondoo-tls-security.mql.yaml
+++ b/core/mondoo-tls-security.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: host,network
+      mondoo.com/platform: host
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com
@@ -18,7 +18,7 @@ policies:
 
         The Transport Layer Security (TLS) protocol is the primary means of protecting network communications.
 
-        The TLS/SSL Security by Mondoo includes checks for ensuring the security and configuration of TLS/SSL connections and certificates.
+        The TLS/SSL Security policy by Mondoo includes checks for ensuring the security and configuration of TLS/SSL connections and certificates.
 
         ## Remote scan
 
@@ -43,7 +43,7 @@ policies:
         If you have any suggestions for how to improve this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     groups:
       - title: Secure TLS/SSL connection
-        filters: asset.family.contains('network')
+        filters: asset.platform == 'host'
         checks:
           - uid: mondoo-tls-security-ciphers-include-aead-ciphers
           - uid: mondoo-tls-security-ciphers-include-pfs
@@ -58,7 +58,7 @@ policies:
           - uid: mondoo-tls-security-no-weak-block-ciphers
           - uid: mondoo-tls-security-no-weak-tls-versions
       - title: Valid TLS/SSL certificate
-        filters: asset.family.contains('network')
+        filters: asset.platform == 'host'
         checks:
           - uid: mondoo-tls-security-cert-domain-name-match
           - uid: mondoo-tls-security-cert-is-valid

--- a/core/mondoo-windows-security.mql.yaml
+++ b/core/mondoo-windows-security.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: windows,host
+      mondoo.com/platform: windows
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com
@@ -56,7 +56,7 @@ policies:
     groups:
       - title: Core
         filters: |
-          asset.family.contains(_ == 'windows')
+          asset.family.contains('windows')
         checks:
           - uid: mondoo-windows-security-allow-users-to-connect-remotely-by-using-remote-desktop-services-is-set-to-
           - uid: mondoo-windows-security-always-prompt-for-password-upon-connection-is-set-to-enabled
@@ -137,7 +137,7 @@ policies:
           - uid: mondoo-windows-security-additional-LSA-protection
       - title: Logging
         filters: |
-          asset.family.contains(_ == 'windows')
+          asset.family.contains('windows')
         checks:
           - uid: mondoo-windows-security-application-control-event-log-behavior-when-the-log-file-reaches-its-maximum
           - uid: mondoo-windows-security-application-specify-the-maximum-log-file-size-kb-is-set-to-enabled-32768
@@ -149,7 +149,7 @@ policies:
           - uid: mondoo-windows-security-system-specify-the-maximum-log-file-size-kb-is-set-to-enabled-32768
       - title: User Rights
         filters: |
-          asset.family.contains(_ == 'windows')
+          asset.family.contains('windows')
         checks:
           - uid: mondoo-windows-security-2.2.19-l1-ensure-debug-programs-is-empty
 queries:

--- a/core/mondoo-windows-workstation-security.mql.yaml
+++ b/core/mondoo-windows-workstation-security.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: windows,host
+      mondoo.com/platform: windows
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com


### PR DESCRIPTION
- Modernize this a bit to make it easier to read
- Nuke the extra API checks we don't need
- Minor tagging / description updates
- Remove the platform of DNS which is not in cnquery
- Remove the platform host from operating system checks since "host" actually means domain/IP to scan
- Add host to policies that are actually host policies