### PR TITLE
:sparkles: Mondoo Email Security- added: Ensure Reverse IP Lookup PTR record is set

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -10,6 +10,7 @@ ANVA
 apigatewayv
 apparmor
 appspot
+arpa
 armv
 asl
 audispd

--- a/core/mondoo-dns-security.mql.yaml
+++ b/core/mondoo-dns-security.mql.yaml
@@ -47,16 +47,7 @@ policies:
           - uid: mondoo-dns-security-no-cname-for-root-domain
           - uid: mondoo-dns-security-no-ip-for-ns-mx-records
           - uid: mondoo-dns-security-no-legacy-office-365-mx-records
-          - uid: mondoo-dns-security-reverse-ip-ptr-record-set
 queries:
-  - uid: mondoo-dns-security-reverse-ip-ptr-record-set
-    title: Ensure Reverse IP Lookup PTR record is set
-    mql: |
-      dns("171.219.85.209.in-addr.arpa").params.PTR.rData.first.contains(asset.fqdn)
-
-
-
-
   - uid: mondoo-dns-security-no-cname-for-root-domain
     title: Ensure no CNAME is used for root domain
     mql: |

--- a/core/mondoo-dns-security.mql.yaml
+++ b/core/mondoo-dns-security.mql.yaml
@@ -47,7 +47,16 @@ policies:
           - uid: mondoo-dns-security-no-cname-for-root-domain
           - uid: mondoo-dns-security-no-ip-for-ns-mx-records
           - uid: mondoo-dns-security-no-legacy-office-365-mx-records
+          - uid: mondoo-dns-security-reverse-ip-ptr-record-set
 queries:
+  - uid: mondoo-dns-security-reverse-ip-ptr-record-set
+    title: Ensure Reverse IP Lookup PTR record is set
+    mql: |
+      dns("171.219.85.209.in-addr.arpa").params.PTR.rData.first.contains(asset.fqdn)
+
+
+
+
   - uid: mondoo-dns-security-no-cname-for-root-domain
     title: Ensure no CNAME is used for root domain
     mql: |

--- a/core/mondoo-email-security.mql.yaml
+++ b/core/mondoo-email-security.mql.yaml
@@ -58,7 +58,7 @@ queries:
           +  dns.params.A.rData.first.split(".")[1] + "."
           +  dns.params.A.rData.first.split(".")[0]
           + ".in-addr.arpa"
-      dns(reverseDNSDomain).params.PTR.rData.first.contains(asset.fqdn)
+      dns(reverseDNSDomain).params.PTR.rData.any(_.contains(asset.fqdn))
     docs:
       desc: |
         Reverse DNS queries for IPv4 addresses use the special domain in-addr.arpa. In this domain, the IPv4 address is represented as a concatenated sequence of four decimal numbers separated by periods, to which is added the second-level domain suffix .in-addr.arpa. The four decimal numbers are obtained by splitting the 32-bit IPv4 address into four octets and converting each octet to a decimal number. These decimal numbers are then arranged in the following order: the smallest octet is first (leftmost) and the most significant octet is last (rightmost). It is important to note that this is the reverse order of the usual convention for writing IPv4 addresses in text form.

--- a/core/mondoo-email-security.mql.yaml
+++ b/core/mondoo-email-security.mql.yaml
@@ -47,7 +47,14 @@ policies:
           - uid: mondoo-email-security-spf-fail
           - uid: mondoo-email-security-spf-dns-record
           - uid: mondoo-email-security-dkim
+          - uid: mondoo-email-security-reverse-ip-ptr-record-set
 queries:
+  - uid: mondoo-email-security-reverse-ip-ptr-record-set
+    title: Ensure Reverse IP Lookup PTR record is set
+    mql: |
+      dns("171.219.85.209.in-addr.arpa").params.PTR.rData.first.contains(asset.fqdn)
+
+
   - uid: mondoo-email-security-txt-record
     title: Domain Apex should have a TXT record
     mql: dns.records.where(type == "TXT") != empty

