### PR TITLE
update the macOS up to date query, get actionable output

### DIFF
--- a/core/mondoo-macos-security.mql.yaml
+++ b/core/mondoo-macos-security.mql.yaml
@@ -1257,7 +1257,7 @@ queries:
     title: Ensure macOS is up to date
     impact: 100
     mql: |
-      command("softwareupdate -l").stderr.contains("No new software available.")
+      parse.plist('/Library/Preferences/com.apple.SoftwareUpdate.plist').params['RecommendedUpdates'] == empty
     docs:
       desc: |
         By staying up to date on macOS patches, vulnerabilities in the macOS can be mitigated. An educated attacker can exploit known vulnerabilities when attempting to attain access or elevate privileges on a macOS.


### PR DESCRIPTION
the new mql provides you a better output which update is missing:

```
cnspec> parse.plist('/Library/Preferences/com.apple.SoftwareUpdate.plist').params['RecommendedUpdates'] == empty
[failed] parse.plist.params.RecommendedUpdates == <ref>
  expected: == _
  actual:   [
    0: {
      Display Name: "macOS Sonoma 14.3.1"
      Display Version: "14.3.1"
      Identifier: "MSU_UPDATE_23D60_patch_14.3.1_minor"
      MobileSoftwareUpdate: true
      Product Key: "MSU_UPDATE_23D60_patch_14.3.1_minor"
    }
  ]
```

Instead of this output:

```
cnspec> command("softwareupdate -l").stderr.contains("No new software available.")
[failed] command.stderr.contains
  expected: == true
  actual:   false
```