### PR TITLE
:sparkles: Update to `v9/variants:` Google Cloud (GCP) Security 

### DIFF
--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -297,9 +297,9 @@ queries:
   - uid: mondoo-gcp-security-block-project-wide-ssh-keys-enabled-vm-instances
     title: Ensure "Block Project-wide SSH keys" is enabled for VM instances
     impact: 70
-    mql: |
-      gcloud.compute.instances
-        .all( metadata['block-project-ssh-keys'] == true )
+    variants:
+      - uid: gcp-compute-block-project-wide-ssh-keys-enabled-vm-instances-all
+      - uid: gcp-compute-block-project-wide-ssh-keys-enabled-vm-instances-single
     docs:
       desc: |
         Project-wide SSH keys can be used to login into all instances within a project. While using project-wide SSH keys eases SSH key management, if SSH keys are compromised, the potential security risk can impact all instances within a project.
@@ -384,6 +384,16 @@ queries:
           ```bash
           gcloud compute instances add-metadata INSTANCE_NAME --metadata block-projectssh-keys=TRUE
           ```
+  - uid: gcp-compute-block-project-wide-ssh-keys-enabled-vm-instances-all
+    filters: asset.platform == "gcp" || asset.platform == "gcp-project"
+    mql: |
+      gcp.compute.instances.all(
+        metadata['block-project-ssh-keys'] == true
+      )
+  - uid: gcp-compute-block-project-wide-ssh-keys-enabled-vm-instances-single
+    filters: asset.platform == "gcp-compute-instance"
+    mql: |
+      gcp.compute.instance.metadata['block-project-ssh-keys'] == true
   - uid: mondoo-gcp-security-oslogin-enabled-project
     title: Ensure oslogin is enabled for compute instances
     impact: 70
@@ -401,7 +411,7 @@ queries:
          1. Run this query:
 
            ```mql
-           cnquery run gcp project <project-id> -c "gcp.compute.instances.all(metadata['enable-oslogin'].downcase == "true")"
+           cnquery run gcp project <project-id> -c "gcp.compute.instances.all(metadata['enable-oslogin'] == true)"
            ```
 
          __cnquery shell__
@@ -481,12 +491,12 @@ queries:
     filters: asset.platform == "gcp" || asset.platform == "gcp-project"
     mql: |
       gcp.compute.instances.all(
-        metadata['enable-oslogin'].downcase == "true"
+        metadata['enable-oslogin'] == true
       )
   - uid: gcp-compute-oslogin-enabled-project-single
     filters: asset.platform == "gcp-compute-instance"
     mql:
-      gcp.compute.instance.metadata['enable-oslogin'].downcase == "true"
+      gcp.compute.instance.metadata['enable-oslogin'] == true
   - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible
     title: Ensure that Cloud Storage buckets are not anonymously or publicly accessible
     impact: 90

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -493,15 +493,9 @@ queries:
     title: Ensure that Cloud Storage buckets are not anonymously or publicly accessible
     impact: 90
     mql: |
-      gcloud.storage.buckets
-        .all(
-          iamPolicy {
-            members {
-              _ != "allUsers"
-              _ != "allAuthenticatedUsers"
-            }
-          }
-        )
+    variants:
+      - uid: gcp-storage-cloud-storage-bucket-anonymously-publicly-accessible-all
+      - uid: gcp-storage-cloud-storage-bucket-anonymously-publicly-accessible-single
     docs:
       desc: |
         Public access prevention protects Cloud Storage buckets and objects from being accidentally exposed to the public. When you enforce public access prevention, no one can make data in applicable buckets public through IAM policies or ACLs.
@@ -580,6 +574,16 @@ queries:
         ```bash
         gcloud storage buckets update gs://BUCKET_NAME --no-pap
         ```
