### PR TITLE
:broom: Fix ` pq: unsupported Unicode escape sequence` in Kubernetes Cluster and Workload Security

### DIFF
--- a/core/mondoo-kubernetes-security.mql.yaml
+++ b/core/mondoo-kubernetes-security.mql.yaml
@@ -4254,10 +4254,8 @@ queries:
       - uid: excludedByFixedImages
         title: Exclude containers from the check when using fixed images using hash values.
         mql: |
-          return [
-            # Add container images <image-name>@<digest>
-            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-          ]
+          # Add a list of container images in the format <image-name>@<digest>, such as: return ['image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2', 'image@sha256:12a23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5123']
+          return ['']
     mql: |
       k8s.pod.ephemeralContainers
         .where(image.in(props.excludedByFixedImages) != true)
@@ -4308,10 +4306,8 @@ queries:
       - uid: excludedByFixedImages
         title: Exclude containers from the check when using fixed images using hash values.
         mql: |
-          return [
-            # Add container images <image-name>@<digest>
-            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-          ]
+          # Add a list of container images in the format <image-name>@<digest>, such as: return ['image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2', 'image@sha256:12a23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5123']
+          return ['']
     mql: |
       k8s.cronjob.initContainers
         .where(image.in(props.excludedByFixedImages) != true)
@@ -4359,10 +4355,8 @@ queries:
       - uid: excludedByFixedImages
         title: Exclude containers from the check when using fixed images using hash values.
         mql: |
-          return [
-            # Add container images <image-name>@<digest>
-            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-          ]
+          # Add a list of container images in the format <image-name>@<digest>, such as: return ['image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2', 'image@sha256:12a23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5123']
+          return ['']
     mql: |
       k8s.statefulset.initContainers
         .where(image.in(props.excludedByFixedImages) != true)
@@ -4410,10 +4404,8 @@ queries:
       - uid: excludedByFixedImages
         title: Exclude containers from the check when using fixed images using hash values.
         mql: |
-          return [
-            # Add container images <image-name>@<digest>
-            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-          ]
+          # Add a list of container images in the format <image-name>@<digest>, such as: return ['image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2', 'image@sha256:12a23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5123']
+          return ['']
     mql: |
       k8s.deployment.initContainers
         .where(image.in(props.excludedByFixedImages) != true)
@@ -4461,10 +4453,8 @@ queries:
       - uid: excludedByFixedImages
         title: Exclude containers from the check when using fixed images using hash values.
         mql: |
-          return [
-            # Add container images <image-name>@<digest>
-            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-          ]
+          # Add a list of container images in the format <image-name>@<digest>, such as: return ['image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2', 'image@sha256:12a23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5123']
+          return ['']
     mql: |
       k8s.job.initContainers
         .where(image.in(props.excludedByFixedImages) != true)
@@ -4512,10 +4502,8 @@ queries:
       - uid: excludedByFixedImages
         title: Exclude containers from the check when using fixed images using hash values.
         mql: |
-          return [
-            # Add container images <image-name>@<digest>
-            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-          ]
+          # Add a list of container images in the format <image-name>@<digest>, such as: return ['image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2', 'image@sha256:12a23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5123']
+          return ['']
     mql: |
       k8s.replicaset.containers
         .where(image.in(props.excludedByFixedImages) != true)
@@ -4563,10 +4551,8 @@ queries:
       - uid: excludedByFixedImages
         title: Exclude containers from the check when using fixed images using hash values.
         mql: |
-          return [
-            # Add container images <image-name>@<digest>
-            # image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-          ]
+          # Add a list of container images in the format <image-name>@<digest>, such as: return ['image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2', 'image@sha256:12a23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5123']
+          return ['']
     mql: |
       k8s.daemonset.containers
         .where(image.in(props.excludedByFixedImages) != true)


### PR DESCRIPTION
- fixes this `pq` error because of the `props` formatting:
```
{"level":"error","req-id":"global","name":"Kubernetes Cluster and Workload Security","mrn":"//policy.api.mondoo.app/policies/mondoo-kubernetes-security","error":"pq: unsupported Unicode escape sequence","time":"2024-06-17T10:01:19Z","message":"marketplace> ensure policyBundle error"}
1 error occurred:
    * could not store policy bundle: /var/opt/mondoo/policies/mondoo-kubernetes-security.mql.yaml: pq: unsupported Unicode escape sequence
```
- props look like that now:
![image](https://github.com/mondoohq/cnspec-policies/assets/112621871/70fe0e14-9012-4e2a-ac88-58379ede5a7d)
