### PR TITLE
🧹 remove slack query that is not useful

### DIFF
--- a/core/mondoo-slack-security.mql.yaml
+++ b/core/mondoo-slack-security.mql.yaml
@@ -4,7 +4,7 @@
 policies:
   - uid: mondoo-slack-security
     name: Slack Team Security
-    version: 1.2.0
+    version: 1.3.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -91,7 +91,6 @@ policies:
           - uid: mondoo-slack-security-name-external-channels
           - uid: mondoo-slack-security-at-least-one-workspace-internal-channel
           - uid: mondoo-slack-security-at-least-one-workspace-internal-channel-no-ext-members
-          - uid: mondoo-slack-domain-whitelisting-enforced-on-internal-channels
 queries:
   - uid: mondoo-slack-security-limit-admin-accounts
     title: Ensure that between 2 and 4 users have admin permissions
@@ -347,44 +346,4 @@ queries:
           ```
       remediation: |
         Create at least one channel which is for internal workspace use only. Make sure that no user who does not belong to your organization is in the channel(s).
-  - uid: mondoo-slack-domain-whitelisting-enforced-on-internal-channels
-    title: Ensure domain whitelisting is enforced on internal channels
-    impact: 75
-    props:
-      - uid: whitelistedDomains
-        title: Enter your whitelisted domains in the mql below
-        mql: |
-          return /mondoo.com|example.com/
-    mql: slack.conversations.where(isExtShared == false ).all( members.all( profile['email'] == props.whitelistedDomains ) )
-    docs:
-      desc: |
-        Ensure there are no users from unwanted domains in your internal channels
-      audit: |
-        Run this command to verify that all users non-externally shared channels adhere to your whitelisted domains:
-
-        __cnspec run__
-
-        To audit Slack with `cnspec run`:
-
-        Run this query:
-
-          ```bash
-          cnspec run slack -c "slack.conversations.where(isExtShared == false ) {name members {name profile['email']}" --token TOKEN
-          ```
-
-        __cnspec shell__
-
-        To audit Slack with `cnspec shell`:
-
-        1. Launch `cnspec shell`:
-
-          ```bash
-          cnspec shell slack ---organization --token TOKEN
-          ```
-
-        2. Run this query:
-
-          ```mql
-          slack.conversations.where(isExtShared == false ) {name members {name profile['email']}
-          ```
-      remediation: Make sure to block or remove any users that don't belong.
+  


### PR DESCRIPTION
After quite some consideration we decided to remove the check for whitelisted domains since it is not adding a lot of security value. We already check for external members and match it with the channel name. The query is also very slow for large slack accounts (caused by slack api rate limiting).