### PR TITLE
:broom: Fix: `Container image pull should be consistent`

### DIFF
--- a/core/mondoo-kubernetes-security.mql.yaml
+++ b/core/mondoo-kubernetes-security.mql.yaml
@@ -4250,10 +4250,24 @@ queries:
   - uid: mondoo-kubernetes-security-pod-imagepull
     title: Container image pull should be consistent
     impact: 60
+    props:
+      - uid: excludedByFixedImages
+        title: Exclude containers from the check when using fixed images using hash values.
+        mql: |
+          return [
+            # Add container images <image-name>@<digest>
+            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+          ]
     mql: |
-      k8s.pod.ephemeralContainers.all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
-      k8s.pod.initContainers.all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
-      k8s.pod.containers.all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
+      k8s.pod.ephemeralContainers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
+      k8s.pod.initContainers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
+      k8s.pod.containers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
     docs:
       desc: |
         It's important that each time a pod is started the same container is pulled, so that services across pods behave the same. To ensure the same container is always used, manifests should set `imagePullPolicy: Always` and the `image` configuration should pull either a tag or a digest (SHA).

--- a/core/mondoo-kubernetes-security.mql.yaml
+++ b/core/mondoo-kubernetes-security.mql.yaml
@@ -4304,9 +4304,21 @@ queries:
   - uid: mondoo-kubernetes-security-cronjob-imagepull
     title: Container image pull should be consistent
     impact: 60
+    props:
+      - uid: excludedByFixedImages
+        title: Exclude containers from the check when using fixed images using hash values.
+        mql: |
+          return [
+            # Add container images <image-name>@<digest>
+            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+          ]
     mql: |
-      k8s.cronjob.initContainers.all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
-      k8s.cronjob.containers.all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
+      k8s.cronjob.initContainers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
+      k8s.cronjob.containers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
     docs:
       desc: |
         It's important that each time a pod is started the same container is pulled, so that services across pods behave the same. To ensure the same container is always used, manifests should set `imagePullPolicy: Always` and the `image` configuration should pull either a tag or a digest (SHA).
@@ -4343,9 +4355,21 @@ queries:
   - uid: mondoo-kubernetes-security-statefulset-imagepull
     title: Container image pull should be consistent
     impact: 60
+    props:
+      - uid: excludedByFixedImages
+        title: Exclude containers from the check when using fixed images using hash values.
+        mql: |
+          return [
+            # Add container images <image-name>@<digest>
+            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+          ]
     mql: |
-      k8s.statefulset.initContainers.all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
-      k8s.statefulset.containers.all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
+      k8s.statefulset.initContainers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
+      k8s.statefulset.containers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
     docs:
       desc: |
         It's important that each time a pod is started the same container is pulled, so that services across pods behave the same. To ensure the same container is always used, manifests should set `imagePullPolicy: Always` and the `image` configuration should pull either a tag or a digest (SHA).
@@ -4382,9 +4406,21 @@ queries:
   - uid: mondoo-kubernetes-security-deployment-imagepull
     title: Container image pull should be consistent
     impact: 60
+    props:
+      - uid: excludedByFixedImages
+        title: Exclude containers from the check when using fixed images using hash values.
+        mql: |
+          return [
+            # Add container images <image-name>@<digest>
+            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+          ]
     mql: |
-      k8s.deployment.initContainers.all( imagePullPolicy == 'Always' && correctImage = image != /:latest/ && image.contains(':') == true )
-      k8s.deployment.containers.all( imagePullPolicy == 'Always' && correctImage = image != /:latest/ && image.contains(':') == true )
+      k8s.deployment.initContainers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && correctImage = image != /:latest/ && image.contains(':') == true )
+      k8s.deployment.containers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && correctImage = image != /:latest/ && image.contains(':') == true )
     docs:
       desc: |
         It's important that each time a pod is started the same container is pulled, so that services across pods behave the same. To ensure the same container is always used, manifests should set `imagePullPolicy: Always` and the `image` configuration should pull either a tag or a digest (SHA).
@@ -4421,9 +4457,21 @@ queries:
   - uid: mondoo-kubernetes-security-job-imagepull
     title: Container image pull should be consistent
     impact: 60
+    props:
+      - uid: excludedByFixedImages
+        title: Exclude containers from the check when using fixed images using hash values.
+        mql: |
+          return [
+            # Add container images <image-name>@<digest>
+            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+          ]
     mql: |
-      k8s.job.initContainers.all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
-      k8s.job.containers.all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
+      k8s.job.initContainers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
+      k8s.job.containers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
     docs:
       desc: |
         It's important that each time a pod is started the same container is pulled, so that services across pods behave the same. To ensure the same container is always used, manifests should set `imagePullPolicy: Always` and the `image` configuration should pull either a tag or a digest (SHA).
@@ -4460,9 +4508,21 @@ queries:
   - uid: mondoo-kubernetes-security-replicaset-imagepull
     title: Container image pull should be consistent
     impact: 60
+    props:
+      - uid: excludedByFixedImages
+        title: Exclude containers from the check when using fixed images using hash values.
+        mql: |
+          return [
+            # Add container images <image-name>@<digest>
+            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+          ]
     mql: |
-      k8s.replicaset.containers.all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
-      k8s.replicaset.initContainers.all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
+      k8s.replicaset.containers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
+      k8s.replicaset.initContainers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
     docs:
       desc: |
         It's important that each time a pod is started the same container is pulled, so that services across pods behave the same. To ensure the same container is always used, manifests should set `imagePullPolicy: Always` and the `image` configuration should pull either a tag or a digest (SHA).
@@ -4499,9 +4559,21 @@ queries:
   - uid: mondoo-kubernetes-security-daemonset-imagepull
     title: Container image pull should be consistent
     impact: 60
+    props:
+      - uid: excludedByFixedImages
+        title: Exclude containers from the check when using fixed images using hash values.
+        mql: |
+          return [
+            # Add container images <image-name>@<digest>
+            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+          ]
     mql: |
-      k8s.daemonset.containers.all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
-      k8s.daemonset.initContainers.all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
+      k8s.daemonset.containers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
+      k8s.daemonset.initContainers
+        .where(image.in(props.excludedByFixedImages) != true)
+        .all( imagePullPolicy == 'Always' && image != /:latest/ && image.contains(':') == true )
     docs:
       desc: |
         It's important that each time a pod is started the same container is pulled, so that services across pods behave the same. To ensure the same container is always used, manifests should set `imagePullPolicy: Always` and the `image` configuration should pull either a tag or a digest (SHA).


### PR DESCRIPTION
Adds `props` to exclude containers from some checks based on image digest:
```
    props:
      - uid: excludedByFixedImages
        title: Exclude containers from the check when using fixed images using hash values.
        mql: |
          return [
            # Add container images <image-name>@<digest>
            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
          ]
```