### PR TITLE
Improve formatting + checks in Mondoo Linux policy

### DIFF
--- a/.github/actions/spelling/line_forbidden.patterns
+++ b/.github/actions/spelling/line_forbidden.patterns
@@ -167,6 +167,10 @@
 # s.b. AlmaLinux
 \bAlma Linux\b
 
+# s.b. CloudLinux
+\bCloud Linux\b
+\bCloudlinux\b
+
 # s.b. openSUSE
 \bOpenSUSE\b
 

--- a/community/mondoo-linux-operational-policy.mql.yaml
+++ b/community/mondoo-linux-operational-policy.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |-
-        ## Overview
-
         Linux Server Operational Policy by Mondoo provides guidance for operational best practices on Linux hosts.
 
         ## Local scan

--- a/community/mondoo-linux-snmp-policy.mql.yaml
+++ b/community/mondoo-linux-snmp-policy.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         Linux Server SNMP Policy by Mondoo provides guidance for vulnerable SNMP configurations on Linux hosts.
 
         ## Local scan

--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         The Mondoo AWS Security policy provides guidance for establishing minimum recommended security and operational best practices for Amazon Web Services (AWS). The checks in this policy bundle are based on AWS's Operational Best Practices recommendations as part of the [AWS Config conformance packs](https://docs.aws.amazon.com/config/latest/developerguide/conformance-packs.html).
 
         ## Remote scan

--- a/core/mondoo-azure-security.mql.yaml
+++ b/core/mondoo-azure-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |-
-        ## Overview
-
         The Mondoo Microsoft Azure Security policy provides guidance for establishing minimum recommended security and operational best practices for Microsoft Azure.
 
         ## Getting Started
@@ -35,7 +33,7 @@ policies:
 
         Step 2: Authentication to Azure
         There are two primary methods to authenticate cnspec to your Azure environments:
-        
+
         **a. Azure CLI Login**
 
         ```
@@ -122,14 +120,14 @@ queries:
 
         ```bash
         az disk list --resource-group "yourResourceGroupName" --query "[].{Name:name, ResourceGroupName:resourceGroup, EncryptionSettings:encryptionSettingsCollection}" -o table
-        ``` 
+        ```
 
         **Automated Audit with PowerShell:**
 
         ```powershell
         Get-AzDisk -ResourceGroupName "yourResourceGroupName" | Select-Object Name, ResourceGroupName, EncryptionSettingsCollection
         ```
-        
+
         Ensure the EncryptionType is set to EncryptionAtRestWithCustomerKey for OS disks.
       remediation: |
         ### Microsoft Azure Portal
@@ -229,7 +227,7 @@ queries:
       desc: |
         Restricting SSH access from the internet minimizes the risk of brute force and other unauthorized access attempts on Azure resources such as virtual machines. Public internet exposure of SSH, especially on the default port 22, significantly increases the attack surface. It's crucial to evaluate and restrict SSH access by configuring network security groups (NSGs) to allow only necessary connections, preferably from known, secure sources. Implementing stringent access controls for SSH enhances security by preventing attackers from using compromised VMs as a pivot point for broader network intrusions.
       audit: |
-       **Manual Audit via Azure Portal:**     
+       **Manual Audit via Azure Portal:**
 
         **Checking via Network Security Groups (NSGs) for All Resources:**
         1. From the main Azure Portal menu, navigate to **Network security groups**.
@@ -345,7 +343,7 @@ queries:
       desc: |
         Restricting RDP access from the internet is crucial for protecting Azure resources against unauthorized access and potential security breaches. RDP, typically listening on TCP port 3389, is a common target for many Cyber attacks. By limiting RDP access to only trusted internal networks or through secure tunnels, the risk of these attacks is significantly reduced. This security measure is essential for maintaining the integrity and security of Azure environments, preventing attackers from using compromised VMs as launch points for further attacks within and beyond the Azure network.
       audit: |
-        **Manual Audit via Azure Portal:**     
+        **Manual Audit via Azure Portal:**
 
         1. Log into the Azure Portal.
         2. Navigate to **Network security groups** under the Networking or directly through the search bar.
@@ -530,7 +528,7 @@ queries:
 
         ```
         az storage account show --name <yourStorageAccountName> --query allowBlobPublicAccess
-        ``` 
+        ```
 
       remediation: |
         ### Terraform
@@ -557,7 +555,7 @@ queries:
           ```
           az storage account update --name <storage-account> --resource-group <resource-group> --public-network-access Disabled
           ```
-        
+
         - Set blob containers to private access:
           ```
           az storage container set-permission --name <container_name> --public-access off --account-name <account_name> --account-key <account_key>
@@ -1046,7 +1044,7 @@ queries:
         It is highly recommended to use the latest TLS version available with Azure App Services for all secure Web App connections. Currently Azure App Services supports TLS 1.2.
       audit: |
         **From Azure Portal:**
-  
+
         1. Log in to the Azure Portal at https://portal.azure.com.
         2. Navigate to **App Services**.
         3. Select an app service and select **TLS/SSL settings** under **Settings**.
@@ -1055,7 +1053,7 @@ queries:
         **From Azure CLI:**
 
         Verify that the minimum TLS version is set to 1.2 for each App Service:
-        
+
         ```bash
         az webapp config show --resource-group <RESOURCE_GROUP_NAME> --name <APP_NAME> --query minTlsVersion
         ```
@@ -1076,7 +1074,7 @@ queries:
            b. Select **Configuration** and select the **General settings** tab.
            c. Under **Minimum Inbound TLS Version**, select **1.2**.
            d. Select **Save**.
-        
+
         **From Azure CLI:**
 
         Set the minimum TLS version to 1.2 for an existing app service:
@@ -1157,7 +1155,7 @@ queries:
            a. Select the key vault.
            b. Select **Keys** or **Secrets**.
            c. Make sure that the key/secret in the key vault has an expiration date.
-        
+
         **From Azure CLI:**
 
         - For keys:

--- a/core/mondoo-dns-security.mql.yaml
+++ b/core/mondoo-dns-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         The Mondoo DNS Security policy includes checks for assessing the configuration of DNS records.
 
         ## Remote scan

--- a/core/mondoo-dockerfile-security.mql.yaml
+++ b/core/mondoo-dockerfile-security.mql.yaml
@@ -13,8 +13,6 @@ policies:
         email: hello@mondoo.com
     docs:
         desc: |-
-          ## Overview
-
           The Dockerfile Security policy by Mondoo provides guidance for establishing secure Docker container configurations and deployments by securing Dockerfiles used to build container images.
 
           If you have questions, comments, or ways to improve this policy, please write us at hello@mondoo.com, or reach out in GitHub Discussions.
@@ -72,7 +70,7 @@ queries:
       desc: |
         Management ports such as SSH (port 22), Docker Remote API (port 2375), Consul (port 8500), and Kubernetes API (port 6443) are commonly targeted by attackers. Exposing these ports in Docker containers increases the risk of unauthorized access and security vulnerabilities. This test ensures that these management ports are not exposed in Docker container configurations.
       remediation: |
-        Review and update your Dockerfile to ensure that management ports (22 for SSH, 2375 for Docker Remote API, 8500 for Consul HTTP API, 6443 for Kubernetes API) are not exposed. 
+        Review and update your Dockerfile to ensure that management ports (22 for SSH, 2375 for Docker Remote API, 8500 for Consul HTTP API, 6443 for Kubernetes API) are not exposed.
         - Remove or restrict the exposure of these ports using the `EXPOSE` instruction in your Dockerfile.
         - Use Docker's port mapping options (`-p` or `--publish`) cautiously to avoid exposing these ports.
         - Ensure that any required management access is secured and appropriately managed.
@@ -89,7 +87,7 @@ queries:
         Disabling certificate validation can expose the system to man-in-the-middle attacks and other security vulnerabilities.
       remediation: |
         - Review the Dockerfile and ensure that package managers are configured to use SSL certificate validation.
-        - Use secure practices for package installations to maintain system integrity: Remove any insecure options such as `--nogpgcheck`, `--no-check-certificate`, `--no-gpg-check`, and similar flags. 
+        - Use secure practices for package installations to maintain system integrity: Remove any insecure options such as `--nogpgcheck`, `--no-check-certificate`, `--no-gpg-check`, and similar flags.
   - uid: mondoo-docker-security-no-insecure-certificate-validation-apt
     title: Don’t disable certificate validation in APT
     impact: 100
@@ -114,7 +112,7 @@ queries:
         Disabling certificate validation can expose the container to man-in-the-middle attacks and other security risks.
       remediation: |
         - Review the `CMD` or `ENTRYPOINT` commands in your Dockerfile and any scripts executed within the container.
-        - Avoid using `curl` with `--insecure` or `-k` options. 
+        - Avoid using `curl` with `--insecure` or `-k` options.
         - Ensure that proper SSL certificate validation is enabled for all `curl` operations.
   - uid: mondoo-docker-security-no-insecure-certificate-validation-wget
     title: Don’t disable certificate validation in Wget
@@ -139,7 +137,7 @@ queries:
         as it grants elevated permissions that can be exploited if not handled properly.
         By avoiding `sudo`, you ensure that all commands run with the default user privileges, which enhances the security of the container.
       remediation: |
-        - Review the Dockerfile and remove any instances of `sudo`. 
+        - Review the Dockerfile and remove any instances of `sudo`.
         - Ensure that all commands are executed with the least privileges required.
         - Configure containers to operate with non-root users where possible, and avoid privilege escalation techniques.
   - uid: mondoo-docker-security-no-gpg-skip-yum

--- a/core/mondoo-edr-policy.mql.yaml
+++ b/core/mondoo-edr-policy.mql.yaml
@@ -20,7 +20,7 @@ policies:
         By implementing this policy, we take a proactive approach to instill confidence in our security posture and reinforce our commitment to safeguarding sensitive data, critical assets, and the integrity of our digital infrastructure.
 
         Additionally, it is highly recommended that antivirus signatures are updated daily to ensure protection against the latest threats. For instance, Windows Defender signatures can be updated using the following PowerShell command:
-  
+
         ```powershell
         Update-MpSignature
         ```
@@ -86,9 +86,9 @@ queries:
   - uid: mondoo-edr-policy-ensure-edr-agent-is-installed-macos
     filters: asset.platform == 'macos'
     mql: |
-      package('Falcon').installed || 
-      package('SentinelOne Extensions').installed || 
-      package('ESET Endpoint Security').installed || 
+      package('Falcon').installed ||
+      package('SentinelOne Extensions').installed ||
+      package('ESET Endpoint Security').installed ||
       file('/Library/Ossec').exists ||
       ['Cortex XDR', 'Cortex XDR Agent'].all(package(_).installed)
   - uid: mondoo-edr-policy-ensure-edr-agent-is-installed-linux

--- a/core/mondoo-email-security.mql.yaml
+++ b/core/mondoo-email-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         This policy bundle verifies best practices for authenticating email messages using security protocols such as Sender Policy Framework (SPF), Domain Keys Identified Mail (DKIM), and Domain-based Message Authentication, Reporting & Conformance (DMARC).
 
         ### Running the Policy

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |-
-        ## Overview
-
         The Mondoo Google Cloud Security policy provides guidance for establishing minimum recommended security and operational best practices for Google Cloud.
 
         ## Remote scan

