### PR TITLE
slack policy with domain validation for users of channels

### DIFF
--- a/core/mondoo-slack-security.mql.yaml
+++ b/core/mondoo-slack-security.mql.yaml
@@ -4,7 +4,7 @@
 policies:
   - uid: mondoo-slack-security
     name: Slack Team Security
-    version: 1.3.0
+    version: 1.4.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -91,6 +91,7 @@ policies:
           - uid: mondoo-slack-security-name-external-channels
           - uid: mondoo-slack-security-at-least-one-workspace-internal-channel
           - uid: mondoo-slack-security-at-least-one-workspace-internal-channel-no-ext-members
+          - uid: mondoo-slack-domain-allowlisting-enforced-on-internal-channels
 queries:
   - uid: mondoo-slack-security-limit-admin-accounts
     title: Ensure that between 2 and 4 users have admin permissions
@@ -346,3 +347,44 @@ queries:
           ```
       remediation: |
         Create at least one channel which is for internal workspace use only. Make sure that no user who does not belong to your organization is in the channel(s).
+  - uid: mondoo-slack-domain-allowlisting-enforced-on-internal-channels
+    title: Ensure domain whitelisting is enforced on internal channels
+    impact: 75
+    props:
+      - uid: allowListedDomains
+        title: Enter your whitelisted domains in the mql below
+        mql: |
+          return /mondoo.com|example.com/
+    mql: slack.conversations.where(isExtShared == false ).all( members.all( profile['email'] == props.allowListedDomains ) )
+    docs:
+      desc: |
+        Ensure there are no users from unwanted domains in your internal channels
+      audit: |
+        Run this command to verify that all users non-externally shared channels adhere to your whitelisted domains:
+
+        __cnspec run__
+
+        To audit Slack with `cnspec run`:
+
+        Run this query:
+
+          ```bash
+          cnspec run slack -c "slack.conversations.where(isExtShared == false ) {name members {name profile['email']}" --token TOKEN
+          ```
+
+        __cnspec shell__
+
+        To audit Slack with `cnspec shell`:
+
+        1. Launch `cnspec shell`:
+
+          ```bash
+          cnspec shell slack ---organization --token TOKEN
+          ```
+
+        2. Run this query:
+
+          ```mql
+          slack.conversations.where(isExtShared == false ) {name members {name profile['email']}
+          ```
+      remediation: Make sure to block or remove any users that don't belong.

--- a/core/mondoo-slack-security.mql.yaml
+++ b/core/mondoo-slack-security.mql.yaml
@@ -70,7 +70,7 @@ policies:
             title: Enter your naming pattern for externally shared Slack channels
             mql: |
               return /ext|extern|ex_/
-          - uid: allowedDomains
+          - uid: allowListedDomains
             title: Enter allowed domains here
             mql: |
               return /mondoo.com|example.com/
@@ -348,11 +348,11 @@ queries:
       remediation: |
         Create at least one channel which is for internal workspace use only. Make sure that no user who does not belong to your organization is in the channel(s).
   - uid: mondoo-slack-domain-allowlisting-enforced-on-internal-channels
-    title: Ensure domain whitelisting is enforced on internal channels
+    title: Ensure domain is enforced on internal channels
     impact: 75
     props:
       - uid: allowListedDomains
-        title: Enter your whitelisted domains in the mql below
+        title: Enter your domains in the mql below
         mql: |
           return /mondoo.com|example.com/
     mql: slack.conversations.where(isExtShared == false ).all( members.all( profile['email'] == props.allowListedDomains ) )
@@ -360,7 +360,7 @@ queries:
       desc: |
         Ensure there are no users from unwanted domains in your internal channels
       audit: |
-        Run this command to verify that all users non-externally shared channels adhere to your whitelisted domains:
+        Run this command to verify that all users non-externally shared channels adhere to your allow-listed domains:
 
         __cnspec run__
 


### PR DESCRIPTION
This re-adds a previous check. With the performance improvements we did, we can add the query again.