### PR TITLE
Removed check for running sentineld-shell

### DIFF
--- a/core/mondoo-edr-policy.mql.yaml
+++ b/core/mondoo-edr-policy.mql.yaml
@@ -160,7 +160,6 @@ queries:
     mql: |
       service('com.sentinelone.sentineld-helper').running
       service('com.sentinelone.sentineld-helper').enabled
-      service('com.sentinelone.sentineld-shell').running
       service('com.sentinelone.sentineld-shell').enabled
       service('com.sentinelone.sentinel-extensions').running
       service('com.sentinelone.sentinel-extensions').enabled


### PR DESCRIPTION
As far as I know sentineld-shell daemon is not running when SentinelOne Agent runs on macOS which causes the policy to fail, even when SentinelOne is running correctly.

I removed the check for the running sentineld-shell.