--- a/core/mondoo-github-best-practices.mql.yaml
+++ b/core/mondoo-github-best-practices.mql.yaml
@@ -18,16 +18,6 @@ policies:
 
         The Mondoo GitHub Repository Best Practices policy provides assessments of public and private GitHub repositories to ensure a minimum recommended operational best practices.
 
-        ## About remote scanning
-
-        Remote scans with cnspec provide on demand security assessments of infrastructure and services without the need to install any agents or integrations. cnspec comes with a growing list of providers to connect and scan local and remote targets.
-
-        A complete list of providers can be found by running this command:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### cnspec GitHub provider
 
         This policy uses the `github` provider to authenticate with GitHub's API in order to remotely scan GitHub repositories. Additional information on the `github` provider can be found by running this command:

--- a/core/mondoo-github-security.mql.yaml
+++ b/core/mondoo-github-security.mql.yaml
@@ -16,16 +16,6 @@ policies:
       desc: |
         The Mondoo GitHub Organization Security policy provides guidance for establishing minimum recommended security and operational best practices for GitHub organizations.
 
-        ## About remote scanning
-
-        Remote scans with cnspec provide on demand security assessments of infrastructure and services without installing any agents or integrations. cnspec comes with a growing list of providers to connect and scan local and remote targets.
-
-        A complete list of providers can be found by running this command:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### cnspec GitHub provider
 
         This policy uses the `github` provider to authenticate with GitHub's API in order to remotely scan GitHub organizations. Additional information on the `github` provider can be found by running this command:
@@ -102,16 +92,6 @@ policies:
         # Overview
 
         GitHub Repository Security by Mondoo provides security assessments of public and private GitHub repositories to ensure minimum recommended security and operational best practices. This policy is also designed to assess public repositories and open source projects your team depends on to evaluate the risk a project poses to your business. Open source projects that do not adhere to GitHub's recommended security best practices pose a higher risk of malicious code making its way into your environments.
-
-        ## About remote scanning
-
-        Remote scans with cnspec provide on demand security assessments of infrastructure and services without installing any agents or integrations. cnspec comes with a growing list of providers to connect and scan local and remote targets.
-
-        A complete list of providers can be found by running this command:
-
-        ```bash
-        cnspec scan --help
-        ```
 
         ### cnspec GitHub Provider
 

--- a/core/mondoo-github-security.mql.yaml
+++ b/core/mondoo-github-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         The Mondoo GitHub Organization Security policy provides guidance for establishing minimum recommended security and operational best practices for GitHub organizations.
 
         ## About remote scanning

--- a/core/mondoo-gitlab-security.mql.yaml
+++ b/core/mondoo-gitlab-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         The Mondoo GitLab Security policy offers guidance on establishing minimum recommended security best practices for GitLab groups and projects.
 
         ## Remote scan

--- a/core/mondoo-gitlab-security.mql.yaml
+++ b/core/mondoo-gitlab-security.mql.yaml
@@ -16,16 +16,6 @@ policies:
       desc: |
         The Mondoo GitLab Security policy offers guidance on establishing minimum recommended security best practices for GitLab groups and projects.
 
-        ## Remote scan
-
-        Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
-
-        A complete list of providers can be found by running this command:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Prerequisites
 
         Remote scans of GitLab require a [personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) with access to the group and projects you plan to scan.

--- a/core/mondoo-http-security.mql.yaml
+++ b/core/mondoo-http-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         The Mondoo HTTP Security policy includes checks for ensuring the security of HTTP headers.
 
         ## Remote scan

--- a/core/mondoo-kubernetes-best-practices.mql.yaml
+++ b/core/mondoo-kubernetes-best-practices.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |-
-        ## Overview
-
         The Mondoo Kubernetes Best Practices policy bundle provides guidance for establishing reliable Kubernetes clusters by encouraging the adoption of best practices.
 
         ## Remote scan

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -553,6 +553,8 @@ queries:
     docs:
       desc: |-
         File Transfer Protocol (FTP) servers enables the transfer of files between computers over a network, supporting file upload, download, and management.
+
+        FTP transmits data—including usernames and passwords—in plaintext. If possible use more secure protocols such as FTPS or SFTP, which encrypt the entire session, ensuring that sensitive information and files remain secure from unauthorized access.
       remediation: |-
         Run this command to stop and disable `vsftpd`, `proftpd`, and `pure-ftpd`:
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1578,10 +1578,7 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/sysconfig\/network\s+\-p\s+wa\s+\-k\s+system-locale(\s+)?$/))
     docs:
       desc: |-
-        Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name)
-        or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the `/etc/issue`
-        and `/etc/issue.net` files (messages displayed pre-login), `/etc/hosts` (file containing host names and associated IP addresses) and `/etc/sysconfig/network`
-        (directory containing network interface scripts and configurations) files.
+        Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the `/etc/issue` and `/etc/issue.net` files (messages displayed pre-login), `/etc/hosts` (file containing host names and associated IP addresses) and `/etc/sysconfig/network` (directory containing network interface scripts and configurations) files.
       remediation: |-
         For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -1622,9 +1619,7 @@ queries:
         -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
 
         -w /etc/issue -p wa -k system-locale
-
         -w /etc/issue.net -p wa -k system-locale
-
         -w /etc/hosts -p wa -k system-locale
         ```
 
@@ -1672,11 +1667,7 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+setxattr(\s+\-S\s+|,)lsetxattr(\s+\-S\s+|,)fsetxattr(\s+\-S\s+|,)removexattr(\s+\-S\s+|,)lremovexattr(\s+\-S\s+|,)fremovexattr\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-F\s+\-k\s+perm\_mod(\s+)?$/))
     docs:
       desc: |-
-        Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes.
-        The `chmod`, `fchmod` and `fchmodat` system calls affect the permissions associated with a file. The `chown`, `fchown`, `fchownat` and `lchown`
-        system calls affect owner and group attributes on a file. The `setxattr`, `lsetxattr`, `fsetxattr` (set extended file attributes) and `removexattr`,
-        `lremovexattr`, `fremovexattr` (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written
-        for non-system user ids (auid >= 1000) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier "perm_mod."
+        Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The `chmod`, `fchmod` and `fchmodat` system calls affect the permissions associated with a file. The `chown`, `fchown`, `fchownat` and `lchown` system calls affect owner and group attributes on a file. The `setxattr`, `lsetxattr`, `fsetxattr` (set extended file attributes) and `removexattr`, `lremovexattr`, `fremovexattr` (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system user ids (auid >= 1000) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier "perm_mod."
 
         **Note:**
         Systems may have been customized to change the default UID_MIN. To confirm the UID_MIN for your system, run this command:
@@ -1695,9 +1686,7 @@ queries:
 
         ```
         -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
-
         -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
-
         -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
         ```
 
@@ -1709,15 +1698,10 @@ queries:
 
         ```
         -a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
-
         -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
-
         -a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
-
         -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
-
         -a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
-
         -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
         ```
 
@@ -1749,10 +1733,7 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+creat\s+\-S\s+open\s+\-S\s+openat\s+\-S\s+truncate\s+\-S\s+ftruncate\s+\-F\s+exit\=\-EPERM\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+access(\s+)?$/)) || props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+creat\s+\-S\s+open\s+\-S\s+openat\s+\-S\s+truncate\s+\-S\s+ftruncate\s+\-F\s+exit\=\-EPERM\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+access(\s+)?$/))
     docs:
       desc: |-
-        Monitor for unsuccessful attempts to access files. The parameters below are associated with system calls that control creation ( `creat` ), opening ( `open`, `openat` ) and
-        truncation ( `truncate`, `ftruncate` ) of files. An audit log record will only be written if the user is a non-privileged user (auid > = 1000), is not a Daemon event
-        (auid=4294967295) and if the system call returned EACCES (permission denied to the file) or EPERM (some other permanent error associated with the specific system call).
-        All audit records will be tagged with the identifier "access."
+        Monitor for unsuccessful attempts to access files. The parameters below are associated with system calls that control creation ( `creat` ), opening ( `open`, `openat` ) and truncation ( `truncate`, `ftruncate` ) of files. An audit log record will only be written if the user is a non-privileged user (auid > = 1000), is not a Daemon event (auid=4294967295) and if the system call returned EACCES (permission denied to the file) or EPERM (some other permanent error associated with the specific system call). All audit records will be tagged with the identifier "access."
 
         **Note:**
         Systems may have been customized to change the default UID_MIN. To confirm the UID_MIN for your system, run this command:
@@ -1771,7 +1752,6 @@ queries:
 
         ```
         -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
-
         -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
         ```
 
@@ -1783,11 +1763,8 @@ queries:
 
         ```
         -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
-
         -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
-
         -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
-
         -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
         ```
 
@@ -1798,7 +1775,6 @@ queries:
         ```
 
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
-
 
         Check if a reboot is required, in case the running configuration is set to be immutable:
 
@@ -1822,9 +1798,7 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/security\/opasswd\s+\-p\s+wa\s+\-k\s+identity(\s+)?$/))
     docs:
       desc: |-
-        Record events affecting the `group`, `passwd` (user IDs), `shadow` and `gshadow` (passwords) or `/etc/security/opasswd`
-        (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch
-        the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier "identity" in the audit log file.
+        Record events affecting the `group`, `passwd` (user IDs), `shadow` and `gshadow` (passwords) or `/etc/security/opasswd` (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier "identity" in the audit log file.
       remediation: |-
         Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -1834,13 +1808,9 @@ queries:
 
         ```
         -w /etc/group -p wa -k identity
-
         -w /etc/passwd -p wa -k identity
-
         -w /etc/gshadow -p wa -k identity
-
         -w /etc/shadow -p wa -k identity
-
         -w /etc/security/opasswd -p wa -k identity
         ```
 
@@ -1851,7 +1821,6 @@ queries:
         ```
 
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
-
 
         Check if a reboot is required, in case the running configuration is set to be immutable:
 
@@ -1871,10 +1840,7 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+mount\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+mounts(\s+)?$/)) || props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+mount\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+mounts(\s+)?$/))
     docs:
       desc: |-
-        Monitor the use of the `mount`
-        system call. The `mount`
-        (and `umount`
-        ) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user
+        Monitor the use of the `mount` system call. The `mount` (and `umount`) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user
       remediation: |-
         For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -1894,7 +1860,6 @@ queries:
 
         ```
         -a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts
-
         -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts
         ```
 
@@ -1905,7 +1870,6 @@ queries:
         ```
 
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
-
 
         Check if a reboot is required, in case the running configuration is set to be immutable:
 
@@ -1926,8 +1890,7 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+rename\,unlink\,unlinkat\,renameat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=unset\s+\-F\s+key\=delete(\s+)?$/)) || props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+unlink\s+\-S\s+unlinkat\s+\-S\s+rename\s+\-S\s+renameat\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+delete(\s+)?$/))
     docs:
       desc: |-
