### PR TITLE
ignore deactivated users in Slack 2FA check

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -41,6 +41,7 @@ crowdstrike
 ctl
 CUSTOMERID
 CYAAAAAAAKEY
+deactivateduser
 decomp
 dhe
 diffie

--- a/core/mondoo-slack-security.mql.yaml
+++ b/core/mondoo-slack-security.mql.yaml
@@ -172,7 +172,7 @@ queries:
     title: Ensure all users use 2FA
     impact: 60
     mql: |
-      slack.users.members.all( has2FA == true || enterpriseUser != null || id=="USLACKBOT" )
+      slack.users.members.where(name != /deactivateduser/).all( has2FA == true || enterpriseUser != null || id=="USLACKBOT" )
     docs:
       desc: |
         All user accounts should be protected with two-factor authentication. This enhances protection against account takeovers by attackers.


### PR DESCRIPTION
**Observed behaviour:**
The Slack integration wants to "Ensure all users use 2FA".
In the check, it includes deactivated users and is therefore failing the check if you have any deactivated user(s) as these have 2FA set to "false".

```
0: slack.user {
    name: "deactivateduser263912"
    has2FA: false
    id: "xxx"
    enterpriseUser: null
  }
 ```

**Expected behaviour:**
It should ignore deactivated users.