+  - uid: gcp-storage-cloud-storage-bucket-anonymously-publicly-accessible-all
+    filters: asset.platform == "gcp" || asset.platform == "gcp-project"
+    mql: |
+      gcp.storage.buckets.all(iamPolicy.all(members.none(_ == "allUsers")))
+      gcp.storage.buckets.all(iamPolicy.all(members.none(_ == "allAuthenticatedUsers")))
+  - uid: gcp-storage-cloud-storage-bucket-anonymously-publicly-accessible-single
+    filters: asset.platform == "gcp-storage-bucket"
+    mql: |
+      gcp.storage.bucket.iamPolicy.all(members.none(_ == "allUsers"))
+      gcp.storage.bucket.iamPolicy.all(members.none(_ == "allAuthenticatedUsers"))
   - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled
     title: Ensure that Cloud Storage buckets have uniform bucket-level access enabled
     impact: 60

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -99,7 +99,7 @@ queries:
 
         To audit your Google Cloud Project with `cnquery run`:
 
-         1. Ensure the `gcloud` cli is configured to the GCP project:
+        1. Ensure the `gcloud` cli is configured to the GCP project:
 
            ```bash
            gcloud config set project <project_id>
@@ -115,7 +115,7 @@ queries:
 
         To audit your Google Cloud Project with `cnquery shell`:
 
-         1. Ensure the `gcloud` cli is configured to the GCP project:
+        1. Ensure the `gcloud` cli is configured to the GCP project:
 
            ```bash
            gcloud config set project <project_id>

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -346,7 +346,7 @@ queries:
          2. Run this query:
 
            ```mql
-           cnquery run gcp -c "gcloud.compute.instances { metadata['block-project-ssh-keys'] }"
+           cnquery run gcp -c "gcp.compute.instances {id name metadata['block-project-ssh-keys'] }"
            ```
 
          __cnquery shell__
@@ -368,7 +368,7 @@ queries:
          3. Run this query:
 
            ```mql
-           gcloud.compute.instances { metadata['block-project-ssh-keys'] }
+           gcp.compute.instances {id name metadata['block-project-ssh-keys'] }
            ```
       remediation: |
         ### Terraform
@@ -435,23 +435,35 @@ queries:
 
          To audit your Google Cloud Project with `cnquery run`:
 
-         1. Run this query:
+         1. Ensure the `gcloud` cli is configured to the GCP project:
+
+           ```bash
+           gcloud config set project <project_id>
+           ```
+
+         2. Run this query:
 
            ```mql
-           cnquery run gcp project <project-id> -c "gcp.compute.instances.all(metadata['enable-oslogin'] == true)"
+           cnquery run gcp project <project-id> -c "gcp.compute.instances {id name metadata['enable-oslogin'] == true}"
            ```
 
          __cnquery shell__
 
          To audit your Google Cloud Project with `cnquery shell`:
 
-         1. Launch `cnquery shell`:
+         1. Ensure the `gcloud` cli is configured to the GCP project:
+
+           ```bash
+           gcloud config set project <project_id>
+           ```
+
+         2. Launch `cnquery shell`:
 
            ```bash
            cnquery shell gcp project <project-id>
            ```
 
