### PR TITLE
:broom: Fixes double `mql` issues: Mondoo Linux Policy

### DIFF
--- a/community/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/community/mondoo-phoenix-plcnext-security.mql.yaml
@@ -119,7 +119,7 @@ queries:
           return ["sntrup761x25519-sha512@openssh.com","curve25519-sha256@libssh.org","diffie-hellman-group-exchange-sha256"]
     mql: |
       sshd.config.kexs != empty
-      sshd.config.kexs.containsOnly(props.PLCKexAlgos)
+      && sshd.config.kexs.containsOnly(props.PLCKexAlgos)
     docs:
       desc: Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received
       remediation: |-
@@ -136,7 +136,7 @@ queries:
         mql: |
           return ["hmac-sha2-512-etm@openssh.com","hmac-sha2-256-etm@openssh.com","umac-128-etm@openssh.com","hmac-sha2-512","hmac-sha2-256"]
     mql: |
-      sshd.config.macs != null
+      sshd.config.macs != empty
       sshd.config.macs.containsOnly(props.PLCMacAlgos)
     docs:
       desc: This variable limits the types of MAC algorithms that SSH can use during communication.

--- a/community/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/community/mondoo-phoenix-plcnext-security.mql.yaml
@@ -118,7 +118,7 @@ queries:
         mql: |
           return ["sntrup761x25519-sha512@openssh.com","curve25519-sha256@libssh.org","diffie-hellman-group-exchange-sha256"]
     mql: |
-      sshd.config.kexs != null
+      sshd.config.kexs != empty
       sshd.config.kexs.containsOnly(props.PLCKexAlgos)
     docs:
       desc: Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1244,9 +1244,9 @@ queries:
       file("/etc/audit/auditd.conf").exists;
       ["/etc/audit/auditd.conf"].where(file(_).exists) {
         parse.ini(_) {
-          params["space_left_action"].downcase == /email|exec|single|halt/
-          params["action_mail_acct"].downcase == "root"
-          params["admin_space_left_action"].downcase == /halt|single/
+          params["space_left_action"].upcase.downcase == /email|exec|single|halt/
+          params["action_mail_acct"].upcase.downcase == "root"
+          params["admin_space_left_action"].upcase.downcase == /halt|single/
         }
       }
     docs:

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -692,8 +692,8 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      service("ypserv").enabled == false
       service("ypserv").running == false
+      service("ypserv").enabled == false
     docs:
       desc: The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -735,8 +735,8 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      service("telnet.socket").enabled == false
       service("telnet.socket").running == false
+      service("telnet.socket").enabled == false
     docs:
       desc: The `telnet-server` package contains the `telnet` daemon, which accepts connections from users from other systems via the `telnet` protocol.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -831,10 +831,10 @@ queries:
     title: Ensure packet redirect sending is disabled
     impact: 75
     mql: |
-      kernel.parameters['net.ipv4.conf.all.send_redirects'] == 0
-        || kernel.parameters['net.ipv4.conf.all.send_redirects'] == null
       kernel.parameters['net.ipv4.conf.default.send_redirects'] == 0
         || kernel.parameters['net.ipv4.conf.default.send_redirects'] == null
+      kernel.parameters['net.ipv4.conf.all.send_redirects'] == 0
+        || kernel.parameters['net.ipv4.conf.all.send_redirects'] == null
     docs:
       desc: ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host-only configuration), there is no need to send redirects.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -752,8 +752,8 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      service("tftp.socket").enabled == false
       service("tftp.socket").running == false
+      service("tftp.socket").enabled == false
     docs:
       desc: Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot machines from a boot server. The package `tftp-server` is used to define and support a TFTP server.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -588,8 +588,8 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      service("dovecot").enabled == false
       service("dovecot").running == false
+      service("dovecot").enabled == false
     docs:
       desc: '`dovecot` is an open source IMAP and POP3 server for Linux based systems.'
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -3033,7 +3033,7 @@ queries:
     filters: | 
       asset.kind != "container-image"
     props:
-      - uid: sudoGroup
+      - uid: sudoGroupMondoo
         title: Define the members of the sudo or wheel group
         mql: |
           return /root|ec2-user|centos|ubuntu|admin|mondoo/
@@ -3043,7 +3043,7 @@ queries:
       groups.where(name == "wheel" || name == "sudo") {
         members {
           name
-          name == props.sudoGroup
+          name == props.sudoGroupMondoo
         }
       }
     docs:
@@ -3075,7 +3075,7 @@ queries:
         ```
         wheel:x:10:root,<user list>
         ```
-        NOTE: The users allowed in the wheel group are defined in the properties `props.SudoGroup` field of this policy. By default the users "root", "ec2-user", "centos" and "ubuntu" are included. To include custom users you need to manually modify this policy. Otherwise the check will fail.
+        NOTE: The users allowed in the wheel group are defined in the properties `props.sudoGroupMondoo` field of this policy. By default the users "root", "ec2-user", "centos" and "ubuntu" are included. To include custom users you need to manually modify this policy. Otherwise the check will fail.
 
         If you want to lock down the use of the command `su` entirely instead, you need to create an empty group, for example `sugroup`:
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1020,7 +1020,8 @@ queries:
     title: Ensure bogus ICMP responses are ignored
     impact: 75
     mql: |
-      kernel.parameters['net.ipv4.icmp_ignore_bogus_error_responses'] == 1
+      # kernel.parameters['net.ipv4.icmp_ignore_bogus_error_responses'] == 1
+      kernel.parameters['net.ipv4.icmp_ignore_bogus_error_responses'].downcase == 1
     docs:
       desc: Setting `icmp_ignore_bogus_error_responses` to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -769,8 +769,8 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      service("rsyncd").enabled == false
       service("rsyncd").running == false
