### PR TITLE
fix http policy to produce better output

### DIFF
--- a/core/mondoo-http-security.mql.yaml
+++ b/core/mondoo-http-security.mql.yaml
@@ -4,7 +4,7 @@
 policies:
   - uid: mondoo-http-security
     name: HTTP Security
-    version: 1.0.0
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -64,7 +64,7 @@ queries:
         title: MDN Web Docs X-Content-Type-Options
   - uid: mondoo-http-security-content-security-policy
     title: Set Content Security Policy (CSP) HTTP header
-    mql: http.get.header.params.keys.contains('Content-Security-Policy')
+    mql: http.get.header.params.keys.any('Content-Security-Policy')
     docs:
       desc: |
         Use the Content Security Policy (CSP) HTTP header to mitigate against Cross-Site Scripting (XSS) and data injection attacks.
@@ -73,7 +73,7 @@ queries:
         title: MDN Web Docs Content Security Policy (CSP)
   - uid: mondoo-http-security-strict-transport-security
     title: Set Strict-Transport-Security (HSTS) HTTP header
-    mql: http.get.header.params.keys.contains('Strict-Transport-Security')
+    mql: http.get.header.params.keys.any('Strict-Transport-Security')
     docs:
       desc: |
         Use the Strict-Transport-Security (HSTS) to eliminate the need for a HTTP to HTTPS redirect and protect against man in the middle attacks.


### PR DESCRIPTION
it fixes the output

before

```coffee
cnspec shell host www.infralovers.com

cnspec> http.get.header.params.keys.contains('Content-Security-Policy')
[failed] [].contains()
  expected: > 0
  actual:   0
```

now:

```coffee
cnspec> http.get.header.params.keys.any('Content-Security-Policy')
[failed] [].any()
  actual:   []
```