-         2. Run this query:
+         3. Run this query:
 
            ```mql
            gcp.compute.instances {id name metadata['enable-oslogin'] }
@@ -696,8 +708,8 @@ queries:
     filters: asset.platform == "gcp" || asset.platform == "gcp-project"
     mql: |
       gcp.storage.buckets.all(
-        iamConfiguration.UniformBucketLevelAccess.enabled == true
+        iamConfiguration.UniformBucketLevelAccess.Enabled == true
       )
   - uid: gcp-storage-cloud-storage-buckets-uniform-bucket-level-access-enabled-single
     filters: asset.platform == "gcp-storage-bucket"
-    mql: gcp.storage.bucket.iamConfiguration.UniformBucketLevelAccess.enabled == true
+    mql: gcp.storage.bucket.iamConfiguration.UniformBucketLevelAccess.Enabled == true

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -708,8 +708,8 @@ queries:
     filters: asset.platform == "gcp" || asset.platform == "gcp-project"
     mql: |
       gcp.storage.buckets.all(
-        iamConfiguration.UniformBucketLevelAccess.Enabled == true
+        iamConfiguration.UniformBucketLevelAccess.enabled == true
       )
   - uid: gcp-storage-cloud-storage-buckets-uniform-bucket-level-access-enabled-single
     filters: asset.platform == "gcp-storage-bucket"
-    mql: gcp.storage.bucket.iamConfiguration.UniformBucketLevelAccess.Enabled == true
+    mql: gcp.storage.bucket.iamConfiguration.UniformBucketLevelAccess.enabled == true

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -587,9 +587,9 @@ queries:
   - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled
     title: Ensure that Cloud Storage buckets have uniform bucket-level access enabled
     impact: 60
-    mql: |
-      gcloud.storage.buckets
-        .all( iamConfiguration['UniformBucketLevelAccess']['enabled'] == true )
+    variants:
+      - uid: gcp-storage-cloud-storage-buckets-uniform-bucket-level-access-enabled-all
+      - uid: gcp-storage-cloud-storage-buckets-uniform-bucket-level-access-enabled-single
     docs:
       desc: |
         Cloud Storage offers two systems for granting users permission to access your buckets and objects: IAM and Access Control Lists (ACLs). These systems act in parallel - in order for a user to access a Cloud Storage resource, only one of the systems needs to grant the user permission. IAM is used throughout Google Cloud and allows you to grant a variety of permissions at the bucket and project levels. ACLs are used only by Cloud Storage and have limited permission options, but they allow you to grant permissions on a per-object basis.
@@ -658,3 +658,12 @@ queries:
         ```bash
         gsutil uniformbucketlevelaccess set STATE gs://BUCKET_NAME
         ```
+  - uid: gcp-storage-cloud-storage-buckets-uniform-bucket-level-access-enabled-all
+    filters: asset.platform == "gcp" || asset.platform == "gcp-project"
+    mql: |
+      gcp.storage.buckets.all(
+        iamConfiguration.UniformBucketLevelAccess.enabled == true
+      )
+  - uid: gcp-storage-cloud-storage-buckets-uniform-bucket-level-access-enabled-single
+    filters: asset.platform == "gcp-storage-bucket"
+    mql: gcp.storage.bucket.iamConfiguration.UniformBucketLevelAccess.enabled == true

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -99,26 +99,38 @@ queries:
 
         To audit your Google Cloud Project with `cnquery run`:
 
-        1. Run this query:
+         1. Ensure the `gcloud` cli is configured to the GCP project:
+
+           ```bash
+           gcloud config set project <project_id>
+           ```
+
+        2. Run this query:
 
           ```mql
-          cnquery run gcp project <project-id> -c "gcp.compute.instances.where( name != /^gke/ ) {id name serviceAccounts.where( email == /^.*compute@developer\.gserviceaccount\.com$/ ) }"
+          cnquery run gcp project <project-id> -c "gcp.compute.instances.where( name != /^gke/ ) {id name serviceAccounts.where( email == /^.*compute@developer\.gserviceaccount\.com$/ )}"
           ```
 
         __cnquery shell__
 
         To audit your Google Cloud Project with `cnquery shell`:
 
-        1. Launch `cnquery shell`:
+         1. Ensure the `gcloud` cli is configured to the GCP project:
+
+           ```bash
+           gcloud config set project <project_id>
+           ```
+
+        2. Launch `cnquery shell`:
 
           ```bash
           cnquery run gcp project <project-id>
           ```
 
-        2. Run this query:
+        3. Run this query:
 
           ```mql
-          gcp.compute.instances.where( name != /^gke/ ) { id name serviceAccounts.where( email == /^.*compute@developer\.gserviceaccount\.com$/ ) }
+          gcp.compute.instances.where( name != /^gke/ ) {id name serviceAccounts.where(email == /^.*compute@developer\.gserviceaccount\.com$/ )}
           ```
       remediation: |
         ### Terraform
@@ -208,13 +220,13 @@ queries:
          1. Ensure the `gcloud` cli is configured to the GCP project:
 
            ```bash
-           gcloud project set <project_id>
+           gcloud config set project <project_id>
            ```
 
          2. Run this query:
 
            ```mql