+      service("rsyncd").enabled == false
     docs:
       desc: The `rsyncd` service can be used to synchronize files between systems over network links.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -859,14 +859,14 @@ queries:
     title: Ensure source routed packets are not accepted
     impact: 75
     mql: |
-      kernel.parameters['net.ipv4.conf.all.accept_source_route'] == 0
-        || kernel.parameters['net.ipv4.conf.all.accept_source_route'] == null
-      kernel.parameters['net.ipv4.conf.default.accept_source_route'] == 0
-        || kernel.parameters['net.ipv4.conf.default.accept_source_route'] == null
       kernel.parameters['net.ipv6.conf.all.accept_source_route'] == 0
         || kernel.parameters['net.ipv6.conf.all.accept_source_route'] == null
       kernel.parameters['net.ipv6.conf.default.accept_source_route'] == 0
         || kernel.parameters['net.ipv6.conf.default.accept_source_route'] == null
+      kernel.parameters['net.ipv4.conf.all.accept_source_route'] == 0
+        || kernel.parameters['net.ipv4.conf.all.accept_source_route'] == null
+      kernel.parameters['net.ipv4.conf.default.accept_source_route'] == 0
+        || kernel.parameters['net.ipv4.conf.default.accept_source_route'] == null
     docs:
       desc: In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -801,10 +801,10 @@ queries:
     title: Ensure IP forwarding is disabled
     impact: 75
     mql: |
-      kernel.parameters['net.ipv4.ip_forward'] == 0
-        || kernel.parameters['net.ipv4.ip_forward'] == null
       kernel.parameters['net.ipv6.conf.all.forwarding'] == 0
         || kernel.parameters['net.ipv6.conf.all.forwarding'] == null
+      kernel.parameters['net.ipv4.ip_forward'] == 0
+        || kernel.parameters['net.ipv4.ip_forward'] == null
     docs:
       desc: The `net.ipv4.ip_forward` and `net.ipv6.conf.all.forwarding` flags are used to tell the system whether it can forward packets or not.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2192,7 +2192,7 @@ queries:
     mql: |
       ["/etc/systemd/journald.conf"].where(file(_).exists) {
         file(_) {
-          parse.ini("/etc/systemd/journald.conf").sections["Journal"]["ForwardToSyslog"].downcase == "yes"
+          parse.ini("/etc/systemd/journald.conf").sections["Journal"]["ForwardToSyslog"].upcase.downcase == "yes"
         }
       }
     docs:

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -901,14 +901,14 @@ queries:
     title: Ensure ICMP redirects are not accepted
     impact: 75
     mql: |
-      kernel.parameters['net.ipv4.conf.all.accept_redirects'] == 0
-        || kernel.parameters['net.ipv4.conf.all.accept_redirects'] == null
-      kernel.parameters['net.ipv4.conf.default.accept_redirects'] == 0
-        || kernel.parameters['net.ipv4.conf.default.accept_redirects'] == null
       kernel.parameters['net.ipv6.conf.all.accept_redirects'] == 0
         || kernel.parameters['net.ipv6.conf.all.accept_redirects'] == null
       kernel.parameters['net.ipv6.conf.default.accept_redirects'] == 0
         || kernel.parameters['net.ipv6.conf.default.accept_redirects'] == null
+      kernel.parameters['net.ipv4.conf.all.accept_redirects'] == 0
+        || kernel.parameters['net.ipv4.conf.all.accept_redirects'] == null
+      kernel.parameters['net.ipv4.conf.default.accept_redirects'] == 0
+        || kernel.parameters['net.ipv4.conf.default.accept_redirects'] == null
     docs:
       desc: ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables. By setting `net.ipv4.conf.all.accept_redirects` and `net.ipv6.conf.all.accept_redirects` to 0, the system will not accept any ICMP redirect messages, and therefore, won't allow outsiders to update the system's routing tables.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -203,7 +203,7 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      package("aide").installed
+      package("aide").installed == true
     docs:
       desc: Advanced Intrusion Detection Environment (AIDE) takes a snapshot of the filesystem state, including modification times, permissions, and file hashes. Administrators can then use this to compare against the current state of the filesystem to detect modifications to the system.
       remediation: |-
@@ -2146,7 +2146,7 @@ queries:
     title: Ensure rsyslog is installed
     impact: 50
     mql: |
-      package("rsyslog").installed
+      package("rsyslog").installed == true
     docs:
       desc: |-
         The `rsyslog`
@@ -2163,7 +2163,7 @@ queries:
     title: Ensure rsyslog Service is enabled
     impact: 50
     mql: |
-      service("rsyslog").enabled
+      service("rsyslog").enabled == true
     docs:
       desc: Once the `rsyslog` package is installed it needs to be enabled.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -378,7 +378,8 @@ queries:
     title: Ensure prelink is disabled
     impact: 70
     mql: |
-      package("prelink").installed == false
+      # package("prelink").installed == false
+      package("prelink").installed != true
     docs:
       desc: The `prelink` command changes binaries in an attempt to decrease their startup time. Prelinking can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2228,7 +2228,7 @@ queries:
     mql: |
       ["/etc/systemd/journald.conf"].where(file(_).exists) {
         file(_) {
-          parse.ini("/etc/systemd/journald.conf").sections["Journal"]["Storage"] == "persistent"
+          parse.ini("/etc/systemd/journald.conf").sections["Journal"]["Storage"].upcase.downcase == "persistent"
         }
       }
     docs:

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2471,8 +2471,7 @@ queries:
           }
           return ["chacha20-poly1305@openssh.com","aes256-gcm@openssh.com","aes128-gcm@openssh.com","aes256-ctr","aes192-ctr","aes128-ctr"]
     mql: |
