### PR TITLE
Update AWS policy to not use deprecated field

### DIFF
--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -1939,8 +1939,8 @@ queries:
     filters: |
       asset.platform == "aws"
     mql: |
-      aws.rds.dbInstances.all(publiclyAccessible == false)
-      aws.rds.dbInstances
+      aws.rds.instances.all(publiclyAccessible == false)
+      aws.rds.instances
         .where(publiclyAccessible != false)
         .none(securityGroups.where(
           vpc.routeTables.where(
@@ -1977,13 +1977,13 @@ queries:
         3. Run this query:
 
         ```mql
-        aws.rds.dbInstances.where(publiclyAccessible == true) {arn name region dbInstanceIdentifier tags}
+        aws.rds.instances.where(publiclyAccessible == true) {arn name region dbInstanceIdentifier tags}
         ```
 
         Example output:
 
         ```mql
-        aws.rds.dbInstances.where: [
+        aws.rds.instances.where: [
           0: {
             arn: \"arn:aws:rds:us-moonbase-2:12345:db:rds-12345-mondoo-demo\"
             tags: {


### PR DESCRIPTION
aws.rds.dbInstances is now just aws.rds.instances.