-           cnquery run gcp -c "gcloud.compute.instances.where( name != /^gke/ ) { serviceAccounts.where( email == /^.*compute@developer\.gserviceaccount\.com$/ ) { email scopes } } "
+           cnquery run gcp project <project-id> -c "gcp.compute.instances.where( name != /^gke/ ) {id name serviceAccounts.where( email == /^.*compute@developer\.gserviceaccount\.com$/ ) {email scopes}}"
            ```
 
          __cnquery shell__
@@ -224,7 +236,7 @@ queries:
          1. Ensure the `gcloud` cli is configured to the GCP project:
 
            ```bash
-           gcloud project set <project_id>
+           gcloud config set project <project_id>
            ```
 
          2. Launch `cnquery shell`:
@@ -236,7 +248,7 @@ queries:
          3. Run this query:
 
            ```mql
-           gcloud.compute.instances.where( name != /^gke/ ) { serviceAccounts.where( email == /^.*compute@developer\.gserviceaccount\.com$/ ) { email scopes } }
+           gcp.compute.instances.where(name != /^gke/) {id name serviceAccounts.where(email == /^.*compute@developer\.gserviceaccount\.com$/) {email scopes}}
            ```
       remediation: |
         ### Terraform
@@ -328,7 +340,7 @@ queries:
          1. Ensure the `gcloud` cli is configured to the GCP project:
 
            ```bash
-           gcloud project set <project_id>
+           gcloud config set project <project_id>
            ```
 
          2. Run this query:
@@ -344,7 +356,7 @@ queries:
          1. Ensure the `gcloud` cli is configured to the GCP project:
 
            ```bash
-           gcloud project set <project_id>
+           gcloud config set project <project_id>
            ```
 
          2. Launch `cnquery shell`:
@@ -529,7 +541,7 @@ queries:
          1. Ensure the `gcloud` cli is configured to the GCP project:
 
            ```bash
-           gcloud project set <project_id>
+           gcloud config set project <project_id>
            ```
 
          2. Run this query:
@@ -545,7 +557,7 @@ queries:
          1. Ensure the `gcloud` cli is configured to the GCP project:
 
            ```bash
-           gcloud project set <project_id>
+           gcloud config set project <project_id>
            ```
 
          2. Launch `cnquery shell`:
@@ -625,7 +637,7 @@ queries:
          1. Ensure the `gcloud` cli is configured to the GCP project:
 
            ```bash
-           gcloud project set <project_id>
+           gcloud config set project <project_id>
            ```
 
          2. Run this query:
@@ -641,7 +653,7 @@ queries:
          1. Ensure the `gcloud` cli is configured to the GCP project:
 
            ```bash
-           gcloud project set <project_id>
+           gcloud config set project <project_id>
            ```
 
          2. Launch `cnquery shell`:

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -77,17 +77,16 @@ policies:
 queries:
   - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account
     title: Ensure that instances are not configured to use the default service account
-    impact: 80
-    mql: |
-      gcloud.compute.instances
-        .where( name != /^gke/ )
-        .all( serviceAccounts { email != /^.*compute@developer\.gserviceaccount\.com$/ } )
+    impact: 95
+    variants:
+      - uid: gcp-compute-instances-configured-use-default-service-account-all
+      - uid: gcp-compute-instances-configured-use-default-service-account-single
     docs:
       desc: |
-        New projects that have enabled the Compute Engine API have a Compute Engine default service account, which has the following email:
+        New projects that have enabled the Compute Engine API have a Compute Engine default service account, which contains the following email pattern:
 
         ```bash
-        PROJECT_NUMBER-compute@developer.gserviceaccount.com
+        -compute@developer.gserviceaccount.com
         ```
 
         The Compute Engine default service account is created with the IAM basic Editor role, but you can modify your service account's roles to control the service account's access to Google APIs.
@@ -100,38 +99,26 @@ queries:
 
         To audit your Google Cloud Project with `cnquery run`:
 
-        1. Ensure the `gcloud` cli is configured to the GCP project:
-
-          ```bash
-          gcloud project set <project_id>
-          ```
-
-        2. Run this query:
+        1. Run this query:
 
           ```mql
