### PR TITLE
Fix remediation for sshd ClientAliveInterval

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2502,7 +2502,7 @@ queries:
         Edit the `/etc/ssh/sshd_config` file to set the `ClientAliveInterval` and `ClientAliveCountMax` parameters according to site policy:
 
         ```
-        ClientAliveInterval no greater than 300 seconds(15 minutes)
+        ClientAliveInterval 300
         ClientAliveCountMax 0
         ```
   - uid: mondoo-linux-security-ssh-logingracetime-is-set-to-one-minute-or-less


### PR DESCRIPTION
Dear Mondoo team,

thanks for your aweseome work!

At a customer project I've discovered, that your remediation for `ClientAliveInterval` at the sshd configuration isn't valid. The Open SSH server requires an integer, not the given text. This PR fixes the issue.

This is my first Open Source contribution, so please tell me, if I could do something better. Thanks! :)

Looking forward to the merge and have nice holidays.

Kind regards,
Tom