### PR TITLE
⭐️ add recommendations from OWASP HTTP Security Response Headers

### DIFF
--- a/core/mondoo-http-security.mql.yaml
+++ b/core/mondoo-http-security.mql.yaml
@@ -45,6 +45,11 @@ policies:
         checks:
           - uid: mondoo-http-security-x-content-type-options-nosniff
           - uid: mondoo-http-security-content-security-policy
+          - uid: mondoo-http-security-obfuscate-server
+          - uid: mondoo-http-security-no-x-powered-by
+          - uid: mondoo-http-security-no-x-aspnet-version
+          - uid: mondoo-http-security-no-x-aspnetmvc-version
+          - uid: mondoo-http-security-no-public-key-pins
       - title: Headers for HTTPS communication
         filters: |
           asset.platform == 'host'
@@ -62,6 +67,8 @@ queries:
     refs:
       - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
         title: MDN Web Docs X-Content-Type-Options
+      - url: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-xss-protection
+        title: OWASP HTTP Security Response Headers Cheat Sheet
   - uid: mondoo-http-security-content-security-policy
     title: Set Content Security Policy (CSP) HTTP header
     mql: http.get.header.params.keys.any('Content-Security-Policy')
@@ -80,3 +87,48 @@ queries:
     refs:
       - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
         title: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+  - uid: mondoo-http-security-obfuscate-server
+    title: Remove Server header or obfuscate it
+    mql: http.get.header.params.keys.none("Server") || http.get.header.params["Server"].map(downcase).none(_ == /nginx|microsoft|apache|lsws|openresty/)
+    docs:
+      desc: |
+        The X-Powered-By header exposes information about the server software. Remove it to reduce the attack surface.
+    refs:
+      - url: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#server
+        title: OWASP HTTP Security Response Headers Cheat Sheet
+  - uid: mondoo-http-security-no-x-powered-by
+    title: Remove all X-Powered-By headers.
+    mql: http.get.header.params.keys.none("X-Powered-By")
+    docs:
+      desc: |
+        The X-Powered-By header exposes information about the server software. Remove it to reduce the attack surface.
+    refs:
+      - url: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-powered-by
+        title: OWASP HTTP Security Response Headers Cheat Sheet
+  - uid: mondoo-http-security-no-x-aspnet-version
+    title: Remove all X-AspNet-Version headers.
+    mql: http.get.header.params.keys.none("X-AspNet-Version")
+    docs:
+      desc: |
+        The X-AspNet-Version header exposes information about the server software. Remove it to reduce the attack surface.
+    refs:
+      - url: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-aspnet-version
+        title: OWASP HTTP Security Response Headers Cheat Sheet
+  - uid: mondoo-http-security-no-x-aspnetmvc-version
+    title: Remove all X-AspNetMvc-Version headers.
+    mql: http.get.header.params.keys.none("X-AspNetMvc-Version")
+    docs:
+      desc: |
+        The X-AspNetMvc-Version header exposes information about the server software. Remove it to reduce the attack surface.
+    refs:
+      - url: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-aspnetmvc-version
+        title: OWASP HTTP Security Response Headers Cheat Sheet
+  - uid: mondoo-http-security-no-public-key-pins
+    title: This header Public-Key-Pins is deprecated and should not be used anymore
+    mql: http.get.header.params.keys.none("Public-Key-Pins")
+    docs:
+      desc: |
+        The Public-Key-Pins header is deprecated and should not be used anymore.
+    refs:
+      - url: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#public-key-pins-hpkp
+        title: OWASP HTTP Security Response Headers Cheat Sheet


### PR DESCRIPTION
This PR adds recommendations from [OWASP http header recommendations](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html).

- Recommendation for removal or obfuscation of http `Server` header
- Recommendation for removal of http header `X-Powered-By`, `X-AspNet-Version`, `X-AspNetMvc-Version` and `Public-Key-Pins`

```
cnspec scan host google.com -f core/mondoo-http-security.mql.yaml

Asset: google.com
-----------------

Checks:
✕ Fail:       Set X-Content-Type-Options HTTP header to 'nosniff'
✓ Pass:       Remove all X-AspNetMvc-Version headers.
✕ Fail:       Set Content Security Policy (CSP) HTTP header
✓ Pass:       This header Public-Key-Pins is deprecated and should not be used anymore
✓ Pass:       Remove Server header or obfuscate it
✓ Pass:       Remove all X-Powered-By headers.
✓ Pass:       Remove all X-AspNet-Version headers.
✕ Fail:       Set Strict-Transport-Security (HSTS) HTTP header
```