### PR TITLE
remove senitnelone updater service from macos check

### DIFF
--- a/core/mondoo-edr-policy.mql.yaml
+++ b/core/mondoo-edr-policy.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-edr-policy
     name: Endpoint Detection and Response (EDR) Policy
-    version: 1.2.0
+    version: 1.2.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -142,8 +142,6 @@ queries:
       service('com.sentinelone.sentineld-shell').enabled
       service('com.sentinelone.sentinel-extensions').running
       service('com.sentinelone.sentinel-extensions').enabled
-      service('com.sentinelone.sentineld-updater').running
-      service('com.sentinelone.sentineld-updater').enabled
       service('com.sentinelone.sentineld').running
       service('com.sentinelone.sentineld').enabled
       service('com.sentinelone.sentineld-guard').running


### PR DESCRIPTION
the sentinelone updater service is not installed in the latest version of SentinelOne