-      sshd.config.ciphers != null
-      sshd.config.ciphers != []
+      sshd.config.ciphers != empty
       sshd.config.ciphers.containsOnly(props.MondooSshdCiphers)
     docs:
       desc: This variable limits the ciphers that SSH can use during communication.

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -248,11 +248,6 @@ queries:
        || command("crontab -u root -l | grep aide").stdout.lines.where(/^[^#]/).any(_.contains("aide --check"))
          || command("crontab -u root -l | grep aide").stdout.lines.where(/^[^#]/).any(_.contains("aide.conf --check"))
            || service('aidecheck').enabled
-
-      file("/etc/default/aide").exists && ["/etc/default/aide"].where(file(_).exists).all(parse.ini(_).params["CRON_DAILY_RUN"] == "yes") ||
-      command("crontab -u root -l | grep aide").stdout.lines.where(/^[^#]/).any(_.contains("aide --check")) ||
-      command("crontab -u root -l | grep aide").stdout.lines.where(/^[^#]/).any(_.contains("aide.conf --check")) ||
-      service('aidecheck').enabled
     docs:
       desc: Periodic checking of the filesystem integrity is needed to detect changes to the filesystem.
       remediation: |-
@@ -317,10 +312,10 @@ queries:
       asset.kind != "container-image"
     impact: 75
     mql: |
+      kernel.parameters['fs.suid_dumpable'] == 0
       file("/etc/security/limits.conf").content.lines.where( _ == /^[^#]/ ).where( _.contains("core") ) {
         _ == /\*\s+hard\s+core\s+0/
       }
-      kernel.parameters['fs.suid_dumpable'] == 0
       if(service("coredump").enabled || service("coredump").running) {
         parse.ini("/etc/systemd/coredump.conf").sections['Coredump']['ProcessSizeMax'] == 0
         parse.ini("/etc/systemd/coredump.conf").sections['Coredump']['Storage'] == 'none'

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2868,7 +2868,7 @@ queries:
     title: Ensure no duplicate user names exist
     impact: 80
     mql: |
-      users.list.duplicates(name).none()
+      users.list.duplicates(name) == empty
     docs:
       desc: |
         Each login name, each user ID (UID), and each group ID (GID) MUST ONLY be used once. Every user MUST be a member of at least one group. Every GID mentioned in the /etc/passwd file MUST be defined in the /etc/group file. Every group SHOULD only contain the users that are absolutely necessary. In networked systems, care MUST also be taken to ensure that user and group names (UIDs and GIDs) are assigned consistently in the system network if there is a possibility that the same UIDs or GIDs could be assigned to different user or group names on the systems during cross-system access.

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -943,10 +943,10 @@ queries:
     title: Ensure secure ICMP redirects are not accepted
     impact: 75
     mql: |
-      kernel.parameters['net.ipv4.conf.all.secure_redirects'] == 0
-        || kernel.parameters['net.ipv4.conf.all.secure_redirects'] == null
       kernel.parameters['net.ipv4.conf.default.secure_redirects'] == 0
         || kernel.parameters['net.ipv4.conf.default.secure_redirects'] == null
+      kernel.parameters['net.ipv4.conf.all.secure_redirects'] == 0
+        || kernel.parameters['net.ipv4.conf.all.secure_redirects'] == null
     docs:
       desc: Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system and are likely to be secure.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -709,12 +709,12 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      service("rsh.socket").enabled == false
-      service("rlogin.socket").enabled == false
-      service("rexec.socket").enabled == false
       service("rsh.socket").running == false
       service("rlogin.socket").running == false
       service("rexec.socket").running == false
+      service("rsh.socket").enabled == false
+      service("rlogin.socket").enabled == false
+      service("rexec.socket").enabled == false
     docs:
       desc: The Berkeley `rsh-server` ( `rsh`, `rlogin`, `rexec` ) package contains legacy services that exchange credentials in clear-text.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1118,8 +1118,8 @@ queries:
     title: Ensure auditd is installed
     impact: 50
     mql: |
-      package("auditd").installed && package("audispd-plugins").installed
-      || package("audit").installed || package("audit-libs").installed
+      package("auditd").installed == true && package("audispd-plugins").installed == true
+      || package("audit").installed == true || package("audit-libs").installed == true
     docs:
       desc: auditd is the user space component to the Linux Auditing System. It's responsible for writing audit records to the disk
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -998,7 +998,8 @@ queries:
     title: Ensure broadcast ICMP requests are ignored
     impact: 60
     mql: |
-      kernel.parameters['net.ipv4.icmp_echo_ignore_broadcasts'] == 1
+      # kernel.parameters['net.ipv4.icmp_echo_ignore_broadcasts'] == 1
+      kernel.parameters['net.ipv4.icmp_echo_ignore_broadcasts'].downcase == 1
     docs:
       desc: Setting `net.ipv4.icmp_echo_ignore_broadcasts` to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -665,13 +665,13 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
+      ports.listening.where(address != "127.0.0.1" && address != "::1").none(port == 25)
       if( package("postfix").installed && service('postfix').running ) {
         parse.ini("/etc/postfix/main.cf").params["inet_interfaces"] == "localhost" || parse.ini("/etc/postfix/main.cf").params["inet_interfaces"] == "loopback-only"
       }
       if( package("exim4").installed && service('exim4').running ) {
         parse.ini("/etc/exim4/update-exim4.conf.conf").params["dc_local_interfaces"] == "'127.0.0.1 ; ::1'"
       }
-      ports.listening.where(address != "127.0.0.1" && address != "::1").none(port == 25)
     docs:
       desc: Mail Transfer Agents (MTA), such as Sendmail and Postfix, listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2493,8 +2493,7 @@ queries:
           return ["umac-128-etm@openssh.com","hmac-sha2-256-etm@openssh.com","hmac-sha2-512-etm@openssh.com",
                   "umac-128@openssh.com","hmac-sha2-256","hmac-sha2-512"]
     mql: |
-      sshd.config.macs != null
-      sshd.config.macs != []
+      sshd.config.macs != empty
       sshd.config.macs.containsOnly(props.macAlgosMondoo)
     docs:
       desc: This variable limits the types of MAC algorithms that SSH can use during communication.

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1155,11 +1155,11 @@ queries:
     impact: 50
     mql: |
       switch {
-        case file("/boot/grub2/grubenv").exists:
-          file("/boot/grub2/grubenv").content.lines.where( _ == /^[^#]/ )
-            .any(_ == /audit(\s+)?\=(\s+)?1/);
         case file("/boot/grub2/grub.cfg").exists:
           file("/boot/grub2/grub.cfg").content.lines.where( _ == /^[^#]/ )
+            .any(_ == /audit(\s+)?\=(\s+)?1/);
+        case file("/boot/grub2/grubenv").exists:
+          file("/boot/grub2/grubenv").content.lines.where( _ == /^[^#]/ )
             .any(_ == /audit(\s+)?\=(\s+)?1/);
         case file("/boot/grub/grub.cfg").exists:
           file("/boot/grub/grub.cfg").content.lines.where( _ == /^[^#]/ )

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2522,8 +2522,7 @@ queries:
           }
           return ["sntrup761x25519-sha512@openssh.com","curve25519-sha256@libssh.org","diffie-hellman-group18-sha512"]
     mql: |
-      sshd.config.kexs != null
-      sshd.config.kexs != []
+      sshd.config.kexs != empty
       sshd.config.kexs.containsOnly(props.kexAlgos)
     docs:
       desc: Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2312,9 +2312,8 @@ queries:
     title: Ensure secure permissions on SSH public host key files are set
     impact: 80
     mql: |
-      files.
-        find(from: "/etc/ssh", type: "file").
-        where(path == /ssh_host_.*key.pub$/).list {
+      files.find(from: "/etc/ssh", type: "file")
+        .where(path == /ssh_host_.*key.pub$/).list {
           permissions.user_executable == false
           permissions.group_writeable == false
           permissions.group_executable == false

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2975,7 +2975,7 @@ queries:
     title: Ensure shadow group is empty
     impact: 80
     mql: |
-      groups.where(name == "shadow").all(members.length == 0)
+      groups.where(name == "shadow").none(members.length != 0)
     docs:
       desc: The shadow group allows system programs or defined users the ability to read the `/etc/shadow` file. No users should be assigned to the shadow group.
       remediation: Remove all users from the shadow group in `/etc/group`, and change the primary group of any users with shadow as their primary group.
@@ -2983,7 +2983,7 @@ queries:
     title: Ensure root group is empty
     impact: 100
     mql: |
-      groups.where(name == "root").all(members.length == 0)
+      groups.where(name == "root").none(members.length != 0)
     docs:
       desc: The root group allows system programs or defined users the ability to read and write configurations and files on the system. No users should be assigned to the root group.
       remediation: Remove all users from the shadow group in `/etc/group`, and change the primary group of any users with root as their primary group, except the root user.
@@ -2992,7 +2992,7 @@ queries:
     impact: 70
     mql: |
       users.where( name != "root" && name != "sync" && name != "shutdown" && name != "halt" ).where( uid < 1000 ).list {
-        shell == "/usr/bin/nologin" || shell == "/sbin/nologin" || shell == "/usr/sbin/nologin"
+        shell == "/sbin/nologin" || shell == "/usr/sbin/nologin" || shell == "/usr/bin/nologin"
       }
     docs:
       desc: |

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1042,8 +1042,8 @@ queries:
     title: Ensure Reverse Path Filtering is enabled
     impact: 75
     mql: |
-      kernel.parameters['net.ipv4.conf.all.rp_filter'] == 1
       kernel.parameters['net.ipv4.conf.default.rp_filter'] == 1
+      kernel.parameters['net.ipv4.conf.all.rp_filter'] == 1
     docs:
       desc: Setting `net.ipv4.conf.all.rp_filter`and `net.ipv4.conf.default.rp_filter` to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if `log_martians` is set).
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2850,7 +2850,7 @@ queries:
     title: Ensure no duplicate UIDs exist
     impact: 80
     mql: |
-      users.list.duplicates(uid).none()
+      users.list.duplicates(uid) == empty
     docs:
       desc: |
         Each login name, each user ID (UID), and each group ID (GID) MUST ONLY be used once. Every user MUST be a member of at least one group. Every GID mentioned in the /etc/passwd file MUST be defined in the /etc/group file. Every group SHOULD only contain the users that are absolutely necessary. In networked systems, care MUST also be taken to ensure that user and group names (UIDs and GIDs) are assigned consistently in the system network if there is a possibility that the same UIDs or GIDs could be assigned to different user or group names on the systems during cross-system access.

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2489,7 +2489,7 @@ queries:
     title: Ensure only strong MAC algorithms are used
     impact: 80
     props:
-      - uid: macAlgos
+      - uid: macAlgosMondoo
         title: Define the accepted MAC algorithms
         mql: |
           return ["umac-128-etm@openssh.com","hmac-sha2-256-etm@openssh.com","hmac-sha2-512-etm@openssh.com",
@@ -2497,7 +2497,7 @@ queries:
     mql: |
       sshd.config.macs != null
       sshd.config.macs != []
-      sshd.config.macs.containsOnly(props.macAlgos)
+      sshd.config.macs.containsOnly(props.macAlgosMondoo)
     docs:
       desc: This variable limits the types of MAC algorithms that SSH can use during communication.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -971,8 +971,8 @@ queries:
     title: Ensure suspicious packets are logged
     impact: 60
     mql: |
-      kernel.parameters['net.ipv4.conf.all.log_martians'] == 1
       kernel.parameters['net.ipv4.conf.default.log_martians'] == 1
+      kernel.parameters['net.ipv4.conf.all.log_martians'] == 1
     docs:
       desc: When enabled, this feature logs packets with un-routable source addresses to the kernel log.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2886,7 +2886,7 @@ queries:
     title: Ensure no duplicate GIDs exist
     impact: 80
     mql: |
-      groups.list.duplicates(gid).none()
+      groups.list.duplicates(gid) == empty
     docs:
       desc: |
         Each login name, each user ID (UID), and each group ID (GID) MUST ONLY be used once. Every user MUST be a member of at least one group. Every GID mentioned in the /etc/passwd file MUST be defined in the /etc/group file. Every group SHOULD only contain the users that are absolutely necessary. In networked systems, care MUST also be taken to ensure that user and group names (UIDs and GIDs) are assigned consistently in the system network if there is a possibility that the same UIDs or GIDs could be assigned to different user or group names on the systems during cross-system access.
@@ -2898,7 +2898,7 @@ queries:
     title: Ensure no duplicate group names exist
     impact: 80
     mql: |
-      groups.list.duplicates(name).none()
+      groups.list.duplicates(name) == empty
     docs:
       desc: |
         Each login name, each user ID (UID), and each group ID (GID) MUST ONLY be used once. Every user MUST be a member of at least one group. Every GID mentioned in the /etc/passwd file MUST be defined in the /etc/group file. Every group SHOULD only contain the users that are absolutely necessary. In networked systems, care MUST also be taken to ensure that user and group names (UIDs and GIDs) are assigned consistently in the system network if there is a possibility that the same UIDs or GIDs could be assigned to different user or group names on the systems during cross-system access.

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1090,10 +1090,10 @@ queries:
     title: Ensure IPv6 router advertisements are not accepted
     impact: 75
     mql: |
-      kernel.parameters['net.ipv6.conf.all.accept_ra'] == 0
-        || kernel.parameters['net.ipv6.conf.all.accept_ra'] == null
       kernel.parameters['net.ipv6.conf.default.accept_ra'] == 0
         || kernel.parameters['net.ipv6.conf.default.accept_ra'] == null
+      kernel.parameters['net.ipv6.conf.all.accept_ra'] == 0
+        || kernel.parameters['net.ipv6.conf.all.accept_ra'] == null
     docs:
       desc: This setting disables the system's ability to accept IPv6 router advertisements.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2916,7 +2916,7 @@ queries:
     title: Ensure default group for the root account is GID 0
     impact: 80
     mql: |
-      users.where(name == "root").list.all(gid == 0)
+      users.where(name == "root").list.none(gid != 0)
     docs:
       desc: |
         The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user.

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1222,7 +1222,7 @@ queries:
     mql: |
       file("/etc/audit/auditd.conf").exists;
       ["/etc/audit/auditd.conf"].where(file(_).exists) {
-        parse.ini(_).params["max_log_file_action"].downcase == "keep_logs"
+        parse.ini(_).params["max_log_file_action"].upcase.downcase == "keep_logs"
       }
     docs:
       desc: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -244,6 +244,11 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
+      file("/etc/default/aide").exists && ["/etc/default/aide"].where(file(_).exists).all(parse.ini(_).params["CRON_DAILY_RUN"] == "yes")
+       || command("crontab -u root -l | grep aide").stdout.lines.where(/^[^#]/).any(_.contains("aide --check"))
+         || command("crontab -u root -l | grep aide").stdout.lines.where(/^[^#]/).any(_.contains("aide.conf --check"))
+           || service('aidecheck').enabled
+
       file("/etc/default/aide").exists && ["/etc/default/aide"].where(file(_).exists).all(parse.ini(_).params["CRON_DAILY_RUN"] == "yes") ||
       command("crontab -u root -l | grep aide").stdout.lines.where(/^[^#]/).any(_.contains("aide --check")) ||
       command("crontab -u root -l | grep aide").stdout.lines.where(/^[^#]/).any(_.contains("aide.conf --check")) ||

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1205,7 +1205,7 @@ queries:
     mql: |
       file("/etc/audit/auditd.conf").exists;
       ["/etc/audit/auditd.conf"].where(file(_).exists) {
-        parse.ini(_).params["max_log_file"] > 0
+        parse.ini(_).params["max_log_file"].downcase > 0
       }
     docs:
       desc: Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started.

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2958,7 +2958,7 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      logindefs.params{ _['UID_MIN'] == 1000 }
+      logindefs.params.UID_MIN == 1000
     docs:
       desc: |
         User ID or UID is used to identify a Linux user with an ID or number. The start number for newly created users can be set with this configuration.

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -786,8 +786,8 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      service("ntalk").enabled == false
       service("ntalk").running == false
+      service("ntalk").enabled == false
     docs:
       desc: The talk software allows users to send and receive messages across systems through a terminal session. The talk client (allows initiate of talk sessions) is installed by default.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2508,7 +2508,7 @@ queries:
     title: Ensure that strong Key Exchange algorithms are used
     impact: 100
     props:
-      - uid: kexAlgos
+      - uid: kexAlgosMondoo
         title: Define the hardened key exchange algorithms for all SSH configurations
         mql: |
           if( package('openssh-server').version == /6./) {
@@ -2523,7 +2523,7 @@ queries:
           return ["sntrup761x25519-sha512@openssh.com","curve25519-sha256@libssh.org","diffie-hellman-group18-sha512"]
     mql: |
       sshd.config.kexs != empty
-      sshd.config.kexs.containsOnly(props.kexAlgos)
+      sshd.config.kexs.containsOnly(props.kexAlgosMondoo)
     docs:
       desc: Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1267,14 +1267,14 @@ queries:
     title: Ensure changes to system administration scope (sudoers) is collected
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/sudoers\.d(\/?)\s+\-p\s+wa\s+\-k\s+scope(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/sudoers(\/?)\s+\-p\s+wa\s+\-k\s+scope(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/sudoers\.d(\/?)\s+\-p\s+wa\s+\-k\s+scope(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/sudoers(\/?)\s+\-p\s+wa\s+\-k\s+scope(\s+)?$/))
     docs:
       desc: |-
         Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the `sudo`
@@ -1310,14 +1310,14 @@ queries:
     title: Ensure login and logout events are collected
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/var\/run\/faillock\s+\-p\s+wa\s+\-k\s+logins(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/var\/log\/lastlog\s+\-p\s+wa\s+\-k\s+logins(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/var\/run\/faillock\s+\-p\s+wa\s+\-k\s+logins(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/var\/log\/lastlog\s+\-p\s+wa\s+\-k\s+logins(\s+)?$/))
     docs:
       desc: |-
         Monitor login and logout events. The parameters below track changes to files associated with login/logout events.
@@ -1366,15 +1366,15 @@ queries:
     title: Ensure session initiation information is collected
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/var\/run\/utmp\s+\-p\s+wa\s+\-k\s+session(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/var\/log\/wtmp\s+\-p\s+wa\s+\-k\s+(logins|session)(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/var\/log\/btmp\s+\-p\s+wa\s+\-k\s+(logins|session)(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/var\/run\/utmp\s+\-p\s+wa\s+\-k\s+session(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/var\/log\/wtmp\s+\-p\s+wa\s+\-k\s+(logins|session)(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/var\/log\/btmp\s+\-p\s+wa\s+\-k\s+(logins|session)(\s+)?$/))
     docs:
       desc: |-
         Monitor session initiation events. The parameters in this section track changes to the files associated with session events.
@@ -1415,17 +1415,17 @@ queries:
     title: Ensure events that modify date and time information are collected
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+adjtimex(\s+\-S\s+|,)settimeofday(\s+\-S\s+|,)?(clock_settime)?\s+\-k\s+time-change(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+adjtimex(\s+\-S\s+|,)settimeofday(\s+\-S\s+|,)?(clock_settime)?(stime)?\s+\-k\s+time-change(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+clock\_settime\s+\-k\s+time-change(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+clock\_settime\s+\-k\s+time-change(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/localtime\s+\-p\s+wa\s+\-k\s+time-change(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+adjtimex(\s+\-S\s+|,)settimeofday(\s+\-S\s+|,)?(clock_settime)?\s+\-k\s+time-change(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+adjtimex(\s+\-S\s+|,)settimeofday(\s+\-S\s+|,)?(clock_settime)?(stime)?\s+\-k\s+time-change(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+clock\_settime\s+\-k\s+time-change(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+clock\_settime\s+\-k\s+time-change(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/localtime\s+\-p\s+wa\s+\-k\s+time-change(\s+)?$/))
     docs:
       desc: |-
         Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the `adjtimex`
@@ -1486,16 +1486,16 @@ queries:
     title: Ensure events that modify the system's Mandatory Access Controls are collected
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      appArmorSys = props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/apparmor(\/?)\s+\-p\s+wa\s+\-k\s+MAC-policy(\s+)?$/))
-        && props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/apparmor.d(\/?)\s+\-p\s+wa\s+\-k\s+MAC-policy(\s+)?$/))
-      seLinuxSys = props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/selinux(\/?)\s+\-p\s+wa\s+\-k\s+MAC-policy(\s+)?$/))
-       && props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/usr\/share\/selinux(\/?)\s+\-p\s+wa\s+\-k\s+MAC-policy(\s+)?$/))
+      appArmorSys = props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/apparmor(\/?)\s+\-p\s+wa\s+\-k\s+MAC-policy(\s+)?$/))
+        && props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/apparmor.d(\/?)\s+\-p\s+wa\s+\-k\s+MAC-policy(\s+)?$/))
+      seLinuxSys = props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/selinux(\/?)\s+\-p\s+wa\s+\-k\s+MAC-policy(\s+)?$/))
+       && props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/usr\/share\/selinux(\/?)\s+\-p\s+wa\s+\-k\s+MAC-policy(\s+)?$/))
       appArmorSys || seLinuxSys
     docs:
       desc: |-
@@ -1540,17 +1540,17 @@ queries:
     title: Ensure events that modify the system's network environment are collected
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+sethostname\s+\-S\s+setdomainname\s+\-k\s+system-locale(\s+)?$/)) || props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+sethostname\s+\-S\s+setdomainname\s+\-k\s+system-locale(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/issue\s+\-p\s+wa\s+\-k\s+system-locale(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/issue.net\s+\-p\s+wa\s+\-k\s+system-locale(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/hosts\s+\-p\s+wa\s+\-k\s+system-locale(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/sysconfig\/network\s+\-p\s+wa\s+\-k\s+system-locale(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+sethostname\s+\-S\s+setdomainname\s+\-k\s+system-locale(\s+)?$/)) || props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+sethostname\s+\-S\s+setdomainname\s+\-k\s+system-locale(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/issue\s+\-p\s+wa\s+\-k\s+system-locale(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/issue.net\s+\-p\s+wa\s+\-k\s+system-locale(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/hosts\s+\-p\s+wa\s+\-k\s+system-locale(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/sysconfig\/network\s+\-p\s+wa\s+\-k\s+system-locale(\s+)?$/))
     docs:
       desc: |-
         Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name)
@@ -1633,18 +1633,18 @@ queries:
     title: Ensure discretionary access control permission modification events are collected
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+chmod(\s+\-S\s+|,)fchmod(\s+\-S\s+|,)fchmodat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-F\s+key=perm\_mod(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+chown(\s+\-S\s+|,)fchown(\s+\-S\s+|,)lchown(\s+\-S\s+|,)fchownat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-F\s+key\=perm\_mod(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+chmod(\s+\-S\s+|,)fchmod(\s+\-S\s+|,)fchmodat\s+\-F+\s+auid\>\=1000\s+\-F\s+auid\!=(4294967295|unset|-1)\s+\-F\s+key\=perm_mod$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+lchown(\s+\-S\s+|,)fchown(\s+\-S\s+|,)chown(\s+\-S\s+|,)fchownat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-F\s+key\=perm\_mod(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+setxattr(\s+\-S\s+|,)lsetxattr(\s+\-S\s+|,)fsetxattr(\s+\-S\s+|,)removexattr(\s+\-S\s+|,)lremovexattr(\s+\-S\s+|,)fremovexattr\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-F\s+key\=perm\_mod(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+setxattr(\s+\-S\s+|,)lsetxattr(\s+\-S\s+|,)fsetxattr(\s+\-S\s+|,)removexattr(\s+\-S\s+|,)lremovexattr(\s+\-S\s+|,)fremovexattr\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-F\s+key\=perm\_mod(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+chmod(\s+\-S\s+|,)fchmod(\s+\-S\s+|,)fchmodat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-F\s+key=perm\_mod(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+chown(\s+\-S\s+|,)fchown(\s+\-S\s+|,)lchown(\s+\-S\s+|,)fchownat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-F\s+key\=perm\_mod(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+chmod(\s+\-S\s+|,)fchmod(\s+\-S\s+|,)fchmodat\s+\-F+\s+auid\>\=1000\s+\-F\s+auid\!=(4294967295|unset|-1)\s+\-F\s+key\=perm_mod$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+lchown(\s+\-S\s+|,)fchown(\s+\-S\s+|,)chown(\s+\-S\s+|,)fchownat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-F\s+key\=perm\_mod(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+setxattr(\s+\-S\s+|,)lsetxattr(\s+\-S\s+|,)fsetxattr(\s+\-S\s+|,)removexattr(\s+\-S\s+|,)lremovexattr(\s+\-S\s+|,)fremovexattr\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-F\s+key\=perm\_mod(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+setxattr(\s+\-S\s+|,)lsetxattr(\s+\-S\s+|,)fsetxattr(\s+\-S\s+|,)removexattr(\s+\-S\s+|,)lremovexattr(\s+\-S\s+|,)fremovexattr\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-F\s+key\=perm\_mod(\s+)?$/))
     docs:
       desc: |-
         Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes.
@@ -1714,14 +1714,14 @@ queries:
     title: Ensure unsuccessful unauthorized file access attempts are collected
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+creat\s+\-S\s+open\s+\-S\s+openat\s+\-S\s+truncate\s+\-S\s+ftruncate\s+\-F\s+exit\=\-EACCES\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+access(\s+)?$/)) || props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+creat\s+\-S\s+open\s+\-S\s+openat\s+\-S\s+truncate\s+\-S\s+ftruncate\s+\-F\s+exit\=\-EACCES\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+access(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+creat\s+\-S\s+open\s+\-S\s+openat\s+\-S\s+truncate\s+\-S\s+ftruncate\s+\-F\s+exit\=\-EPERM\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+access(\s+)?$/)) || props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+creat\s+\-S\s+open\s+\-S\s+openat\s+\-S\s+truncate\s+\-S\s+ftruncate\s+\-F\s+exit\=\-EPERM\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+access(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+creat\s+\-S\s+open\s+\-S\s+openat\s+\-S\s+truncate\s+\-S\s+ftruncate\s+\-F\s+exit\=\-EACCES\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+access(\s+)?$/)) || props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+creat\s+\-S\s+open\s+\-S\s+openat\s+\-S\s+truncate\s+\-S\s+ftruncate\s+\-F\s+exit\=\-EACCES\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+access(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+creat\s+\-S\s+open\s+\-S\s+openat\s+\-S\s+truncate\s+\-S\s+ftruncate\s+\-F\s+exit\=\-EPERM\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+access(\s+)?$/)) || props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+creat\s+\-S\s+open\s+\-S\s+openat\s+\-S\s+truncate\s+\-S\s+ftruncate\s+\-F\s+exit\=\-EPERM\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+access(\s+)?$/))
     docs:
       desc: |-
         Monitor for unsuccessful attempts to access files. The parameters below are associated with system calls that control creation ( `creat` ), opening ( `open`, `openat` ) and
@@ -1785,17 +1785,17 @@ queries:
     title: Ensure events that modify user/group information are collected
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/group\s+\-p\s+wa\s+\-k\s+identity(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/passwd\s+\-p\s+wa\s+\-k\s+identity(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/gshadow\s+\-p\s+wa\s+\-k\s+identity(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/shadow\s+\-p\s+wa\s+\-k\s+identity(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/security\/opasswd\s+\-p\s+wa\s+\-k\s+identity(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/group\s+\-p\s+wa\s+\-k\s+identity(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/passwd\s+\-p\s+wa\s+\-k\s+identity(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/gshadow\s+\-p\s+wa\s+\-k\s+identity(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/shadow\s+\-p\s+wa\s+\-k\s+identity(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/etc\/security\/opasswd\s+\-p\s+wa\s+\-k\s+identity(\s+)?$/))
     docs:
       desc: |-
         Record events affecting the `group`, `passwd` (user IDs), `shadow` and `gshadow` (passwords) or `/etc/security/opasswd`
@@ -1837,13 +1837,13 @@ queries:
     title: Ensure successful file system mounts are collected
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+mount\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+mounts(\s+)?$/)) || props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+mount\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+mounts(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+mount\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+mounts(\s+)?$/)) || props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+mount\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+mounts(\s+)?$/))
     docs:
       desc: |-
         Monitor the use of the `mount`
@@ -1890,14 +1890,14 @@ queries:
     title: Ensure file deletion events by users are collected
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+rename\,unlink\,unlinkat\,renameat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=unset\s+\-F\s+key\=delete(\s+)?$/)) || props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+unlink\s+\-S\s+unlinkat\s+\-S\s+rename\s+\-S\s+renameat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+delete(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+rename\,unlink\,unlinkat\,renameat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=unset\s+\-F\s+key\=delete(\s+)?$/)) || props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+unlink\s+\-S\s+unlinkat\s+\-S\s+rename\s+\-S\s+renameat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+delete(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+rename\,unlink\,unlinkat\,renameat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=unset\s+\-F\s+key\=delete(\s+)?$/)) || props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+unlink\s+\-S\s+unlinkat\s+\-S\s+rename\s+\-S\s+renameat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+delete(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+rename\,unlink\,unlinkat\,renameat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=unset\s+\-F\s+key\=delete(\s+)?$/)) || props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+unlink\s+\-S\s+unlinkat\s+\-S\s+rename\s+\-S\s+renameat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+delete(\s+)?$/))
     docs:
       desc: |-
         Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for the `unlink`
@@ -1951,16 +1951,16 @@ queries:
     title: Ensure kernel module loading and unloading is collected
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/sbin\/insmod\s+\-p\s+x\s+\-k\s+modules(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/sbin\/rmmod\s+\-p\s+x\s+\-k\s+modules(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/sbin\/modprobe\s+\-p\s+x\s+\-k\s+modules(\s+)?$/))
-      props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always,exit\s+\-F\s+arch\=b64\s+\-S\s+init\_module\s+\-S\s+delete\_module\s+\-k\s+modules(\s+)?$/)) || props.auditFiles.any(_.contains(/^(\s+)?\-a\s+always,exit\s+\-F\s+arch\=b32\s+\-S\s+init\_module\s+\-S\s+delete\_module\s+\-k\s+modules(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/sbin\/insmod\s+\-p\s+x\s+\-k\s+modules(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/sbin\/rmmod\s+\-p\s+x\s+\-k\s+modules(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/sbin\/modprobe\s+\-p\s+x\s+\-k\s+modules(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always,exit\s+\-F\s+arch\=b64\s+\-S\s+init\_module\s+\-S\s+delete\_module\s+\-k\s+modules(\s+)?$/)) || props.auditFilesMondoo.any(_.contains(/^(\s+)?\-a\s+always,exit\s+\-F\s+arch\=b32\s+\-S\s+init\_module\s+\-S\s+delete\_module\s+\-k\s+modules(\s+)?$/))
     docs:
       desc: |-
         Monitor the loading and unloading of kernel modules. The programs `insmod`
@@ -2019,13 +2019,13 @@ queries:
     title: Ensure system administrator actions (sudolog) are collected
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      props.auditFiles.any(_.contains(/^(\s+)?\-w\s+\/var\/log\/sudo\.log\s+\-p\s+wa\s+\-k\s+actions(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/^(\s+)?\-w\s+\/var\/log\/sudo\.log\s+\-p\s+wa\s+\-k\s+actions(\s+)?$/))
     docs:
       desc: |-
         Monitor the `sudo` log file. If the system has been properly configured to disable the use of the `su`
@@ -2065,13 +2065,13 @@ queries:
     title: Ensure the audit configuration is immutable
     impact: 50
     props:
-      - uid: auditFiles
+      - uid: auditFilesMondoo
         title: Return the content from all /etc/audit/rules.d and /etc/audit/audit.rules
         mql: |
-          auditFiles = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
-          return auditFiles.map(file(_).content.lines.where( _ == /^[^#]/ ))
+          auditFilesMondoo = files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file").list.map(path) + ["/etc/audit/audit.rules"]
+          return auditFilesMondoo.map(file(_).content.lines.where( _ == /^[^#]/ ))
     mql: |
-      props.auditFiles.any(_.contains(/(\s+)?\-e\s+2(\s+)?$/))
+      props.auditFilesMondoo.any(_.contains(/(\s+)?\-e\s+2(\s+)?$/))
     docs:
       desc: |-
         Set system audit so that audit rules cannot be modified with `auditctl`

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2211,7 +2211,7 @@ queries:
     mql: |
       ["/etc/systemd/journald.conf"].where(file(_).exists) {
         file(_) {
-          parse.ini("/etc/systemd/journald.conf").sections["Journal"]["Compress"] == "yes"
+          parse.ini("/etc/systemd/journald.conf").sections["Journal"]["Compress"].upcase.downcase == "yes"
         }
       }
     docs:

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1068,7 +1068,8 @@ queries:
     title: Ensure TCP SYN Cookies is enabled
     impact: 75
     mql: |
-      kernel.parameters['net.ipv4.tcp_syncookies'] == 1
+      # kernel.parameters['net.ipv4.tcp_syncookies'] == 1
+      kernel.parameters['net.ipv4.tcp_syncookies'].downcase == 1
     docs:
       desc: When `tcp_syncookies` is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN\|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the system to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue.
       remediation: |-

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1138,7 +1138,7 @@ queries:
     title: Ensure auditd service is enabled
     impact: 50
     mql: |
-      service("auditd").enabled
+      service("auditd").enabled == true
     docs:
       desc: |-
         Turn on the `auditd`

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -359,7 +359,7 @@ queries:
     title: Ensure address space layout randomization (ASLR) is enabled
     impact: 90
     mql: |
-      kernel.parameters["kernel.randomize_va_space"] == 2
+      kernel.parameters["kernel.randomize_va_space"].downcase == 2
     docs:
       desc: Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process.
       remediation: |-


### PR DESCRIPTION
This is a workaround that fixes the Mondoo Linux Policy by re-writing the `mql` of all checks.