### PR TITLE
🧹 update aws policy asset filter

### DIFF
--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -70,7 +70,7 @@ policies:
         If you have any suggestions for how to improve this policy or need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     groups:
       - title: AWS IAM
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-access-keys-rotated
           - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access
@@ -81,37 +81,37 @@ policies:
           - uid: mondoo-aws-security-iam-group-has-users-check
           - uid: mondoo-aws-security-iam-user-no-inline-policies-check
       - title: AWS Lambda Function
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-lambda-concurrency-check
       - title: AWS S3 Bucket
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-s3-bucket-level-public-access-prohibited
           - uid: mondoo-aws-security-s3-buckets-account-level-block-public-access
       - title: AWS Security Group
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-secgroup-restricted-ssh
       - title: AWS VPC
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-vpc-default-security-group-closed
           - uid: mondoo-aws-security-vpc-flow-logs-enabled
       - title: AWS DynamoDB Table
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-dynamodb-table-encrypted-kms
       - title: AWS RDS DBInstance
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-rds-instance-public-access-check
       - title: AWS Redshift Cluster
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-redshift-cluster-public-access-check
       - title: AWS EC2
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-ec2-ebs-encryption-by-default
           - uid: mondoo-aws-security-ec2-imdsv2-check
@@ -119,31 +119,31 @@ policies:
           - uid: mondoo-aws-security-ec2-volume-inuse-check
           - uid: mondoo-aws-security-ebs-snapshot-public-restorable-check
       - title: AWS EFS Filesystem
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-efs-encrypted-check
       - title: AWS CloudWatch LogGroup
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-cloudwatch-log-group-encrypted
       - title: AWS ELB LoadBalancer
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-elb-deletion-protection-enabled
       - title: AWS ES Domain
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest
       - title: AWS KMS Key
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled
       - title: AWS SageMaker NotebookInstance
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-sagemaker-notebook-instance-kms-key-configured
       - title: AWS CloudTrail Trail
-        filters: asset.runtime == "aws"
+        filters: asset.platform == "aws"
         checks:
           - uid: mondoo-aws-security-cloud-trail-encryption-enabled
     scoring_system: highest impact


### PR DESCRIPTION
Since we enabled deep scanning for AWS in cnspec, we need to adjust the asset filter for the queries, so that they do not match all individual assets. As a followup step, we need to add the variants to the AWS policy.