-          cnquery run gcp -c "gcloud.compute.instances.where( name != /^gke/ ) serviceAccounts.where( email == /^.*compute@developer\.gserviceaccount\.com$/ )"
+          cnquery run gcp project <project-id> -c "gcp.compute.instances.where( name != /^gke/ ) {id name serviceAccounts.where( email == /^.*compute@developer\.gserviceaccount\.com$/ ) }"
           ```
 
         __cnquery shell__
 
         To audit your Google Cloud Project with `cnquery shell`:
 
-        1. Ensure the `gcloud` cli is configured to the GCP project:
+        1. Launch `cnquery shell`:
 
           ```bash
-          gcloud project set <project_id>
+          cnquery run gcp project <project-id>
           ```
 
-        2. Launch `cnquery shell`:
-
-          ```bash
-          cnquery shell gcp
-          ```
-
-        3. Run this query:
+        2. Run this query:
 
           ```mql
-          gcloud.compute.instances.where( name != /^gke/ ) serviceAccounts.where( email == /^.*compute@developer\.gserviceaccount\.com$/ )
+          gcp.compute.instances.where( name != /^gke/ ) { id name serviceAccounts.where( email == /^.*compute@developer\.gserviceaccount\.com$/ ) }
           ```
       remediation: |
         ### Terraform
@@ -188,6 +175,22 @@ queries:
           ```bash
           gcloud compute instances start INSTANCE_NAME
           ```
+  - uid: gcp-compute-instances-configured-use-default-service-account-all
+    filters: asset.platform == "gcp" || asset.platform == "gcp-project"
+    mql: |
+      gcp.compute.instances.where(name != /^gke-/).all(
+        serviceAccounts.none(
+          email == /^.*compute@developer\.gserviceaccount\.com$/
+        )
+      )
+  - uid: gcp-compute-instances-configured-use-default-service-account-single
+    filters: |
+      asset.platform == "gcp-compute-instance"
+      gcp.compute.instance.name != /^gke-/
+    mql: |
+        gcp.compute.instance.serviceAccounts.none(
+          email == /^.*compute@developer\.gserviceaccount\.com$/
+        )
   - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api
     title: Ensure instances are not configured to use the default service account with full access to all Cloud APIs
     impact: 90

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -387,9 +387,9 @@ queries:
   - uid: mondoo-gcp-security-oslogin-enabled-project
     title: Ensure oslogin is enabled for compute instances
     impact: 70
-    mql: |
-      gcloud.compute.instances
-        .all( metadata['enable-oslogin'] == true )
+    variants:
+      - uid: gcp-compute-oslogin-enabled-project-all
+      - uid: gcp-compute-oslogin-enabled-project-single
     docs:
       desc: |
         OS Login lets you use Compute Engine Identity and Access Management (IAM) roles to grant or revoke SSH access to your Linux instances. OS Login is an alternative to managing instance access by adding and removing SSH keys in metadata.
@@ -398,38 +398,26 @@ queries:
 
          To audit your Google Cloud Project with `cnquery run`:
 
-         1. Ensure the `gcloud` cli is configured to the GCP project:
-
-           ```bash
-           gcloud project set <project_id>
-           ```
-
-         2. Run this query:
+         1. Run this query:
 
            ```mql
-           cnquery run gcp -c "gcloud.compute.instances { metadata['enable-oslogin'] }"
+           cnquery run gcp project <project-id> -c "gcp.compute.instances.all(metadata['enable-oslogin'].downcase == "true")"
            ```
 
          __cnquery shell__
 
          To audit your Google Cloud Project with `cnquery shell`:
 
-         1. Ensure the `gcloud` cli is configured to the GCP project:
+         1. Launch `cnquery shell`:
 
            ```bash
-           gcloud project set <project_id>
+           cnquery shell gcp project <project-id>
            ```
 
-         2. Launch `cnquery shell`:
-
-           ```bash
-           cnquery shell gcp
-           ```
-
-         3. Run this query:
+         2. Run this query:
 
            ```mql
