### PR TITLE
:broom: Mondoo Linux Policy - Fix: Don't run `kernel.parameters` checks from inside containers

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -310,7 +310,7 @@ queries:
     title: Ensure core dumps are restricted
     filters: |
       asset.kind != "container-image"
-      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
+      asset.runtime != "docker-container"
     impact: 75
     mql: |
       file("/etc/security/limits.conf").content.lines.where( _ == /^[^#]/ ).where( _.contains("core") ) {
@@ -361,7 +361,7 @@ queries:
     impact: 90
     filters: |
       asset.kind != "container-image"
-      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
+      asset.runtime != "docker-container"
     mql: |
       kernel.parameters["kernel.randomize_va_space"] == 2
     docs:
@@ -805,7 +805,7 @@ queries:
     impact: 75
     filters: |
       asset.kind != "container-image"
-      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
+      asset.runtime != "docker-container"
     mql: |
       kernel.parameters['net.ipv4.ip_forward'] == 0
         || kernel.parameters['net.ipv4.ip_forward'] == null
@@ -838,7 +838,7 @@ queries:
     impact: 75
     filters: |
       asset.kind != "container-image"
-      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
+      asset.runtime != "docker-container"
     mql: |
       kernel.parameters['net.ipv4.conf.all.send_redirects'] == 0
         || kernel.parameters['net.ipv4.conf.all.send_redirects'] == null
@@ -869,7 +869,7 @@ queries:
     impact: 75
     filters: |
       asset.kind != "container-image"
-      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
+      asset.runtime != "docker-container"
     mql: |
       kernel.parameters['net.ipv4.conf.all.accept_source_route'] == 0
         || kernel.parameters['net.ipv4.conf.all.accept_source_route'] == null
@@ -914,7 +914,7 @@ queries:
     impact: 75
     filters: |
       asset.kind != "container-image"
-      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
+      asset.runtime != "docker-container"
     mql: |
       kernel.parameters['net.ipv4.conf.all.accept_redirects'] == 0
         || kernel.parameters['net.ipv4.conf.all.accept_redirects'] == null
@@ -959,7 +959,7 @@ queries:
     impact: 75
     filters: |
       asset.kind != "container-image"
-      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
+      asset.runtime != "docker-container"
     mql: |
       kernel.parameters['net.ipv4.conf.all.secure_redirects'] == 0
         || kernel.parameters['net.ipv4.conf.all.secure_redirects'] == null
@@ -990,7 +990,7 @@ queries:
     impact: 60
     filters: |
       asset.kind != "container-image"
-      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
+      asset.runtime != "docker-container"
     mql: |
       kernel.parameters['net.ipv4.conf.all.log_martians'] == 1
       kernel.parameters['net.ipv4.conf.default.log_martians'] == 1
@@ -1020,7 +1020,7 @@ queries:
     impact: 60
     filters: |
       asset.kind != "container-image"
-      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
+      asset.runtime != "docker-container"
     mql: |
       kernel.parameters['net.ipv4.icmp_echo_ignore_broadcasts'] == 1
     docs:
@@ -1044,7 +1044,7 @@ queries:
     impact: 75
     filters: |
       asset.kind != "container-image"
-      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
+      asset.runtime != "docker-container"
     mql: |
       kernel.parameters['net.ipv4.icmp_ignore_bogus_error_responses'] == 1
     docs:
@@ -1068,7 +1068,7 @@ queries:
     impact: 75
     filters: |
       asset.kind != "container-image"
-      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
+      asset.runtime != "docker-container"
     mql: |
       kernel.parameters['net.ipv4.conf.all.rp_filter'] == 1
       kernel.parameters['net.ipv4.conf.default.rp_filter'] == 1
@@ -1097,7 +1097,7 @@ queries:
     impact: 75
     filters: |
       asset.kind != "container-image"
-      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
+      asset.runtime != "docker-container"
     mql: |
       kernel.parameters['net.ipv4.tcp_syncookies'] == 1
     docs:
@@ -1121,7 +1121,7 @@ queries:
     impact: 75
     filters: |
       asset.kind != "container-image"
-      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
+      asset.runtime != "docker-container"
     mql: |
       kernel.parameters['net.ipv6.conf.all.accept_ra'] == 0
         || kernel.parameters['net.ipv6.conf.all.accept_ra'] == null

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -310,6 +310,7 @@ queries:
     title: Ensure core dumps are restricted
     filters: |
       asset.kind != "container-image"
+      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
     impact: 75
     mql: |
       file("/etc/security/limits.conf").content.lines.where( _ == /^[^#]/ ).where( _.contains("core") ) {
@@ -358,6 +359,9 @@ queries:
   - uid: mondoo-linux-security-address-space-layout-randomization-aslr-is-enabled
     title: Ensure address space layout randomization (ASLR) is enabled
     impact: 90
+    filters: |
+      asset.kind != "container-image"
+      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
     mql: |
       kernel.parameters["kernel.randomize_va_space"] == 2
     docs:
@@ -799,6 +803,9 @@ queries:
   - uid: mondoo-linux-security-ip-forwarding-is-disabled
     title: Ensure IP forwarding is disabled
     impact: 75
+    filters: |
+      asset.kind != "container-image"
+      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
     mql: |
       kernel.parameters['net.ipv4.ip_forward'] == 0
         || kernel.parameters['net.ipv4.ip_forward'] == null
@@ -829,6 +836,9 @@ queries:
   - uid: mondoo-linux-security-packet-redirect-sending-is-disabled
     title: Ensure packet redirect sending is disabled
     impact: 75
+    filters: |
+      asset.kind != "container-image"
+      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
     mql: |
       kernel.parameters['net.ipv4.conf.all.send_redirects'] == 0
         || kernel.parameters['net.ipv4.conf.all.send_redirects'] == null
@@ -857,6 +867,9 @@ queries:
   - uid: mondoo-linux-security-source-routed-packets-are-not-accepted
     title: Ensure source routed packets are not accepted
     impact: 75
+    filters: |
+      asset.kind != "container-image"
+      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
     mql: |
       kernel.parameters['net.ipv4.conf.all.accept_source_route'] == 0
         || kernel.parameters['net.ipv4.conf.all.accept_source_route'] == null
@@ -899,6 +912,9 @@ queries:
   - uid: mondoo-linux-security-icmp-redirects-are-not-accepted
     title: Ensure ICMP redirects are not accepted
     impact: 75
+    filters: |
+      asset.kind != "container-image"
+      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
     mql: |
       kernel.parameters['net.ipv4.conf.all.accept_redirects'] == 0
         || kernel.parameters['net.ipv4.conf.all.accept_redirects'] == null
@@ -941,6 +957,9 @@ queries:
   - uid: mondoo-linux-security-secure-icmp-redirects-are-not-accepted
     title: Ensure secure ICMP redirects are not accepted
     impact: 75
+    filters: |
+      asset.kind != "container-image"
+      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
     mql: |
       kernel.parameters['net.ipv4.conf.all.secure_redirects'] == 0
         || kernel.parameters['net.ipv4.conf.all.secure_redirects'] == null
@@ -969,6 +988,9 @@ queries:
   - uid: mondoo-linux-security-suspicious-packets-are-logged
     title: Ensure suspicious packets are logged
     impact: 60
+    filters: |
+      asset.kind != "container-image"
+      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
     mql: |
       kernel.parameters['net.ipv4.conf.all.log_martians'] == 1
       kernel.parameters['net.ipv4.conf.default.log_martians'] == 1
@@ -996,6 +1018,9 @@ queries:
   - uid: mondoo-linux-security-broadcast-icmp-requests-are-ignored
     title: Ensure broadcast ICMP requests are ignored
     impact: 60
+    filters: |
+      asset.kind != "container-image"
+      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
     mql: |
       kernel.parameters['net.ipv4.icmp_echo_ignore_broadcasts'] == 1
     docs:
@@ -1017,6 +1042,9 @@ queries:
   - uid: mondoo-linux-security-bogus-icmp-responses-are-ignored
     title: Ensure bogus ICMP responses are ignored
     impact: 75
+    filters: |
+      asset.kind != "container-image"
+      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
     mql: |
       kernel.parameters['net.ipv4.icmp_ignore_bogus_error_responses'] == 1
     docs:
@@ -1038,6 +1066,9 @@ queries:
   - uid: mondoo-linux-security-reverse-path-filtering-is-enabled
     title: Ensure Reverse Path Filtering is enabled
     impact: 75
+    filters: |
+      asset.kind != "container-image"
+      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
     mql: |
       kernel.parameters['net.ipv4.conf.all.rp_filter'] == 1
       kernel.parameters['net.ipv4.conf.default.rp_filter'] == 1
@@ -1064,6 +1095,9 @@ queries:
   - uid: mondoo-linux-security-tcp-syn-cookies-is-enabled
     title: Ensure TCP SYN Cookies is enabled
     impact: 75
+    filters: |
+      asset.kind != "container-image"
+      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
     mql: |
       kernel.parameters['net.ipv4.tcp_syncookies'] == 1
     docs:
@@ -1085,6 +1119,9 @@ queries:
   - uid: mondoo-linux-security-ipv6-router-advertisements-are-not-accepted
     title: Ensure IPv6 router advertisements are not accepted
     impact: 75
+    filters: |
+      asset.kind != "container-image"
+      command("cat /proc/1/sched | head -n 1").stdout.contains(/systemd/) == true
     mql: |
       kernel.parameters['net.ipv6.conf.all.accept_ra'] == 0
         || kernel.parameters['net.ipv6.conf.all.accept_ra'] == null


### PR DESCRIPTION
Using the following filters to make sure `kernel.parameter` checks don't run inside of docker containers or images.
```
    filters: |
      asset.kind != "container-image"
      asset.runtime != "docker-container"
```