-        Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for the `unlink`
-        (remove a file), `unlinkat` (remove a file attribute), `rename` (rename a file) and `renameat` (rename a file attribute) system calls and tags them with the identifier "delete".
+        Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for the `unlink` (remove a file), `unlinkat` (remove a file attribute), `rename` (rename a file) and `renameat` (rename a file attribute) system calls and tags them with the identifier "delete".
 
         **Note:**
         Systems may have been customized to change the default UID_MIN. To confirm the UID_MIN for your system, run this command:
@@ -1956,7 +1919,6 @@ queries:
 
         ```
         -a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete
-
         -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete
         ```
 
@@ -1967,7 +1929,6 @@ queries:
         ```
 
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
-
 
         Check if a reboot is required, in case the running configuration is set to be immutable:
 
@@ -1990,12 +1951,7 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-a\s+always,exit\s+\-F\s+arch\=b64\s+\-S\s+init\_module\s+\-S\s+delete\_module\s+\-k\s+modules(\s+)?$/)) || props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-a\s+always,exit\s+\-F\s+arch\=b32\s+\-S\s+init\_module\s+\-S\s+delete\_module\s+\-k\s+modules(\s+)?$/))
     docs:
       desc: |-
-        Monitor the loading and unloading of kernel modules. The programs `insmod`
-        (install a kernel module), `rmmod`
-        (remove a kernel module), and `modprobe`
-        (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The `init_module`
-        (load a module) and `delete_module`
-        (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of "modules".
+        Monitor the loading and unloading of kernel modules. The programs `insmod` (install a kernel module), `rmmod` (remove a kernel module), and `modprobe` (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The `init_module` (load a module) and `delete_module` (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of "modules".
       remediation: |-
         For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -2005,11 +1961,8 @@ queries:
 
         ```
         -w /sbin/insmod -p x -k modules
-
         -w /sbin/rmmod -p x -k modules
-
         -w /sbin/modprobe -p x -k modules
-
         -a always,exit -F arch=b32 -S init_module -S delete_module -k modules
         ```
 
@@ -2021,11 +1974,8 @@ queries:
 
         ```
         -w /sbin/insmod -p x -k modules
-
         -w /sbin/rmmod -p x -k modules
-
         -w /sbin/modprobe -p x -k modules
-
         -a always,exit -F arch=b64 -S init_module -S delete_module -k modules
         ```
 
@@ -2036,7 +1986,6 @@ queries:
         ```
 
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
-
 
         Check if a reboot is required, in case the running configuration is set to be immutable:
 
@@ -2056,11 +2005,7 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-w\s+\/var\/log\/sudo\.log\s+\-p\s+wa\s+\-k\s+actions(\s+)?$/))
     docs:
       desc: |-
-        Monitor the `sudo` log file. If the system has been properly configured to disable the use of the `su`
-        command and force all administrators to have to log in first and then use `sudo`
-        to execute privileged commands, then all administrator commands will be logged to `/var/log/sudo.log`
-        . Any time a command is executed, an audit event will be triggered as the `/var/log/sudo.log`
-        file will be opened for write and the executed administration command will be written to the log.
+        Monitor the `sudo` log file. If the system has been properly configured to disable the use of the `su` command and force all administrators to have to log in first and then use `sudo` to execute privileged commands, then all administrator commands will be logged to `/var/log/sudo.log`. Any time a command is executed, an audit event will be triggered as the `/var/log/sudo.log` file will be opened for write and the executed administration command will be written to the log.
       remediation: |
         Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules` and add the following line:
 
@@ -2083,7 +2028,6 @@ queries:
         ```
 
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
-
 
         Check if a reboot is required, in case the running configuration is set to be immutable:
 
