### PR TITLE
Rename the TLS/SSL policy to match our names

### DIFF
--- a/core/mondoo-tls-security.mql.yaml
+++ b/core/mondoo-tls-security.mql.yaml
@@ -3,7 +3,7 @@
 
 policies:
   - uid: mondoo-tls-security
-    name: TLS/SSL Security
+    name: Mondoo TLS/SSL Security
     version: 1.4.0
     license: BUSL-1.1
     tags:
@@ -20,17 +20,7 @@ policies:
 
         The Mondoo TLS/SSL Security policy includes checks for ensuring the security and configuration of TLS/SSL connections and certificates.
 
-        ## Remote scan
-
-        Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
-
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
-        ### Scan a host
+        ## Remote scan a host
 
         ```bash
         cnspec scan host <fqdn>


### PR DESCRIPTION
Also remove the extra section about how providers work that's not necessary here