### PR TITLE
More updates to the Linux policy

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -1164,16 +1164,14 @@ queries:
       remediation: |-
         Run this command to install `auditd`:
 
-        ### Debian/Ubuntu and derivatives
-
         ### RHEL/Fedora/Amazon Linux and derivatives
         ```
         dnf install audit audit-libs
         ```
 
-        ### Debian/Ubuntu
+        ### Debian/Ubuntu and derivatives
         ```
-        apt install auditd audispd-plugins
+        apt-get install auditd audispd-plugins
         ```
 
         ### SLES and openSUSE
@@ -1230,14 +1228,14 @@ queries:
 
         ### RHEL/Fedora/Amazon Linux and derivatives
         ```
-        sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+        grub2-mkconfig -o /boot/grub2/grub.cfg
         ```
         **Note:**
         The path looks different for UEFI systems.
 
         ### Debian/Ubuntu and derivatives
         ```
-        sudo update-grub
+        update-grub
         ```
   - uid: mondoo-linux-security-audit-log-storage-size-is-configured
     title: Ensure audit log storage size is configured
@@ -2368,6 +2366,7 @@ queries:
   - uid: mondoo-linux-security-ssh-protocol-is-set-to-2
     title: Ensure SSH Protocol is set to 2
     impact: 80
+    # openssh-server 7.6 and later remove support for protocol v1
     filters: package('openssh-server').version == /6./ || package('openssh-server').version == /7\.[0|1|2|3|4|5]/
     mql: |
       sshd.config.params["Protocol"] == 2


### PR DESCRIPTION
- Cleanup remediation steps headings
- Make sure Debian uses apt-get not apt
- Don't use sudo with commands. We assume root or they add sudo on their own everywhere