--- a/core/mondoo-email-security.mql.yaml
+++ b/core/mondoo-email-security.mql.yaml
@@ -61,11 +61,12 @@ queries:
       dns(reverseDNSDomain).params.PTR.rData.first.contains(asset.fqdn)
     docs:
       desc: |
-        Reverse DNS lookups for IPv4 addresses use the special domain in-addr.arpa. In this domain, an IPv4 address is represented as a concatenated sequence of four decimal numbers, separated by dots, to which is appended the second level domain suffix .in-addr.arpa. The four decimal numbers are obtained by splitting the 32-bit IPv4 address into four octets and converting each octet into a decimal number. These decimal numbers are then concatenated in the order: least significant octet first (leftmost), to most significant octet last (rightmost). It is important to note that this is the reverse order to the usual dotted-decimal convention for writing IPv4 addresses in textual form.
+        Reverse DNS queries for IPv4 addresses use the special domain in-addr.arpa. In this domain, the IPv4 address is represented as a concatenated sequence of four decimal numbers separated by periods, to which is added the second-level domain suffix .in-addr.arpa. The four decimal numbers are obtained by splitting the 32-bit IPv4 address into four octets and converting each octet to a decimal number. These decimal numbers are then arranged in the following order: the smallest octet is first (leftmost) and the most significant octet is last (rightmost). It is important to note that this is the reverse order of the usual convention for writing IPv4 addresses in text form.
 
-        For example, to do a reverse lookup of the IP address 8.8.4.4 the PTR record for the domain name 4.4.8.8.in-addr.arpa would be looked up, and found to point to dns.google.
+        For example, to query the IP address 8.8.4.4 in reverse order, the PTR record for the domain name 4.4.8.8.in-addr.arpa is queried, which points to dns.google.
 
-        If the A record for dns.google in turn pointed back to 8.8.4.4 then it would be said to be forward-confirmed.
+        If the A record for dns.google in turn points back to 8.8.4.4.4, it will be said to be forward confirmed.
+Translated with DeepL.com (free version)
       audit: Run the `dig -t PTR <special-reverse-domain>` command and verify that the it points to your mail domain.
       remediation: |
         Add a PTR record to the Reverse your DNS zone file.

