### PR TITLE
:broom: fix: Ensure SSH Idle Timeout Interval is configured

### DIFF
--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -2689,10 +2689,31 @@ queries:
   - uid: mondoo-linux-security-ssh-idle-timeout-interval-is-configured
     title: Ensure SSH Idle Timeout Interval is configured
     impact: 60
+    props:
+      - uid: excludedMatchBlocks
+        title: A list of match blocks to exclude from checking, add items such as "User ansible"
+        mql: |
+          return [
+            "placeholder-do-not-delete",
+          ]
+      - uid: checkDefaultMatchBlock
+        title: Set to true if you want to check the default "" match block
+        mql: |
+          return true
     mql: |
-      sshd.config.params["ClientAliveInterval"] >= 1
-      sshd.config.params["ClientAliveInterval"] <= 300
-      sshd.config.params["ClientAliveCountMax"] = 0
+      defaultBlock = sshd.config.blocks.where(criteria.in([""]) == props.checkDefaultMatchBlock && criteria == "");
+
+      userBlocks = sshd.config.blocks.where(criteria.contains(props.excludedMatchBlocks) == false && criteria != "");
+
+      userBlocks.all(params.ClientAliveInterval >= 1)
+      userBlocks.all(params.ClientAliveInterval <= 900)
+      userBlocks.all(params.ClientAliveCountMax > 0)
+      userBlocks.all(params.ClientAliveCountMax <= 3)
+
+      defaultBlock.all(params.ClientAliveInterval >= 1)
+      defaultBlock.all(params.ClientAliveInterval <= 900)
+      defaultBlock.all(params.ClientAliveCountMax > 0)
+      defaultBlock.all(params.ClientAliveCountMax <= 3)
     docs:
       desc: The two options `ClientAliveInterval` and `ClientAliveCountMax` control the timeout of ssh sessions. When the `ClientAliveInterval` variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the `ClientAliveCountMax` variable is set, `sshd` will send client alive messages at every `ClientAliveInterval` interval. When the number of consecutive client alive messages are sent with no response from the client, the `ssh` session is terminated. For example, if the `ClientAliveInterval` is set to 15 seconds and the `ClientAliveCountMax` is set to 3, the client `ssh` session will be terminated after 45 seconds of idle time.
       remediation: |-


### PR DESCRIPTION
replaces: https://github.com/mondoohq/cnspec-policies/pull/461 (and https://github.com/mondoohq/cnspec-policies/pull/467)