### PR TITLE
🧹   Improving windows policies

### DIFF
--- a/core/mondoo-windows-security.mql.yaml
+++ b/core/mondoo-windows-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-windows-security
     name: Windows Security
-    version: 2.3.1
+    version: 2.3.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/core/mondoo-windows-security.mql.yaml
+++ b/core/mondoo-windows-security.mql.yaml
@@ -468,7 +468,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure1
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -476,7 +476,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess1
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -484,7 +484,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -531,7 +531,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure2
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -539,7 +539,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess2
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -547,7 +547,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure1
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -597,7 +597,7 @@ queries:
       - uid: auditpolAuditPolicyChange
         title: A list of Windows audit policy names depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Richtlinienänderungen überwachen";
             case _ == "nl-BE": "Beleidswijzigingen controleren";
             case _ == "it-IT": "Modifica del criterio di controllo";
@@ -606,7 +606,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure3
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -614,7 +614,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess3
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -622,7 +622,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure2
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -677,7 +677,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure4
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -685,7 +685,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess4
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -693,7 +693,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure3
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -750,7 +750,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure5
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -758,7 +758,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess5
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -766,7 +766,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure4
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -817,7 +817,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure6
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -825,7 +825,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess6
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -833,7 +833,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure5
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -883,7 +883,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure7
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -891,7 +891,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess7
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -899,7 +899,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure6
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -946,7 +946,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure8
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -954,7 +954,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess8
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -962,7 +962,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure7
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1058,7 +1058,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure9
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1066,7 +1066,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess9
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1074,7 +1074,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure8
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1122,7 +1122,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure10
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1130,7 +1130,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess10
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1138,7 +1138,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure9
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1195,7 +1195,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure11
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1203,7 +1203,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess11
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1211,7 +1211,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure10
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1259,7 +1259,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure12
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1267,7 +1267,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess12
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1275,7 +1275,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure11
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1325,7 +1325,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure13
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1333,7 +1333,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess13
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1341,7 +1341,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure12
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1402,7 +1402,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure14
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1410,7 +1410,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess14
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1418,7 +1418,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure13
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1474,7 +1474,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure15
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1482,7 +1482,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess15
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1490,7 +1490,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure14
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1549,7 +1549,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure16
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1557,7 +1557,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess16
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1565,7 +1565,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure15
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1620,7 +1620,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure16
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1628,7 +1628,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess17
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1636,7 +1636,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure16
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1695,7 +1695,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure17
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1703,7 +1703,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess18
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1711,7 +1711,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure17
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1759,7 +1759,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure18
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1767,7 +1767,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess19
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1775,7 +1775,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure18
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1826,7 +1826,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure19
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1834,7 +1834,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess20
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1842,7 +1842,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure19
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1890,7 +1890,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure20
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1898,7 +1898,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess21
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1906,7 +1906,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure20
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -1968,7 +1968,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure21
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -1976,7 +1976,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess22
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -1984,7 +1984,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure21
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -2034,7 +2034,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure22
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -2042,7 +2042,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess23
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -2050,7 +2050,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure22
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -2101,7 +2101,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure23
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -2109,7 +2109,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess24
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -2117,7 +2117,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure23
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -2227,7 +2227,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure24
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -2235,7 +2235,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess25
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -2243,7 +2243,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure24
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -2290,7 +2290,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure25
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -2298,7 +2298,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess26
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -2306,7 +2306,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure25
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";
@@ -2362,7 +2362,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccessFailure26
         title: Returns 'Success and Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg und Fehler";
             case _ == "it-IT": "Esito positivo e negativo";
             default: "Success and Failure";
@@ -2370,7 +2370,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolSuccess27
         title: Returns 'Success' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Erfolg";
             case _ == "it-IT": "Operazione riuscita";
             default: "Success";
@@ -2378,7 +2378,7 @@ queries:
       - uid: mondooWindowsSecurityAuditpolFailure26
         title: Returns 'Failure' depending on the operating system language
         mql: |
-          switch(windows.computerInfo['OsLanguage']) {
+          switch(windows.computerInfo['OsLocale']) {
             case _ == "de-DE": "Fehler";
             case _ == "it-IT": "Errore";
             default: "Failure";


### PR DESCRIPTION
It has been observed that `OsLocale` provides a more accurate identification of the operating system's language settings compared to `OsLanguage`. The `OsLocale` value, such as `de-DE`, includes both the language and regional settings, making it a better indicator of the actual language configured on the system.