-           gcloud.compute.instances { metadata['enable-oslogin'] }
+           gcp.compute.instances {id name metadata['enable-oslogin'] }
            ```
       remediation: |
         ### Terraform
@@ -489,6 +477,16 @@ queries:
           ```bash
           gcloud compute instances add-metadata INSTANCE_NAME --metadata enable-oslogin=TRUE
           ```
+  - uid: gcp-compute-oslogin-enabled-project-all
+    filters: asset.platform == "gcp" || asset.platform == "gcp-project"
+    mql: |
+      gcp.compute.instances.all(
+        metadata['enable-oslogin'].downcase == "true"
+      )
+  - uid: gcp-compute-oslogin-enabled-project-single
+    filters: asset.platform == "gcp-compute-instance"
+    mql:
+      gcp.compute.instance.metadata['enable-oslogin'].downcase == "true"
   - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible
     title: Ensure that Cloud Storage buckets are not anonymously or publicly accessible
     impact: 90

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -194,10 +194,9 @@ queries:
   - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api
     title: Ensure instances are not configured to use the default service account with full access to all Cloud APIs
     impact: 90
-    mql: |
-      gcloud.compute.instances
-        .where( name != /^gke/ )
-        .all( serviceAccounts { scopes { _ != "https://www.googleapis.com/auth/cloud-platform" } } )
+    variants:
+      - uid: gcp-compute-instances-configured-use-default-service-account-full-access-all-cloud-all
+      - uid: gcp-compute-instances-configured-use-default-service-account-full-access-all-cloud-single
     docs:
       desc: |
         Google compute instances provisioned with full access to all cloud APIs pose a security risk to a GCP environment. Instances should instead be provisioned using a non-default service account, and limited permissions to cloud APIs using the principle of least privilege.
@@ -294,6 +293,22 @@ queries:
           ```bash
           gcloud compute instances start INSTANCE_NAME
           ```
+  - uid: gcp-compute-instances-configured-use-default-service-account-full-access-all-cloud-all
+    filters: asset.platform == "gcp" || asset.platform == "gcp-project"
+    mql: |
+      gcp.compute.instances.where(name != /^gke-/).all(
+        serviceAccounts.none(
+          scopes == "https://www.googleapis.com/auth/cloud-platform"
+        )
+      )
+  - uid: gcp-compute-instances-configured-use-default-service-account-full-access-all-cloud-single
+    filters: |
+      asset.platform == "gcp-compute-instance"
+      gcp.compute.instance.name != /^gke-/
+    mql: |
+      gcp.compute.instance.serviceAccounts.none(
+        scopes == "https://www.googleapis.com/auth/cloud-platform"
+      )
   - uid: mondoo-gcp-security-block-project-wide-ssh-keys-enabled-vm-instances
     title: Ensure "Block Project-wide SSH keys" is enabled for VM instances
     impact: 70

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -490,7 +490,6 @@ queries:
   - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible
     title: Ensure that Cloud Storage buckets are not anonymously or publicly accessible
     impact: 90
-    mql: |
     variants:
       - uid: gcp-storage-cloud-storage-bucket-anonymously-publicly-accessible-all
       - uid: gcp-storage-cloud-storage-bucket-anonymously-publicly-accessible-single

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -64,8 +64,8 @@ policies:
     groups:
       - title: GCP Project
         filters: |
-          asset.platform == "gcp" || asset.platform == "gcp-project"
-          asset.kind == "api" || asset.kind == "gcp-object"
+          asset.family.contains("google")
+          asset.runtime == "gcp"
         checks:
           - uid: mondoo-gcp-security-block-project-wide-ssh-keys-enabled-vm-instances
           - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible


### PR DESCRIPTION
This PR updates the checks in `core/mondoo-gcp-security.mql.yaml` to the latest `v9` + `variants:` MQL. 

One query in here needs https://github.com/mondoohq/cnquery/issues/3236 to be fixed.