--- a/core/mondoo-email-security.mql.yaml
+++ b/core/mondoo-email-security.mql.yaml
@@ -67,7 +67,7 @@ queries:
 
         If the A record for dns.google in turn points back to 8.8.4.4, it means that the domain is in a [forward-confirmed reverse DNS](https://en.wikipedia.org/wiki/Forward-confirmed_reverse_DNS) state.
 
-        This creates a form of authentication, which is strong enough to be used for whitelisting purposes of E-Mail servers.
+        This creates a form of authentication, which is strong enough to be used for whitelisting purposes of e-mail servers.
         According to Google's latest guidelines:
 
         "Your sending IP address must have a PTR record. PTR records verify that the sending hostname is associated with the sending IP address.

--- a/core/mondoo-email-security.mql.yaml
+++ b/core/mondoo-email-security.mql.yaml
@@ -72,6 +72,8 @@ queries:
     refs:
       - url: https://en.wikipedia.org/wiki/Reverse_DNS_lookup
         title: Reverse DNS Lookup
+      - url: https://support.google.com/a/answer/81126?hl=en#ip
+        title: Google Email sender guidelines - IP Addresses
 
   - uid: mondoo-email-security-txt-record
     title: Domain Apex should have a TXT record

--- a/core/mondoo-email-security.mql.yaml
+++ b/core/mondoo-email-security.mql.yaml
@@ -50,10 +50,28 @@ policies:
           - uid: mondoo-email-security-reverse-ip-ptr-record-set
 queries:
   - uid: mondoo-email-security-reverse-ip-ptr-record-set
-    title: Ensure Reverse IP Lookup PTR record is set
+    title: Ensure Reverse IP Lookup PTR record is set (DNS Forward confirmed)
     mql: |
-      dns("171.219.85.209.in-addr.arpa").params.PTR.rData.first.contains(asset.fqdn)
+      reverseDNSDomain =
+        dns.params.A.rData.first.split(".")[3] + "."
+          + dns.params.A.rData.first.split(".")[2] + "."
+          +  dns.params.A.rData.first.split(".")[1] + "."
+          +  dns.params.A.rData.first.split(".")[0]
+          + ".in-addr.arpa"
+      dns(reverseDNSDomain).params.PTR.rData.first.contains(asset.fqdn)
+    docs:
+      desc: |
+        Reverse DNS lookups for IPv4 addresses use the special domain in-addr.arpa. In this domain, an IPv4 address is represented as a concatenated sequence of four decimal numbers, separated by dots, to which is appended the second level domain suffix .in-addr.arpa. The four decimal numbers are obtained by splitting the 32-bit IPv4 address into four octets and converting each octet into a decimal number. These decimal numbers are then concatenated in the order: least significant octet first (leftmost), to most significant octet last (rightmost). It is important to note that this is the reverse order to the usual dotted-decimal convention for writing IPv4 addresses in textual form.
 
+        For example, to do a reverse lookup of the IP address 8.8.4.4 the PTR record for the domain name 4.4.8.8.in-addr.arpa would be looked up, and found to point to dns.google.
+
+        If the A record for dns.google in turn pointed back to 8.8.4.4 then it would be said to be forward-confirmed.
+      audit: Run the `dig -t PTR <special-reverse-domain>` command and verify that the it points to your mail domain.
+      remediation: |
+        Add a PTR record to the Reverse your DNS zone file.
+    refs:
+      - url: https://en.wikipedia.org/wiki/Reverse_DNS_lookup
+        title: Reverse DNS Lookup
 
   - uid: mondoo-email-security-txt-record
     title: Domain Apex should have a TXT record

--- a/core/mondoo-email-security.mql.yaml
+++ b/core/mondoo-email-security.mql.yaml
@@ -65,14 +65,21 @@ queries:
 
         For example, to query the IP address 8.8.4.4 in reverse order, the PTR record for the domain name 4.4.8.8.in-addr.arpa is queried, which points to dns.google.
 
-        If the A record for dns.google in turn points back to 8.8.4.4.4, it will be said to be forward confirmed.
-Translated with DeepL.com (free version)
+        If the A record for dns.google in turn points back to 8.8.4.4, it means that the domain is in a [forward-confirmed reverse DNS](https://en.wikipedia.org/wiki/Forward-confirmed_reverse_DNS) state.
+
+        This creates a form of authentication, which is strong enough to be used for whitelisting purposes of E-Mail servers.
+        According to Google's latest guidelines:
+
+        "Your sending IP address must have a PTR record. PTR records verify that the sending hostname is associated with the sending IP address.
+        Every IP address must map to a hostname in the PTR record. The hostname specified in the PTR record must have a forward DNS that refers to the sending IP address."
       audit: Run the `dig -t PTR <special-reverse-domain>` command and verify that the it points to your mail domain.
       remediation: |
-        Add a PTR record to the Reverse your DNS zone file.
+        Set up valid reverse DNS records of your sending server IP addresses that point to your domain.
     refs:
       - url: https://en.wikipedia.org/wiki/Reverse_DNS_lookup
         title: Reverse DNS Lookup
+      - url: https://en.wikipedia.org/wiki/Forward-confirmed_reverse_DNS
+        title: Forward-confirmed reverse DNS
       - url: https://support.google.com/a/answer/81126?hl=en#ip
         title: Google Email sender guidelines - IP Addresses
 


### PR DESCRIPTION
Adds a check to the Email Security Policy:

- Ensure Reverse IP Lookup PTR record is set (DNS Forward confirmed)