@@ -2118,7 +2062,6 @@ queries:
         ```
 
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
-
 
         Check if a reboot is required, in case the running configuration is set to be immutable:
 
@@ -2178,10 +2121,7 @@ queries:
       package("rsyslog").installed
     docs:
       desc: |-
-        The `rsyslog`
-        software is a recommended replacement to the original `syslogd`
-        daemon which provide improvements over `syslogd`
-        , such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server.
+        The `rsyslog` software is a recommended replacement to the original `syslogd` daemon which provide improvements over `syslogd`, such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server.
       remediation: |-
         Run this command to install rsyslog:
 
@@ -2209,8 +2149,7 @@ queries:
     docs:
       desc: rsyslog will create log files that do not already exist on the system. This setting controls what permissions will be applied to these newly created files.
       remediation: |-
-        Edit the `/etc/rsyslog.conf` and `/etc/rsyslog.d/*.conf`
-        files and set `$FileCreateMode` to `0640` or more restrictive:
+        Edit the `/etc/rsyslog.conf` and `/etc/rsyslog.d/*.conf` files and set `$FileCreateMode` to `0640` or more restrictive:
 
         ```
         $FileCreateMode 0640
@@ -2226,8 +2165,7 @@ queries:
       }
     docs:
       desc: |-
-        Data from journald may be stored in volatile memory or persisted locally on the server. Utilities exist to accept remote export of journald logs,
-        however, use of the rsyslog service provides a consistent means of log collection and export.
+        Data from journald may be stored in volatile memory or persisted locally on the server. Utilities exist to accept remote export of journald logs, however, use of the rsyslog service provides a consistent means of log collection and export.
       remediation: |-
         Edit the `/etc/systemd/journald.conf` file and add the following line:
 
@@ -2682,7 +2620,6 @@ queries:
 
         ```
         chown root:root /etc/passwd
-
         chmod 644 /etc/passwd
         ```
   - uid: mondoo-linux-security-permissions-on-etcshadow-are-configured
@@ -2702,11 +2639,10 @@ queries:
     docs:
       desc: The `/etc/shadow` file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information.
       remediation: |-
-        Run these commands to set permissions on `/etc/shadow` :
+        Run these commands to set permissions on `/etc/shadow`:
 
         ```
         chown root:root /etc/shadow
-
         chmod 640 /etc/shadow
         ```
   - uid: mondoo-linux-security-permissions-on-etcgroup-are-configured
@@ -2723,11 +2659,10 @@ queries:
     docs:
       desc: The `/etc/group` file contains a list of all the valid groups defined in the system. This file should have read/write access for root and read access for all other users to prevent non-administrative users from modifying groups.
       remediation: |-
-        Run this command to set permissions on `/etc/group` :
+        Run this command to set permissions on `/etc/group`:
 
         ```
         chown root:root /etc/group
-
         chmod 644 /etc/group
         ```
   - uid: mondoo-linux-security-permissions-on-etcgshadow-are-configured
@@ -2747,11 +2682,10 @@ queries:
     docs:
       desc: The `/etc/gshadow` file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information.
       remediation: |-
-        Run the following chown to set permissions on `/etc/gshadow` :
+        Run the following chown to set permissions on `/etc/gshadow`:
 
         ```
         chown root:root /etc/gshadow
-
         chmod 640 /etc/gshadow
         ```
   - uid: mondoo-linux-security-permissions-on-etcpasswd--are-configured
@@ -2772,11 +2706,10 @@ queries:
     docs:
       desc: The `/etc/passwd-` file contains backup user account information.
       remediation: |-
-        Run this command to set permissions on `/etc/passwd-` :
+        Run this command to set permissions on `/etc/passwd-`:
 
         ```
         chown root:root /etc/passwd-
-
         chmod 600 /etc/passwd-
         ```
 
@@ -2806,7 +2739,6 @@ queries:
 
         ```
         chown root:root /etc/shadow-
-
         chmod 640 /etc/shadow-
         ```
 
@@ -2837,7 +2769,6 @@ queries:
 
         ```
         chown root:root /etc/group-
-
         chmod 600 /etc/group-
         ```
 
@@ -2867,7 +2798,6 @@ queries:
 
         ```
         chown root:root /etc/gshadow-
-
         chmod 640 /etc/gshadow-
         ```
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -4,7 +4,7 @@
 policies:
   - uid: mondoo-linux-security
     name: Mondoo Linux Security
-    version: 2.4.1
+    version: 2.5.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -73,25 +73,14 @@ policies:
           - uid: mondoo-linux-security--window-system-is-not-installed
           - uid: mondoo-linux-security-address-space-layout-randomization-aslr-is-enabled
           - uid: mondoo-linux-security-aide-is-installed
-          - uid: mondoo-linux-security-avahi-server-is-not-enabled
           - uid: mondoo-linux-security-bogus-icmp-responses-are-ignored
           - uid: mondoo-linux-security-broadcast-icmp-requests-are-ignored
           - uid: mondoo-linux-security-core-dumps-are-restricted
-          - uid: mondoo-linux-security-cups-is-not-enabled
-          - uid: mondoo-linux-security-dhcp-server-is-not-enabled
-          - uid: mondoo-linux-security-dns-server-is-not-enabled
           - uid: mondoo-linux-security-filesystem-integrity-is-regularly-checked
-          - uid: mondoo-linux-security-ftp-server-is-not-enabled
-          - uid: mondoo-linux-security-http-proxy-server-is-not-enabled
-          - uid: mondoo-linux-security-http-server-is-not-enabled
           - uid: mondoo-linux-security-icmp-redirects-are-not-accepted
-          - uid: mondoo-linux-security-imap-and-pop3-server-is-not-enabled
           - uid: mondoo-linux-security-ip-forwarding-is-disabled
           - uid: mondoo-linux-security-ipv6-router-advertisements-are-not-accepted
-          - uid: mondoo-linux-security-ldap-server-is-not-enabled
           - uid: mondoo-linux-security-mail-transfer-agent-is-configured-for-local-only-mode
-          - uid: mondoo-linux-security-nfs-and-rpc-are-not-enabled
-          - uid: mondoo-linux-security-nis-server-is-not-enabled
           - uid: mondoo-linux-security-packet-redirect-sending-is-disabled
           - uid: mondoo-linux-security-permissions-on-etcgroup--are-configured
           - uid: mondoo-linux-security-permissions-on-etcgroup-are-configured
@@ -103,18 +92,33 @@ policies:
           - uid: mondoo-linux-security-permissions-on-etcshadow-are-configured
           - uid: mondoo-linux-security-prelink-is-disabled
           - uid: mondoo-linux-security-reverse-path-filtering-is-enabled
+          - uid: mondoo-linux-security-secure-icmp-redirects-are-not-accepted
+          - uid: mondoo-linux-security-source-routed-packets-are-not-accepted
+          - uid: mondoo-linux-security-suspicious-packets-are-logged
+          - uid: mondoo-linux-security-tcp-syn-cookies-is-enabled
+      - title: Sensitive Services
+        filters: |
+          asset.family.contains('linux')
+        checks:
+          - uid: mondoo-linux-security-avahi-server-is-not-enabled
+          - uid: mondoo-linux-security-dhcp-server-is-not-enabled
+          - uid: mondoo-linux-security-dns-server-is-not-enabled
+          - uid: mondoo-linux-security-ftp-server-is-not-enabled
+          - uid: mondoo-linux-security-http-proxy-server-is-not-enabled
+          - uid: mondoo-linux-security-http-server-is-not-enabled
+          - uid: mondoo-linux-security-imap-and-pop3-server-is-not-enabled
+          - uid: mondoo-linux-security-ldap-server-is-not-enabled
+          - uid: mondoo-linux-security-nfs-and-rpc-are-not-enabled
+          - uid: mondoo-linux-security-nis-server-is-not-enabled
           - uid: mondoo-linux-security-rsh-server-is-not-enabled
           - uid: mondoo-linux-security-rsync-service-is-not-enabled
           - uid: mondoo-linux-security-samba-is-not-enabled
-          - uid: mondoo-linux-security-secure-icmp-redirects-are-not-accepted
           - uid: mondoo-linux-security-snmp-server-is-not-enabled
-          - uid: mondoo-linux-security-source-routed-packets-are-not-accepted
-          - uid: mondoo-linux-security-suspicious-packets-are-logged
           - uid: mondoo-linux-security-talk-server-is-not-enabled
-          - uid: mondoo-linux-security-tcp-syn-cookies-is-enabled
           - uid: mondoo-linux-security-telnet-server-is-not-enabled
           - uid: mondoo-linux-security-tftp-server-is-not-enabled
-      - title: Configure SSH Server
+          - uid: mondoo-linux-security-cups-is-not-enabled
+      - title: SSH Server Configuration
         filters: |
           asset.family.contains('linux')
           package('openssh-server').installed
@@ -316,13 +320,13 @@ queries:
     docs:
       desc: A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user.
       remediation: |-
-        Add the following line to `/etc/security/limits.conf` or a `/etc/security/limits.d/\*` file:
+        Add the following line to `/etc/security/limits.conf` or a `/etc/security/limits.d/` file:
 
         ```
         * hard core 0
         ```
 
-        Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/\*` file:
+        Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
         ```
         fs.suid_dumpable = 0
@@ -359,7 +363,7 @@ queries:
     docs:
       desc: Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process.
       remediation: |-
-        Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/\*` file:
+        Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
         ```
         kernel.randomize_va_space = 2
@@ -809,7 +813,7 @@ queries:
     docs:
       desc: The `net.ipv4.ip_forward` and `net.ipv6.conf.all.forwarding` flags are used to tell the system whether it can forward packets or not.
       remediation: |-
-        Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/\*` file:
+        Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
         ```
         net.ipv4.ip_forward = 0
@@ -840,7 +844,7 @@ queries:
     docs:
       desc: ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host-only configuration), there is no need to send redirects.
       remediation: |-
-        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/\*` file:
+        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
         ```
         net.ipv4.conf.all.send_redirects = 0
@@ -873,7 +877,7 @@ queries:
     docs:
       desc: In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used.
       remediation: |-
-        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/\*` file:
+        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
         ```
         net.ipv4.conf.all.accept_source_route = 0
@@ -911,7 +915,7 @@ queries:
     docs:
       desc: ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables. By setting `net.ipv4.conf.all.accept_redirects` and `net.ipv6.conf.all.accept_redirects` to 0, the system will not accept any ICMP redirect messages, and therefore, won't allow outsiders to update the system's routing tables.
       remediation: |-
-        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/\*` file:
+        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
         ```
         net.ipv4.conf.all.accept_redirects = 0
@@ -946,7 +950,7 @@ queries:
     docs:
       desc: Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system and are likely to be secure.
       remediation: |-
-        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/\*` file:
+        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
         ```
         net.ipv4.conf.all.secure_redirects = 0
@@ -972,7 +976,7 @@ queries:
     docs:
       desc: When enabled, this feature logs packets with un-routable source addresses to the kernel log.
       remediation: |-
-        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/\*` or in /etc/ufw/sysctl.conf file:
+        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` or in /etc/ufw/sysctl.conf file:
 
         ```
         net.ipv4.conf.all.log_martians = 1
@@ -999,7 +1003,7 @@ queries:
     docs:
       desc: Setting `net.ipv4.icmp_echo_ignore_broadcasts` to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses.
       remediation: |-
-        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/\*` file:
+        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
         ```
         net.ipv4.icmp_echo_ignore_broadcasts = 1
@@ -1022,7 +1026,7 @@ queries:
     docs:
       desc: Setting `icmp_ignore_bogus_error_responses` to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages.
       remediation: |-
-        Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/\*` file:
+        Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
         ```
         net.ipv4.icmp_ignore_bogus_error_responses = 1
@@ -1046,7 +1050,7 @@ queries:
     docs:
       desc: Setting `net.ipv4.conf.all.rp_filter`and `net.ipv4.conf.default.rp_filter` to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if `log_martians` is set).
       remediation: |-
-        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/\*` file:
+        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
         ```
         net.ipv4.conf.all.rp_filter = 1
@@ -1071,7 +1075,7 @@ queries:
     docs:
       desc: When `tcp_syncookies` is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN\|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the system to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue.
       remediation: |-
-        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/\*` file:
+        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
         ```
         net.ipv4.tcp_syncookies = 1
@@ -1097,7 +1101,7 @@ queries:
     docs:
       desc: This setting disables the system's ability to accept IPv6 router advertisements.
       remediation: |-
-        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/\*` file:
+        Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
         ```
         net.ipv6.conf.all.accept_ra = 0

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -406,6 +406,11 @@ queries:
         ```
         apt-get purge xserver-xorg
         ```
+
+        ### SLES and openSUSE
+        ```
+        zypper remove xorg-x11-server
+        ```
   - uid: mondoo-linux-security-avahi-server-is-not-enabled
     title: Ensure Avahi server is stopped and not enabled
     impact: 100

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |-
-        ## Overview
-
         The Mondoo Linux Security policy provides guidance for establishing a secure baseline configuration for Linux systems running on x86 and x64 platforms.
 
         This policy includes queries to help harden Linux systems by:

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -719,14 +719,19 @@ queries:
     mql: |
       service("ypserv").enabled == false
       service("ypserv").running == false
+      service("nis").enabled == false
+      service("nis").running == false
     docs:
       desc: The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files.
       remediation: |-
-        Run this command to stop and disable `ypserv`:
+        Run this command to stop and disable `ypserv` and `nis` services:
 
         ```
         systemctl stop ypserv
+        systemctl stop nis
+
         systemctl disable ypserv
+        systemctl disable nis
         ```
   - uid: mondoo-linux-security-rsh-server-is-not-enabled
     title: Ensure rsh server is stopped and not enabled

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2107,8 +2107,7 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/(\s+)?\-e\s+2(\s+)?$/))
     docs:
       desc: |-
-        Set system audit so that audit rules cannot be modified with `auditctl`
-        . Setting the flag "-e 2" forces audit to be put in immutable mode. Audit changes can only be made on system reboot.
+        Set system audit so that audit rules cannot be modified with `auditctl`. Setting the flag "-e 2" forces audit to be put in immutable mode. Audit changes can only be made on system reboot.
       remediation: |-
         Edit or create the file `/etc/audit/audit.rules` and add the following line at the end of the file:
 
@@ -2121,6 +2120,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 
@@ -3061,7 +3061,7 @@ queries:
   - uid: mondoo-linux-security-access-to-the-su-command-is-restricted
     title: Ensure access to the su command is restricted
     impact: 80
-    filters: | 
+    filters: |
       asset.kind != "container-image"
     props:
       - uid: mondooLinuxSecuritySudoGroup

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1310,9 +1310,7 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/sudoers(\/?)\s+\-p\s+wa\s+\-k\s+scope(\s+)?$/))
     docs:
       desc: |-
-        Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the `sudo`
-        command to execute privileged commands, it is possible to monitor changes in scope. The file `/etc/sudoers`
-        will be written to when the file or its attributes have changed. The audit records will be tagged with the identifier "scope."
+        Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the `sudo` command to execute privileged commands, it is possible to monitor changes in scope. The file `/etc/sudoers` will be written to when the file or its attributes have changed. The audit records will be tagged with the identifier "scope."
       remediation: |-
         Edit or create a file in the `/etc/audit/rules.d/`
         directory ending in `.rules`
@@ -1332,6 +1330,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
         Check if a reboot is required, in case the running configuration is set to be immutable:

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2630,7 +2630,10 @@ queries:
         }
       }
     docs:
-      desc: The `/etc/gshadow` file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information.
+      desc: |-
+        The `/etc/gshadow` file stores hashed group passwords. It serves as a companion to `/etc/group`, which lists groups and membership, but not sensitive password information.
+
+        If an attacker gains access to `/etc/gshadow` file, they could potentially crack the group passwords to gain elevated access across the system.
       remediation: |-
         Run the following chown to set permissions on `/etc/gshadow`:
 
@@ -2654,7 +2657,8 @@ queries:
         }
       }
     docs:
-      desc: The `/etc/passwd-` file contains backup user account information.
+      desc: |-
+        The `/etc/passwd-`` file in Linux is a backup copy of the main `/etc/passwd` file, which contains essential information about system users. The `-` suffix signifies that this file is a backup and is created automatically by the system when there are changes made to the /etc/passwd file, such as adding or deleting a user.
       remediation: |-
         Run this command to set permissions on `/etc/passwd-`:
 
@@ -2742,7 +2746,10 @@ queries:
         }
       }
     docs:
-      desc: The `/etc/gshadow-` file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information.
+      desc: |-
+        The `/etc/gshadow-` file in is a backup of `/etc/gshadow` file, which contains group password information. This file stores information about group administrators, group members, and encrypted group passwords.
+
+        If an attacker gains access to `/etc/gshadow-`, they could potentially crack the group passwords to gain elevated access across the system.
       remediation: |-
         Run these commands to set permissions on `/etc/gshadow-`:
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1379,6 +1379,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 
@@ -1408,8 +1409,7 @@ queries:
         login attempts and can be read by entering the command `/usr/bin/last -f /var/log/btmp`. All audit records will be tagged with
         the identifier "logins."
       remediation: |-
-        Edit or create a file in the `/etc/audit/rules.d/`
-        directory ending in `.rules`
+        Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
         Example: `vi /etc/audit/rules.d/50-session.rules`
 
@@ -1428,6 +1428,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 
@@ -1460,8 +1461,7 @@ queries:
         (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the `/var/log/audit.log`
         file upon exit, tagging the records with the identifier "time-change"
       remediation: |-
-        For 32-bit systems edit or create a file in the `/etc/audit/rules.d/`
-        directory ending in `.rules`_
+        For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`_
 
         Example: `vi /etc/audit/rules.d/50-time_change.rules`
 
@@ -1475,8 +1475,7 @@ queries:
         -w /etc/localtime -p wa -k time-change
         ```
 
-        For 64-bit systems edit or create a file in the `/etc/audit/rules.d/`
-        directory ending in `.rules`
+        For 64-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
         Example: `vi /etc/audit/rules.d/50-time_change.rules`
 
@@ -1499,6 +1498,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 
@@ -1527,8 +1527,7 @@ queries:
         Monitor SELinux/AppArmor mandatory access controls. The parameters below monitor any write access (potential additional,
         deletion or modification of files in the directory) or attribute changes to the /etc/selinux or /etc/apparmor and /etc/apparmor.d directories.
       remediation: |-
-        Edit or create a file in the `/etc/audit/rules.d/`
-        directory ending in `.rules`
+        Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
         Example: `vi /etc/audit/rules.d/50-MAC_policy.rules`
 
@@ -1553,6 +1552,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 
@@ -1611,8 +1611,7 @@ queries:
         -w /etc/network -p wa -k system-locale
         ```
 
-        For 64-bit systems edit or create a file in the `/etc/audit/rules.d/`
-        directory ending in `.rules`
+        For 64-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
         Example: `vi /etc/audit/rules.d/50-system_local.rules`
 
@@ -1646,6 +1645,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 
@@ -1687,8 +1687,7 @@ queries:
 
         If your systems' UID_MIN is not `1000`, replace `audit>=1000` with `audit>=<UID_MIN for your system>` in the Audit and Remediation procedures.
       remediation: |-
-        For 32-bit systems edit or create a file in the `/etc/audit/rules.d/`
-        directory ending in `.rules`
+        For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
         Example: `vi /etc/audit/rules.d/50-perm_mod.rules`
 
@@ -1727,6 +1726,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 
@@ -1763,8 +1763,7 @@ queries:
 
         If your systems' UID_MIN is not `1000`, replace `audit>=1000` with `audit>=<UID_MIN for your system>` in the Audit and Remediation procedures.
       remediation: |-
-        For 32-bit systems edit or create a file in the `/etc/audit/rules.d/`
-        directory ending in `.rules`
+        For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
         Example: `vi /etc/audit/rules.d/50-access.rules`
 
@@ -1776,8 +1775,7 @@ queries:
         -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
         ```
 
-        For 64-bit systems edit or create a file in the `/etc/audit/rules.d/`
-        directory ending in `.rules`
+        For 64-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
         Example: `vi /etc/audit/rules.d/50-access.rules`
 
@@ -1798,6 +1796,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 
@@ -1850,6 +1849,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 
@@ -1903,6 +1903,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 
@@ -1964,6 +1965,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 
@@ -2032,6 +2034,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 
@@ -2078,6 +2081,7 @@ queries:
         ```
         augenrules --load
         ```
+
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -210,14 +210,9 @@ queries:
         yum install aide
         ```
 
-        # Ubuntu
+        # Debian/Ubuntu
         ```
         apt-get install aide
-        ```
-
-        # Debian
-        ```
-        apt install aide
         ```
 
         # SLES and openSUSE
@@ -391,7 +386,7 @@ queries:
         yum remove prelink
         ```
 
-        ### Ubuntu/Debian
+        ### Debian/Ubuntu and derivatives
         ```
         prelink -ua
 
@@ -857,7 +852,6 @@ queries:
 
         ```
         net.ipv4.conf.all.send_redirects = 0
-
         net.ipv4.conf.default.send_redirects = 0
         ```
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -435,6 +435,7 @@ queries:
         ```
 
         Note: Since the `avahi-daemon` service is often interdependent with other services, it might not be enough to disable the service because other services will likely restart the service automatically.
+
         To make the service `avahi-daemon` invisible to other services run this command :
 
         ```
@@ -459,9 +460,12 @@ queries:
         ```
 
         Note: Since the `cups` service is often interdependent with other services, it might not be enough to disable the service because other services such as `cups-browsed` will likely restart the service automatically.
+
         To make the service `cups` invisible to other services run this command :
 
-        `systemctl mask cups`
+        ```
+        systemctl mask cups
+        ```
 
         **Impact:**
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -203,7 +203,7 @@ queries:
     docs:
       desc: Advanced Intrusion Detection Environment (AIDE) takes a snapshot of the filesystem state, including modification times, permissions, and file hashes. Administrators can then use this to compare against the current state of the filesystem to detect modifications to the system.
       remediation: |-
-        Run this command to install `aide` :
+        Run this command to install `aide`:
 
         # RHEL/Fedora/Amazon Linux and derivatives
         ```
@@ -427,7 +427,7 @@ queries:
     docs:
       desc: Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine.
       remediation: |-
-        Run this command to stop and disable `avahi-daemon` :
+        Run this command to stop and disable `avahi-daemon`:
 
         ```
         systemctl stop avahi-daemon
@@ -452,7 +452,7 @@ queries:
     docs:
       desc: The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability.
       remediation: |-
-        Run this command to stop and disable `cups` :
+        Run this command to stop and disable `cups`:
 
         ```
         systemctl stop cups
@@ -481,7 +481,7 @@ queries:
     docs:
       desc: The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses.
       remediation: |-
-        Run this command to stop and disable `dhcpd` :
+        Run this command to stop and disable `dhcpd`:
 
         ```
         systemctl stop dhcpd
@@ -498,7 +498,7 @@ queries:
     docs:
       desc: The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database.
       remediation: |-
-        Run this command to stop and disable `slapd` :
+        Run this command to stop and disable `slapd`:
 
         ```
         systemctl stop slapd
@@ -537,7 +537,7 @@ queries:
     docs:
       desc: The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network.
       remediation: |-
-        Run this command to stop and disable `named` :
+        Run this command to stop and disable `named`:
 
         ```
         systemctl stop named
@@ -554,7 +554,7 @@ queries:
     docs:
       desc: The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files.
       remediation: |-
-        Run this command to stop and disable `vsftpd` :
+        Run this command to stop and disable `vsftpd`:
 
         ```
         systemctl stop vsftpd
@@ -684,7 +684,7 @@ queries:
       }
       ports.listening.where(address != "127.0.0.1" && address != "::1").none(port == 25)
     docs:
-      desc: Mail Transfer Agents (MTA), such as Sendmail and Postfix, listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail.
+      desc: Mail Transfer Agents (MTA), such as Exim and Postfix, listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail.
       remediation: |-
         Edit `/etc/postfix/main.cf` and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below:
 
@@ -708,7 +708,7 @@ queries:
     docs:
       desc: The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files.
       remediation: |-
-        Run this command to stop and disable `ypserv` :
+        Run this command to stop and disable `ypserv`:
 
         ```
         systemctl stop ypserv
@@ -729,7 +729,7 @@ queries:
     docs:
       desc: The Berkeley `rsh-server` ( `rsh`, `rlogin`, `rexec` ) package contains legacy services that exchange credentials in clear-text.
       remediation: |-
-        Run these commands to stop and disable `rsh`, `rlogin`, and `rexec` :
+        Run these commands to stop and disable `rsh`, `rlogin`, and `rexec`:
 
         ```
         systemctl stop rsh.socket
@@ -785,7 +785,7 @@ queries:
     docs:
       desc: The `rsyncd` service can be used to synchronize files between systems over network links.
       remediation: |-
-        Run this command to stop and disable `rsync` :
+        Run this command to stop and disable `rsync`:
 
         ```
         systemctl stop rsyncd
@@ -1131,7 +1131,8 @@ queries:
       package("auditd").installed && package("audispd-plugins").installed
       || package("audit").installed || package("audit-libs").installed
     docs:
-      desc: auditd is the user space component to the Linux Auditing System. It's responsible for writing audit records to the disk
+      desc: |-
+        `auditd` is the user space component to the Linux Auditing System. It's responsible for writing audit records to the disk.
       remediation: |-
         Run this command to install auditd with dnf
 
@@ -2711,7 +2712,7 @@ queries:
     docs:
       desc: The `/etc/group-` file contains a backup list of all the valid groups defined in the system. Only the root user should have read and write permissions on this file so that group names an user membership is not available to non-administrative users on the system.
       remediation: |-
-        Run this command to set permissions on `/etc/group-` :
+        Run this command to set permissions on `/etc/group-`:
 
         ```
         chown root:root /etc/group-
@@ -2740,7 +2741,7 @@ queries:
     docs:
       desc: The `/etc/gshadow-` file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information.
       remediation: |-
-        Run these commands to set permissions on `/etc/gshadow-` :
+        Run these commands to set permissions on `/etc/gshadow-`:
 
         ```
         chown root:root /etc/gshadow-
@@ -2827,7 +2828,7 @@ queries:
       desc: |
         The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user.
       remediation: |
-        Run this command to set the `root` user default group to GID `0` :
+        Run this command to set the `root` user default group to GID `0`:
 
         ```
         usermod -g 0 root

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1135,16 +1135,23 @@ queries:
       desc: |-
         `auditd` is the user space component to the Linux Auditing System. It's responsible for writing audit records to the disk.
       remediation: |-
-        Run this command to install auditd with dnf
+        Run this command to install `auditd`:
 
+        ### Debian/Ubuntu and derivatives
+
+        ### RHEL/Fedora/Amazon Linux and derivatives
         ```
         dnf install audit audit-libs
         ```
 
-        Run this command to install auditd with apt
-
+        ### Debian/Ubuntu
         ```
         apt install auditd audispd-plugins
+        ```
+
+        ### SLES and openSUSE
+        ```
+        zypper install audit
         ```
   - uid: mondoo-linux-security-auditd-service-is-enabled
     title: Ensure auditd service is enabled

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -539,21 +539,32 @@ queries:
         systemctl disable named
         ```
   - uid: mondoo-linux-security-ftp-server-is-not-enabled
-    title: Ensure FTP server is stopped and not enabled
+    title: Ensure FTP servers are stopped and not enabled
     impact: 60
     filters: |
       asset.kind != "container-image"
     mql: |
       service("vsftpd").enabled == false
       service("vsftpd").running == false
+      service("proftpd").enabled == false
+      service("proftpd").running == false
+      service("pure-ftpd").enabled == false
+      service("pure-ftpd").running == false
     docs:
-      desc: The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files.
+      desc: |-
+        File Transfer Protocol (FTP) servers enables the transfer of files between computers over a network, supporting file upload, download, and management.
       remediation: |-
-        Run this command to stop and disable `vsftpd`:
+        Run this command to stop and disable `vsftpd`, `proftpd`, and `pure-ftpd`:
 
         ```
         systemctl stop vsftpd
         systemctl disable vsftpd
+
+        systemctl stop proftpd
+        systemctl disable proftpd
+
+        systemctl stop pure-ftpd
+        systemctl disable pure-ftpd
         ```
   - uid: mondoo-linux-security-http-server-is-not-enabled
     title: Ensure HTTP servers are stopped and not enabled

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -761,7 +761,7 @@ queries:
       service("tftp.socket").enabled == false
       service("tftp.socket").running == false
     docs:
-      desc: Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot machines from a boot server. The package `tftp-server` is used to define and support a TFTP server.
+      desc: Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot machines from a boot server.
       remediation: |-
         Run this command to stop and disable tftp:
 
@@ -936,7 +936,6 @@ queries:
 
         sysctl -w net.ipv6.conf.all.accept_redirects=0
         sysctl -w net.ipv6.conf.default.accept_redirects=0
-
         sysctl -w net.ipv6.route.flush=1
         ```
   - uid: mondoo-linux-security-secure-icmp-redirects-are-not-accepted

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -433,7 +433,9 @@ queries:
         Note: Since the `avahi-daemon` service is often interdependent with other services, it might not be enough to disable the service because other services will likely restart the service automatically.
         To make the service `avahi-daemon` invisible to other services run this command :
 
-        `systemctl mask avahi-daemon`
+        ```
+        systemctl mask avahi-daemon
+        ```
   - uid: mondoo-linux-security-cups-is-not-enabled
     title: Ensure CUPS is stopped and not enabled
     impact: 100
@@ -612,6 +614,7 @@ queries:
         ```
         systemctl stop smb
         systemctl stop smbd
+
         systemctl disable smb
         systemctl disable smbd
         ```
@@ -818,11 +821,9 @@ queries:
 
         ```
         sysctl -w net.ipv4.ip_forward=0
-
-        sysctl -w net.ipv6.conf.all.forwarding=0
-
         sysctl -w net.ipv4.route.flush=1
 
+        sysctl -w net.ipv6.conf.all.forwarding=0
         sysctl -w net.ipv6.route.flush=1
         ```
   - uid: mondoo-linux-security-packet-redirect-sending-is-disabled
@@ -851,9 +852,7 @@ queries:
 
         ```
         sysctl -w net.ipv4.conf.all.send_redirects=0
-
         sysctl -w net.ipv4.conf.default.send_redirects=0
-
         sysctl -w net.ipv4.route.flush=1
         ```
   - uid: mondoo-linux-security-source-routed-packets-are-not-accepted
@@ -888,9 +887,10 @@ queries:
         ```
         sysctl -w net.ipv4.conf.all.accept_source_route=0
         sysctl -w net.ipv4.conf.default.accept_source_route=0
+        sysctl -w net.ipv4.route.flush=1
+
         sysctl -w net.ipv6.conf.all.accept_source_route=0
         sysctl -w net.ipv6.conf.default.accept_source_route=0
-        sysctl -w net.ipv4.route.flush=1
         sysctl -w net.ipv6.route.flush=1
         ```
   - uid: mondoo-linux-security-icmp-redirects-are-not-accepted
@@ -925,9 +925,11 @@ queries:
         ```
         sysctl -w net.ipv4.conf.all.accept_redirects=0
         sysctl -w net.ipv4.conf.default.accept_redirects=0
+        sysctl -w net.ipv4.route.flush=1
+
         sysctl -w net.ipv6.conf.all.accept_redirects=0
         sysctl -w net.ipv6.conf.default.accept_redirects=0
-        sysctl -w net.ipv4.route.flush=1
+
         sysctl -w net.ipv6.route.flush=1
         ```
   - uid: mondoo-linux-security-secure-icmp-redirects-are-not-accepted
@@ -1243,9 +1245,7 @@ queries:
 
         ```
         space_left_action = email
-
         action_mail_acct = root
-
         admin_space_left_action = halt
         ```
   - uid: mondoo-linux-security-changes-to-system-administration-scope-sudoers-is-collected

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -746,7 +746,10 @@ queries:
       service("rlogin.socket").running == false
       service("rexec.socket").running == false
     docs:
-      desc: The Berkeley `rsh-server` ( `rsh`, `rlogin`, `rexec` ) package contains legacy services that exchange credentials in clear-text.
+      desc: |-
+        `rsh`, sometimes referred to as Remote Shell, is a command-line client/server suite or tools (rsh, rlogin, and rcp) used to execute commands on a remote machine.
+
+        `rsh` is inherently insecure because it transmits data, including passwords, in plaintext over the network, making it vulnerable to interception and includes weak host-based authentiction.  If possible use more secure commands such as SSH, which encrypt the entire session, ensuring that sensitive information and files remain secure from unauthorized access.
       remediation: |-
         Run these commands to stop and disable `rsh`, `rlogin`, and `rexec`:
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1177,8 +1177,7 @@ queries:
         Turn on the `auditd`
         daemon to record system events.
       remediation: |-
-        Run this command to enable `auditd`
-        :
+        Run this command to enable `auditd`:
 
         ```
         systemctl --now enable auditd
@@ -1211,15 +1210,13 @@ queries:
         so that processes that are capable of being audited can be audited even if they start up prior to `auditd`
         startup.
       remediation: |-
-        Edit `/etc/default/grub` and add `audit=1`
-        to `GRUB_CMDLINE_LINUX`:
+        Edit `/etc/default/grub` and add `audit=1` to `GRUB_CMDLINE_LINUX`:
 
         ```
         GRUB_CMDLINE_LINUX="audit=1"
         ```
 
-        Run this command to update the `grub2`
-        configuration:
+        Run this command to update the `grub2` configuration:
 
         ### RHEL/Fedora/Amazon Linux and derivatives
         ```
@@ -1243,8 +1240,7 @@ queries:
     docs:
       desc: Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started.
       remediation: |-
-        Set the following parameter in `/etc/audit/auditd.conf`
-        in accordance with site policy:
+        Set the following parameter in `/etc/audit/auditd.conf` in accordance with site policy:
 
         ```
         max_log_file = <MB>
@@ -1263,7 +1259,7 @@ queries:
         setting determines how to handle the audit log file reaching the max file size. A value of `keep_logs`
         will rotate the logs but never delete old logs.
       remediation: |-
-        Set the following parameter in `/etc/audit/auditd.conf:`
+        Set the following parameter in `/etc/audit/auditd.conf`:
 
         ```
         max_log_file_action = keep_logs
@@ -1287,7 +1283,7 @@ queries:
         The `auditd`
         daemon can be configured to halt the system when the audit logs are full.
       remediation: |-
-        Set the following parameters in `/etc/audit/auditd.conf:`
+        Set the following parameters in `/etc/audit/auditd.conf`:
 
         ```
         space_left_action = email
@@ -1312,8 +1308,7 @@ queries:
       desc: |-
         Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the `sudo` command to execute privileged commands, it is possible to monitor changes in scope. The file `/etc/sudoers` will be written to when the file or its attributes have changed. The audit records will be tagged with the identifier "scope."
       remediation: |-
-        Edit or create a file in the `/etc/audit/rules.d/`
-        directory ending in `.rules`
+        Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
         Example: `vi /etc/audit/rules.d/50-scope.rules`
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -426,7 +426,7 @@ queries:
 
         Note: Since the `avahi-daemon` service is often interdependent with other services, it might not be enough to disable the service because other services will likely restart the service automatically.
 
-        To make the service `avahi-daemon` invisible to other services run this command :
+        To make the service `avahi-daemon` invisible to other services run this command:
 
         ```
         systemctl mask avahi-daemon
@@ -451,7 +451,7 @@ queries:
 
         Note: Since the `cups` service is often interdependent with other services, it might not be enough to disable the service because other services such as `cups-browsed` will likely restart the service automatically.
 
-        To make the service `cups` invisible to other services run this command :
+        To make the service `cups` invisible to other services run this command:
 
         ```
         systemctl mask cups
@@ -625,7 +625,7 @@ queries:
     docs:
       desc: The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users can mount these directories and file systems as letter drives on their systems.
       remediation: |-
-        Run this command to stop and disable `smb` and `smbd` services :
+        Run this command to stop and disable `smb` and `smbd` services:
 
         ```
         systemctl stop smb

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -513,7 +513,7 @@ queries:
     docs:
       desc: The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network.
       remediation: |-
-        Run these commands to stop and disable `nfs`, `nfs-server`, and `rpcbind`:
+        Run these commands to stop and disable `nfs` and `rpcbind`:
 
         ```
         systemctl stop nfs
@@ -884,11 +884,8 @@ queries:
 
         ```
         net.ipv4.conf.all.accept_source_route = 0
-
         net.ipv4.conf.default.accept_source_route = 0
-
         net.ipv6.conf.all.accept_source_route = 0
-
         net.ipv6.conf.default.accept_source_route = 0
         ```
 
@@ -896,15 +893,10 @@ queries:
 
         ```
         sysctl -w net.ipv4.conf.all.accept_source_route=0
-
         sysctl -w net.ipv4.conf.default.accept_source_route=0
-
         sysctl -w net.ipv6.conf.all.accept_source_route=0
-
         sysctl -w net.ipv6.conf.default.accept_source_route=0
-
         sysctl -w net.ipv4.route.flush=1
-
         sysctl -w net.ipv6.route.flush=1
         ```
   - uid: mondoo-linux-security-icmp-redirects-are-not-accepted
@@ -929,11 +921,8 @@ queries:
 
         ```
         net.ipv4.conf.all.accept_redirects = 0
-
         net.ipv4.conf.default.accept_redirects = 0
-
         net.ipv6.conf.all.accept_redirects = 0
-
         net.ipv6.conf.default.accept_redirects = 0
         ```
 
@@ -941,15 +930,10 @@ queries:
 
         ```
         sysctl -w net.ipv4.conf.all.accept_redirects=0
-
         sysctl -w net.ipv4.conf.default.accept_redirects=0
-
         sysctl -w net.ipv6.conf.all.accept_redirects=0
-
         sysctl -w net.ipv6.conf.default.accept_redirects=0
-
         sysctl -w net.ipv4.route.flush=1
-
         sysctl -w net.ipv6.route.flush=1
         ```
   - uid: mondoo-linux-security-secure-icmp-redirects-are-not-accepted
@@ -970,7 +954,6 @@ queries:
 
         ```
         net.ipv4.conf.all.secure_redirects = 0
-
         net.ipv4.conf.default.secure_redirects = 0
         ```
 
@@ -978,9 +961,7 @@ queries:
 
         ```
         sysctl -w net.ipv4.conf.all.secure_redirects=0
-
         sysctl -w net.ipv4.conf.default.secure_redirects=0
-
         sysctl -w net.ipv4.route.flush=1
         ```
   - uid: mondoo-linux-security-suspicious-packets-are-logged
@@ -999,18 +980,16 @@ queries:
 
         ```
         net.ipv4.conf.all.log_martians = 1
-
         net.ipv4.conf.default.log_martians = 1
         ```
+
         Hint: If you're using Ubuntu's UFW, please check the for the above configuration in the file /etc/ufw/sysctl.conf in addition, because these settings will overwrite the kernel parameters on UFW startup.
 
         Run these commands to set the active kernel parameters:
 
         ```
         sysctl -w net.ipv4.conf.all.log_martians=1
-
         sysctl -w net.ipv4.conf.default.log_martians=1
-
         sysctl -w net.ipv4.route.flush=1
         ```
   - uid: mondoo-linux-security-broadcast-icmp-requests-are-ignored
@@ -1034,7 +1013,6 @@ queries:
 
         ```
         sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1
-
         sysctl -w net.ipv4.route.flush=1
         ```
   - uid: mondoo-linux-security-bogus-icmp-responses-are-ignored
@@ -1058,7 +1036,6 @@ queries:
 
         ```
         sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1
-
         sysctl -w net.ipv4.route.flush=1
         ```
   - uid: mondoo-linux-security-reverse-path-filtering-is-enabled
@@ -1077,7 +1054,6 @@ queries:
 
         ```
         net.ipv4.conf.all.rp_filter = 1
-
         net.ipv4.conf.default.rp_filter = 1
         ```
 
@@ -1085,9 +1061,7 @@ queries:
 
         ```
         sysctl -w net.ipv4.conf.all.rp_filter=1
-
         sysctl -w net.ipv4.conf.default.rp_filter=1
-
         sysctl -w net.ipv4.route.flush=1
         ```
   - uid: mondoo-linux-security-tcp-syn-cookies-is-enabled
@@ -1111,7 +1085,6 @@ queries:
 
         ```
         sysctl -w net.ipv4.tcp_syncookies=1
-
         sysctl -w net.ipv4.route.flush=1
         ```
   - uid: mondoo-linux-security-ipv6-router-advertisements-are-not-accepted
@@ -1132,7 +1105,6 @@ queries:
 
         ```
         net.ipv6.conf.all.accept_ra = 0
-
         net.ipv6.conf.default.accept_ra = 0
         ```
 
@@ -1140,9 +1112,7 @@ queries:
 
         ```
         sysctl -w net.ipv6.conf.all.accept_ra=0
-
         sysctl -w net.ipv6.conf.default.accept_ra=0
-
         sysctl -w net.ipv6.route.flush=1
         ```
   - uid: mondoo-linux-security-auditd-is-installed

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -205,17 +205,17 @@ queries:
       remediation: |-
         Run this command to install `aide`:
 
-        # RHEL/Fedora/Amazon Linux and derivatives
+        ### RHEL/Fedora/Amazon Linux and derivatives
         ```
         yum install aide
         ```
 
-        # Debian/Ubuntu
+        ### Debian/Ubuntu
         ```
         apt-get install aide
         ```
 
-        # SLES and openSUSE
+        ### SLES and openSUSE
         ```
         zypper install aide
         ```
@@ -2051,7 +2051,6 @@ queries:
 
         ```
         chown root:root /etc/ssh/sshd_config
-
         chmod og-rwx /etc/ssh/sshd_config
         ```
   - uid: mondoo-linux-security-rsyslog-is-installed
@@ -2065,8 +2064,19 @@ queries:
       remediation: |-
         Run this command to install rsyslog:
 
+        ### RHEL/Fedora/Amazon Linux and derivatives
         ```
-        dnf install rsyslog
+        yum install rsyslog
+        ```
+
+        ### Debian/Ubuntu
+        ```
+        apt-get install rsyslog
+        ```
+
+        ### SLES and openSUSE
+        ```
+        zypper install rsyslog
         ```
   - uid: mondoo-linux-security-rsyslog-service-is-enabled
     title: Ensure rsyslog Service is enabled
@@ -2819,7 +2829,7 @@ queries:
       users.where(name == "root").list.all(gid == 0)
     docs:
       desc: |
-        The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user.
+        The `usermod` command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user.
       remediation: |
         Run this command to set the `root` user default group to GID `0`:
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1328,7 +1328,6 @@ queries:
 
         ```
         -w /var/log/lastlog -p wa -k logins
-
         -w /var/log/tallylog -p wa -k logins
         ```
 
@@ -1387,9 +1386,7 @@ queries:
 
         ```
         -w /var/run/utmp -p wa -k session
-
         -w /var/log/wtmp -p wa -k logins
-
         -w /var/log/btmp -p wa -k logins
         ```
 
@@ -1439,9 +1436,7 @@ queries:
 
         ```
         -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
-
         -a always,exit -F arch=b32 -S clock_settime -k time-change
-
         -w /etc/localtime -p wa -k time-change
         ```
 
@@ -1453,13 +1448,9 @@ queries:
 
         ```
         -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change
-
         -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
-
         -a always,exit -F arch=b64 -S clock_settime -k time-change
-
         -a always,exit -F arch=b32 -S clock_settime -k time-change
-
         -w /etc/localtime -p wa -k time-change
         ```
 
@@ -1505,7 +1496,6 @@ queries:
 
         ```
         -w /etc/selinux/ -p wa -k MAC-policy
-
         -w /usr/share/selinux/ -p wa -k MAC-policy
         ```
 
@@ -1513,7 +1503,6 @@ queries:
 
         ```
         -w /etc/apparmor/ -p wa -k MAC-policy
-
         -w /etc/apparmor.d/ -p wa -k MAC-policy
         ```
 
@@ -1558,11 +1547,8 @@ queries:
 
         ```
         -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
-
         -w /etc/issue -p wa -k system-locale
-
         -w /etc/issue.net -p wa -k system-locale
-
         -w /etc/hosts -p wa -k system-locale
         ```
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -749,7 +749,7 @@ queries:
       desc: |-
         `rsh`, sometimes referred to as Remote Shell, is a command-line client/server suite or tools (rsh, rlogin, and rcp) used to execute commands on a remote machine.
 
-        `rsh` is inherently insecure because it transmits data, including passwords, in plaintext over the network, making it vulnerable to interception and includes weak host-based authentiction.  If possible use more secure commands such as SSH, which encrypt the entire session, ensuring that sensitive information and files remain secure from unauthorized access.
+        `rsh` is inherently insecure because it transmits data, including passwords, in plaintext over the network, making it vulnerable to interception and includes weak host-based authentiction. If possible use more secure commands such as SSH, which encrypt the entire session, ensuring that sensitive information and files remain secure from unauthorized access.
       remediation: |-
         Run these commands to stop and disable `rsh`, `rlogin`, and `rexec`:
 
@@ -771,7 +771,10 @@ queries:
       service("telnet.socket").enabled == false
       service("telnet.socket").running == false
     docs:
-      desc: The `telnet-server` package contains the `telnet` daemon, which accepts connections from users from other systems via the `telnet` protocol.
+      desc: |-
+        Telnet is a protocol used to connect and manage remote computers via command-line interfaces over a network. It is considered insecure because it transmits data, including login credentials, in plaintext, making it vulnerable to interception and unauthorized access.
+
+        If possible use more secure commands such as SSH, which encrypt the entire session, ensuring that sensitive information and files remain secure from unauthorized access.
       remediation: |-
         Run this command to stop and disable telnet:
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -50,12 +50,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Prerequisites
 
         Remote scans of Linux hosts requires authentication such as SSH keys.
@@ -1142,8 +1136,7 @@ queries:
       service("auditd").enabled
     docs:
       desc: |-
-        Turn on the `auditd`
-        daemon to record system events.
+        Turn on the `auditd` daemon to record system events.
       remediation: |-
         Run this command to enable `auditd`:
 
@@ -1174,9 +1167,7 @@ queries:
       }
     docs:
       desc: |-
-        Configure `grub2`
-        so that processes that are capable of being audited can be audited even if they start up prior to `auditd`
-        startup.
+        Configure `grub2` so that processes that are capable of being audited can be audited even if they start up prior to `auditd` startup.
       remediation: |-
         Edit `/etc/default/grub` and add `audit=1` to `GRUB_CMDLINE_LINUX`:
 
@@ -1223,9 +1214,7 @@ queries:
       }
     docs:
       desc: |-
-        The `max_log_file_action`
-        setting determines how to handle the audit log file reaching the max file size. A value of `keep_logs`
-        will rotate the logs but never delete old logs.
+        The `max_log_file_action` setting determines how to handle the audit log file reaching the max file size. A value of `keep_logs` will rotate the logs but never delete old logs.
       remediation: |-
         Set the following parameter in `/etc/audit/auditd.conf`:
 
@@ -1248,8 +1237,7 @@ queries:
       }
     docs:
       desc: |-
-        The `auditd`
-        daemon can be configured to halt the system when the audit logs are full.
+        The `auditd` daemon can be configured to halt the system when the audit logs are full.
       remediation: |-
         Set the following parameters in `/etc/audit/auditd.conf`:
 
@@ -1372,11 +1360,7 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-w\s+\/var\/log\/btmp\s+\-p\s+wa\s+\-k\s+(logins|session)(\s+)?$/))
     docs:
       desc: |-
-        Monitor session initiation events. The parameters in this section track changes to the files associated with session events.
-        The file `/var/run/utmp` tracks all currently logged in users. All audit records will be tagged with the identifier "session."
-        The `/var/log/wtmp` file tracks logins, logouts, shutdown, and reboot events. The file `/var/log/btmp` keeps track of failed
-        login attempts and can be read by entering the command `/usr/bin/last -f /var/log/btmp`. All audit records will be tagged with
-        the identifier "logins."
+        Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file `/var/run/utmp` tracks all currently logged in users. All audit records will be tagged with the identifier "session." The `/var/log/wtmp` file tracks logins, logouts, shutdown, and reboot events. The file `/var/log/btmp` keeps track of failed login attempts and can be read by entering the command `/usr/bin/last -f /var/log/btmp`. All audit records will be tagged with the identifier "logins."
       remediation: |-
         Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -1421,12 +1405,7 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/localtime\s+\-p\s+wa\s+\-k\s+time-change(\s+)?$/))
     docs:
       desc: |-
-        Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the `adjtimex`
-        (tune kernel clock), `settimeofday`
-        (Set time, using timeval and timezone structures) `stime`
-        (using seconds since 1/1/1970) or `clock_settime`
-        (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the `/var/log/audit.log`
-        file upon exit, tagging the records with the identifier "time-change"
+        Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the `adjtimex` (tune kernel clock), `settimeofday` (Set time, using timeval and timezone structures) `stime` (using seconds since 1/1/1970) or `clock_settime` (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the `/var/log/audit.log` file upon exit, tagging the records with the identifier "time-change"
       remediation: |-
         For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`_
 
@@ -1485,8 +1464,7 @@ queries:
       appArmorSys || seLinuxSys
     docs:
       desc: |-
-        Monitor SELinux/AppArmor mandatory access controls. The parameters below monitor any write access (potential additional,
-        deletion or modification of files in the directory) or attribute changes to the /etc/selinux or /etc/apparmor and /etc/apparmor.d directories.
+        Monitor SELinux/AppArmor mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/selinux or /etc/apparmor and /etc/apparmor.d directories.
       remediation: |-
         Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -2003,7 +1981,7 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/(\s+)?\-e\s+2(\s+)?$/))
     docs:
       desc: |-
-        Set system audit so that audit rules cannot be modified with `auditctl`. Setting the flag "-e 2" forces audit to be put in immutable mode. Audit changes can only be made on system reboot.
+        Set system audit so that audit rules cannot be modified with `auditctl`. Setting the flag `-e 2` forces audit to be put in immutable mode. Audit changes can only be made on system reboot.
       remediation: |-
         Edit or create the file `/etc/audit/audit.rules` and add the following line at the end of the file:
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -584,21 +584,26 @@ queries:
         systemctl disable nginx
         ```
   - uid: mondoo-linux-security-imap-and-pop3-server-is-not-enabled
-    title: Ensure IMAP and POP3 server is stopped and not enabled
+    title: Ensure IMAP and POP3 servers are stopped and not enabled
     impact: 100
     filters: |
       asset.kind != "container-image"
     mql: |
       service("dovecot").enabled == false
       service("dovecot").running == false
+      service("cyrus-imapd").enabled == false
+      service("cyrus-imapd").running == false
     docs:
-      desc: '`dovecot` is an open source IMAP and POP3 server for Linux based systems.'
+      desc: '`dovecot` and `cyrus-imapd` are open source IMAP and POP3 servers for Linux.'
       remediation: |-
-        Run this command to stop and disable `dovecot` :
+        Run this command to stop and disable `dovecot` and `cyrus-imapd`:
 
         ```
         systemctl stop dovecot
         systemctl disable dovecot
+
+        systemctl stop cyrus-imapd
+        systemctl disable cyrus-imapd
         ```
   - uid: mondoo-linux-security-samba-is-not-enabled
     title: Ensure Samba is stopped and not enabled
@@ -1276,7 +1281,6 @@ queries:
 
         ```
         -w /etc/sudoers -p wa -k scope
-
         -w /etc/sudoers.d -p wa -k scope
         ```
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -31,11 +31,6 @@ policies:
         Non-root users may not be able to access certain areas of the system, especially after remediation has been performed. It is advisable to verify
         root users path integrity and the integrity of any programs being run prior to execution of commands and scripts included in this benchmark.
 
-        ### Intended Audience
-
-        This benchmark is intended for system and application administrators, security specialists, auditors, help desk, and platform deployment personnel
-        who plan to develop, deploy, assess, or secure solutions that incorporate Linux on x86 or x64 platforms.
-
         ## Local scan
 
         Local scan refer to scans of files and operating systems where cnspec is installed.

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -749,7 +749,7 @@ queries:
       desc: |-
         `rsh`, sometimes referred to as Remote Shell, is a command-line client/server suite or tools (rsh, rlogin, and rcp) used to execute commands on a remote machine.
 
-        `rsh` is inherently insecure because it transmits data, including passwords, in plaintext over the network, making it vulnerable to interception and includes weak host-based authentiction. If possible use more secure commands such as SSH, which encrypt the entire session, ensuring that sensitive information and files remain secure from unauthorized access.
+        `rsh` is inherently insecure because it transmits data, including passwords, in plaintext over the network, making it vulnerable to interception and includes weak host-based authentication. If possible use more secure commands such as SSH, which encrypt the entire session, ensuring that sensitive information and files remain secure from unauthorized access.
       remediation: |-
         Run these commands to stop and disable `rsh`, `rlogin`, and `rexec`:
 

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -824,6 +824,8 @@ queries:
     mql: |
       service("ntalk").enabled == false
       service("ntalk").running == false
+      service("talkd").enabled == false
+      service("talkd").running == false
     docs:
       desc: The talk software allows users to send and receive messages across systems through a terminal session. The talk client (allows initiate of talk sessions) is installed by default.
       remediation: |-
@@ -831,7 +833,10 @@ queries:
 
         ```
         systemctl stop ntalk
+        systemctl stop talkd
+
         systemctl disable ntalk
+        systemctl disable talkd
         ```
   - uid: mondoo-linux-security-ip-forwarding-is-disabled
     title: Ensure IP forwarding is disabled

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1,3 +1,4 @@
+
 # Copyright (c) Mondoo, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
@@ -529,14 +530,19 @@ queries:
     mql: |
       service("named").enabled == false
       service("named").running == false
+      service("bind9").enabled == false
+      service("bind9").running == false
     docs:
       desc: The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network.
       remediation: |-
-        Run this command to stop and disable `named`:
+        Run this command to stop and disable BIND:
 
         ```
         systemctl stop named
+        systemctl stop bind9
+
         systemctl disable named
+        systemctl disable bind9
         ```
   - uid: mondoo-linux-security-ftp-server-is-not-enabled
     title: Ensure FTP servers are stopped and not enabled

--- a/core/mondoo-linux-workstation-security.mql.yaml
+++ b/core/mondoo-linux-workstation-security.mql.yaml
@@ -20,10 +20,6 @@ policies:
 
         Where possible Red Hat, Debian, and SUSE derivative styles are provided. Many lists are included including filesystem types, services, clients, and network protocols. Not all items in these lists are guaranteed to exist on all distributions and additional similar items may exist, which should be considered in addition to those explicitly mentioned. The guidance within broadly assumes that operations are being performed as the root user. Operations performed using sudo instead of the root user may produce unexpected results, or fail to make the intended changes to the system. Non-root users may not be able to access certain areas of the system, especially after remediation has been performed. It is advisable to verify root users path integrity and the integrity of any programs being run before execution of commands and scripts included in this benchmark.
 
-        ### Intended Audience
-
-        This benchmark is intended for system and application administrators, security specialists, auditors, help desk, and platform deployment personnel who plan to develop, deploy, assess, or secure solutions that incorporate Linux on x86 or x64 platforms.
-
         ## Local scan
 
         Local scan refer to scans of files and operating systems where cnspec is installed.

--- a/core/mondoo-linux-workstation-security.mql.yaml
+++ b/core/mondoo-linux-workstation-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         This policy provides prescriptive guidance for establishing a secure configuration posture for Client Linux systems running on x86 and x64 platforms.
 
         Commands and scripts are provided which should work on most distributions however some translation to local styles may be required in places.

--- a/core/mondoo-macos-security.mql.yaml
+++ b/core/mondoo-macos-security.mql.yaml
@@ -13,8 +13,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |-
-        ## Overview
-
         This policy provides prescriptive guidance for establishing a secure configuration posture for Apple macOS. This guide was tested against Apple macOS 10.15, 11, 12, 13, and 14.
 
         ## Local scan

--- a/core/mondoo-macos-vulnerability.mql.yaml
+++ b/core/mondoo-macos-vulnerability.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         The Mondoo macOS Vulnerability policy checks for macOS vulnerabilities. It should be used in combination with the Mondoo macOS Security policy.
 
         ### Run policy

--- a/core/mondoo-microsoft-vulnerability.mql.yaml
+++ b/core/mondoo-microsoft-vulnerability.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         The Mondoo Microsoft Vulnerability policy checks for Windows and Microsoft Application vulnerabilities. It should be used in combination with the Platform Vulnerability Policy to identify missing patches.
 
         ### Run policy

--- a/core/mondoo-ms365-security.mql.yaml
+++ b/core/mondoo-ms365-security.mql.yaml
@@ -13,8 +13,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |-
-        ## Overview
-
         The Mondoo Microsoft 365 Security policy provides guidance for establishing minimum recommended security and operational best practices for Microsoft 365.
 
         ## Remote scan

--- a/core/mondoo-okta-security.mql.yaml
+++ b/core/mondoo-okta-security.mql.yaml
@@ -18,16 +18,6 @@ policies:
 
         The Mondoo Okta Organization Security policy provides security recommendations for Okta organizations. This policy supports scanning of Okta organizations as well as Terraform projects using the [Okta Terraform provider](https://registry.terraform.io/providers/okta/okta/latest/docs) from the HashiCorp Terraform Registry.
 
-        ## About remote scanning
-
-        Remote scans with cnspec provide on demand security assessments of infrastructure and services without the need to install any agents or integrations. cnspec comes with a growing list of providers to connect and scan local and remote targets.
-
-        A complete list of providers can be found by running this command:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### cnspec Okta provider
 
         This policy uses the `okta` provider to authenticate with Okta's API in order to remotely scan an Okta organization. Additional information on the `okta` provider can be found by running this command:

--- a/core/mondoo-openssl-vulnerability.mql.yaml
+++ b/core/mondoo-openssl-vulnerability.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         The Mondoo OpenSSL Vulnerability policy checks for vulnerable OpenSSL installation on Unix/Linux system.
 
         ## Remote scan

--- a/core/mondoo-slack-security.mql.yaml
+++ b/core/mondoo-slack-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         The Mondoo Slack Team Security policy ensures that Slack team configurations follow best security practices.
 
         ### Prerequisites

--- a/core/mondoo-terraform-aws-security.mql.yaml
+++ b/core/mondoo-terraform-aws-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         This policy checks for security misconfigurations in Terraform for Amazon Web Services.
 
         ## Local scan

--- a/core/mondoo-terraform-gcp-security.mql.yaml
+++ b/core/mondoo-terraform-gcp-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         This policy checks for security misconfigurations in Terraform HCL for Google Cloud.
 
         ## Local scan

--- a/core/mondoo-tls-security.mql.yaml
+++ b/core/mondoo-tls-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         The Transport Layer Security (TLS) protocol is the primary means of protecting network communications.
 
         The Mondoo TLS/SSL Security policy includes checks for ensuring the security and configuration of TLS/SSL connections and certificates.

--- a/core/mondoo-vmware-vulnerability.mql.yaml
+++ b/core/mondoo-vmware-vulnerability.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         The Mondoo VMware vCenter policy checks for vulnerable vCenter/ESXi configuration. It should be used in combination with the Platform Vulnerability Policy to identify missing patches.
 
         ### Run policy

--- a/core/mondoo-windows-security.mql.yaml
+++ b/core/mondoo-windows-security.mql.yaml
@@ -13,8 +13,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |-
-        ## Overview
-
         This policy provides prescriptive guidance for establishing a secure configuration posture for Microsoft Windows. This guide was tested against Microsoft Windows 10 Release 20H2 Enterprise.
 
         ## Local scan

--- a/core/mondoo-windows-workstation-security.mql.yaml
+++ b/core/mondoo-windows-workstation-security.mql.yaml
@@ -18,10 +18,6 @@ policies:
 
         Commands and scripts are provided which should work on Windows 10 and 11.
 
-        ### Intended Audience
-
-        This benchmark is intended for system and application administrators, security specialists, auditors, help desk, and platform deployment personnel who plan to develop, deploy, assess, or secure solutions that incorporate Windows on x86 or x64 platforms.
-
         ## Local scan
 
         Local scan refer to scans of files and operating systems where cnspec is installed.

--- a/core/mondoo-windows-workstation-security.mql.yaml
+++ b/core/mondoo-windows-workstation-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         This policy provides prescriptive guidance for establishing a secure configuration posture for Microsoft Windows client systems running on x86 and x64 platforms.
 
         Commands and scripts are provided which should work on Windows 10 and 11.

--- a/extra/mondoo-google-workspace-security.mql.yaml
+++ b/extra/mondoo-google-workspace-security.mql.yaml
@@ -14,8 +14,6 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        ## Overview
-
         The Mondoo Google Workspace Security policy ensures that Google Workspace configurations follow best security practices.
 
         ### Prerequisites


### PR DESCRIPTION
### Some fixes for all policies

- Remove the Overview headers that don't display correctly in the console
- Remove remote scan sections that just tell the user to run help to see all the providers since this isn't really helpful
- Remove Intended Audience sections from descriptions


### A pile of fixes for the Linux Security policy

- Prevent weird 2 line displays like this:
   <img width="913" alt="image" src="https://github.com/user-attachments/assets/7d6f4d82-e685-4a07-9755-4fceae8f1d5a">

- Shorten some remediation steps by removing extra spacing
- Add remediation steps for SLES/openSUSE
- Be clear that debian/ubuntu steps include derivatives
- Break out sensitive service checks into their own chapter
- Use more consistent naming for chapters
- Detect cyrus-imapd as a mail server to disable
- Remove sendmail in a description since we don't check for it
- Expand the FTP server check to include proftpd, and pure-ftpd
- Rework some descriptions to better understand *why* it's important to secure things
- Add support for Debian/Ubuntu to the DNS, NIS, and Talk server checks