### PR TITLE
Remove the quote escaping in AWS policy

### DIFF
--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -163,7 +163,7 @@ queries:
         3. Run this query:
 
           ```mql
-          aws.iam.credentialReport.where( properties[\"user\"] == \"<root_account>\") { accessKey1Active accessKey2Active }
+          aws.iam.credentialReport.where( properties["user"] == "<root_account>") { accessKey1Active accessKey2Active }
           ```
 
           Example output:
@@ -219,10 +219,10 @@ queries:
         After creating the virtual MFA device, the root user can follow the procedure described under the AWS Console section.
 
         ```hcl
-        resource \"aws_iam_virtual_mfa_device\" \"root_mfa\" {
-          virtual_mfa_device_name = \"root\"
+        resource "aws_iam_virtual_mfa_device" "root_mfa" {
+          virtual_mfa_device_name = "root"
         }
-        output \"root_qr_code\" {
+        output "root_qr_code" {
           value = tomap({
             (aws_iam_virtual_mfa_device.root_mfa.virtual_mfa_device_name) = aws_iam_virtual_mfa_device.root_mfa.qr_code_png
           })
@@ -244,7 +244,7 @@ queries:
 
         ```bash
         aws iam create-virtual-mfa-device \\
-          --virtual-mfa-device-name \"root\" \\
+          --virtual-mfa-device-name "root" \\
           --outfile ./QRCode.png \\
           --bootstrap-method QRCodePNG
         ```
@@ -253,8 +253,8 @@ queries:
 
         ```bash
         aws iam enable-mfa-device \\
-          --user-name \"root\" \\
-          --serial-number \"arn:aws:iam::123456976749:mfa/root\" \\
+          --user-name "root" \\
+          --serial-number "arn:aws:iam::123456976749:mfa/root" \\
           --authentication-code1 123456 \\
           --authentication-code2 654321
         ```
@@ -347,7 +347,7 @@ queries:
         __Terraform__
 
         ```hcl
-        resource \"aws_iam_account_password_policy\" \"strict\" {
+        resource "aws_iam_account_password_policy" "strict" {
           allow_users_to_change_password = true
           require_uppercase_characters   = true
           require_lowercase_characters   = true
@@ -426,28 +426,28 @@ queries:
             accessKey2LastRotated: Never
             accessKey1Active: true
             accessKey2Active: false
-            properties[user]: \"jimmy\"
+            properties[user]: "jimmy"
           }
           1: {
             accessKey1LastRotated: 2021-09-09 19:16:35 +0000 +0000
             accessKey2LastRotated: Never
             accessKey1Active: true
             accessKey2Active: false
-            properties[user]: \"robert\"
+            properties[user]: "robert"
           }
           2: {
             accessKey1LastRotated: 2021-06-15 07:18:34 +0000 +0000
             accessKey2LastRotated: Never
             accessKey1Active: true
             accessKey2Active: false
-            properties[user]: \"johnpaul\"
+            properties[user]: "johnpaul"
           }
           3: {
             accessKey1LastRotated: 2021-09-29 21:53:04 +0000 +0000
             accessKey2LastRotated: Never
             accessKey1Active: true
             accessKey2Active: false
-            properties[user]: \"bonzo\"
+            properties[user]: "bonzo"
           }
         ]
         ```
@@ -474,15 +474,15 @@ queries:
         ```mql
         aws.iam.credentialReport.where(
           mfaActive != true
-        ) {arn properties[\"user\"]}
+        ) {arn properties["user"]}
         ```
         Example output:
 
         ```mql
         aws.iam.credentialReport.where: [
           0: {
-            properties[user]: \"test-iam-user\"
-            arn: \"arn:aws:iam::053121068929:user/users/test-iam-user\"
+            properties[user]: "test-iam-user"
+            arn: "arn:aws:iam::053121068929:user/users/test-iam-user"
           }
         ]
         ```
@@ -502,24 +502,24 @@ queries:
         6. Provide each user with the output QR Code and password.
 
         ```hcl
-        variable \"users\" {
+        variable "users" {
           type = set(string)
           default = [
-            \"mondoo-test@mondoo.com\",
-            \"mondoo-test2@mondoo.com\"
+            "mondoo-test@mondoo.com",
+            "mondoo-test2@mondoo.com"
           ]
         }
 
-        resource \"aws_iam_user\" \"mondoo_test_users\" {
+        resource "aws_iam_user" "mondoo_test_users" {
           for_each = toset(var.users)
           name     = each.key
         }
 
-        resource \"aws_iam_user_login_profile\" \"mondoo_test_users_profile\" {
+        resource "aws_iam_user_login_profile" "mondoo_test_users_profile" {
           for_each                = var.users
           user                    = each.key
           # Key pair created using GnuPG. This is the public key
-          pgp_key = file(\"path/to/gpg_pub_key_base64.pem\")
+          pgp_key = file("path/to/gpg_pub_key_base64.pem")
           password_reset_required = true
           lifecycle {
             ignore_changes = [
@@ -530,128 +530,128 @@ queries:
           }
         }
 
-        resource \"aws_iam_virtual_mfa_device\" \"mondoo_test_mfa\" {
+        resource "aws_iam_virtual_mfa_device" "mondoo_test_mfa" {
           for_each                = toset(var.users)
           virtual_mfa_device_name = each.key
         }
 
-        resource \"aws_iam_group\" \"enforce_mfa_group\" {
-          name = \"EnforceMFAGroup\"
+        resource "aws_iam_group" "enforce_mfa_group" {
+          name = "EnforceMFAGroup"
         }
 
-        resource \"aws_iam_group_membership\" \"enforce_mfa_group_membership\" {
-          name  = \"EnforceMFAGroupMembership\"
+        resource "aws_iam_group_membership" "enforce_mfa_group_membership" {
+          name  = "EnforceMFAGroupMembership"
           group = aws_iam_group.enforce_mfa_group.name
           users = [for k in aws_iam_user.mondoo_test_users : k.name]
         }
 
-        resource \"aws_iam_group_policy\" \"enforce_mfa_policy\" {
-          name   = \"EnforceMFAGroupPolicy\"
+        resource "aws_iam_group_policy" "enforce_mfa_policy" {
+          name   = "EnforceMFAGroupPolicy"
           group  = aws_iam_group.enforce_mfa_group.id
           policy = <<POLICY
         {
-          \"Version\": \"2012-10-17\",
-          \"Statement\": [
+          "Version": "2012-10-17",
+          "Statement": [
             {
-                \"Sid\": \"AllowViewAccountInfo\",
-                \"Effect\": \"Allow\",
-                \"Action\": [
-                    \"iam:GetAccountPasswordPolicy\",
-                    \"iam:ListVirtualMFADevices\"
+                "Sid": "AllowViewAccountInfo",
+                "Effect": "Allow",
+                "Action": [
+                    "iam:GetAccountPasswordPolicy",
+                    "iam:ListVirtualMFADevices"
                 ],
-                \"Resource\": \"*\"
+                "Resource": "*"
             },
             {
-                \"Sid\": \"AllowManageOwnPasswords\",
-                \"Effect\": \"Allow\",
-                \"Action\": [
-                    \"iam:ChangePassword\",
-                    \"iam:GetUser\"
+                "Sid": "AllowManageOwnPasswords",
+                "Effect": "Allow",
+                "Action": [
+                    "iam:ChangePassword",
+                    "iam:GetUser"
                 ],
-                \"Resource\": \"arn:aws:iam::*:user/$${aws:username}\"
+                "Resource": "arn:aws:iam::*:user/$${aws:username}"
             },
             {
-                \"Sid\": \"AllowManageOwnAccessKeys\",
-                \"Effect\": \"Allow\",
-                \"Action\": [
-                    \"iam:CreateAccessKey\",
-                    \"iam:DeleteAccessKey\",
-                    \"iam:ListAccessKeys\",
-                    \"iam:UpdateAccessKey\"
+                "Sid": "AllowManageOwnAccessKeys",
+                "Effect": "Allow",
+                "Action": [
+                    "iam:CreateAccessKey",
+                    "iam:DeleteAccessKey",
+                    "iam:ListAccessKeys",
+                    "iam:UpdateAccessKey"
                 ],
-                \"Resource\": \"arn:aws:iam::*:user/$${aws:username}\"
+                "Resource": "arn:aws:iam::*:user/$${aws:username}"
             },
             {
-                \"Sid\": \"AllowManageOwnSigningCertificates\",
-                \"Effect\": \"Allow\",
-                \"Action\": [
-                    \"iam:DeleteSigningCertificate\",
-                    \"iam:ListSigningCertificates\",
-                    \"iam:UpdateSigningCertificate\",
-                    \"iam:UploadSigningCertificate\"
+                "Sid": "AllowManageOwnSigningCertificates",
+                "Effect": "Allow",
+                "Action": [
+                    "iam:DeleteSigningCertificate",
+                    "iam:ListSigningCertificates",
+                    "iam:UpdateSigningCertificate",
+                    "iam:UploadSigningCertificate"
                 ],
-                \"Resource\": \"arn:aws:iam::*:user/$${aws:username}\"
+                "Resource": "arn:aws:iam::*:user/$${aws:username}"
             },
             {
-                \"Sid\": \"AllowManageOwnSSHPublicKeys\",
-                \"Effect\": \"Allow\",
-                \"Action\": [
-                    \"iam:DeleteSSHPublicKey\",
-                    \"iam:GetSSHPublicKey\",
-                    \"iam:ListSSHPublicKeys\",
-                    \"iam:UpdateSSHPublicKey\",
-                    \"iam:UploadSSHPublicKey\"
+                "Sid": "AllowManageOwnSSHPublicKeys",
+                "Effect": "Allow",
+                "Action": [
+                    "iam:DeleteSSHPublicKey",
+                    "iam:GetSSHPublicKey",
+                    "iam:ListSSHPublicKeys",
+                    "iam:UpdateSSHPublicKey",
+                    "iam:UploadSSHPublicKey"
                 ],
-                \"Resource\": \"arn:aws:iam::*:user/$${aws:username}\"
+                "Resource": "arn:aws:iam::*:user/$${aws:username}"
             },
             {
-                \"Sid\": \"AllowManageOwnGitCredentials\",
-                \"Effect\": \"Allow\",
-                \"Action\": [
-                    \"iam:CreateServiceSpecificCredential\",
-                    \"iam:DeleteServiceSpecificCredential\",
-                    \"iam:ListServiceSpecificCredentials\",
-                    \"iam:ResetServiceSpecificCredential\",
-                    \"iam:UpdateServiceSpecificCredential\"
+                "Sid": "AllowManageOwnGitCredentials",
+                "Effect": "Allow",
+                "Action": [
+                    "iam:CreateServiceSpecificCredential",
+                    "iam:DeleteServiceSpecificCredential",
+                    "iam:ListServiceSpecificCredentials",
+                    "iam:ResetServiceSpecificCredential",
+                    "iam:UpdateServiceSpecificCredential"
                 ],
-                \"Resource\": \"arn:aws:iam::*:user/$${aws:username}\"
+                "Resource": "arn:aws:iam::*:user/$${aws:username}"
             },
             {
-                \"Sid\": \"AllowManageOwnVirtualMFADevice\",
-                \"Effect\": \"Allow\",
-                \"Action\": [
-                    \"iam:CreateVirtualMFADevice\",
-                    \"iam:DeleteVirtualMFADevice\"
+                "Sid": "AllowManageOwnVirtualMFADevice",
+                "Effect": "Allow",
+                "Action": [
+                    "iam:CreateVirtualMFADevice",
+                    "iam:DeleteVirtualMFADevice"
                 ],
-                \"Resource\": \"arn:aws:iam::*:mfa/$${aws:username}\"
+                "Resource": "arn:aws:iam::*:mfa/$${aws:username}"
             },
             {
-                \"Sid\": \"AllowManageOwnUserMFA\",
-                \"Effect\": \"Allow\",
-                \"Action\": [
-                    \"iam:DeactivateMFADevice\",
-                    \"iam:EnableMFADevice\",
-                    \"iam:ListMFADevices\",
-                    \"iam:ResyncMFADevice\"
+                "Sid": "AllowManageOwnUserMFA",
+                "Effect": "Allow",
+                "Action": [
+                    "iam:DeactivateMFADevice",
+                    "iam:EnableMFADevice",
+                    "iam:ListMFADevices",
+                    "iam:ResyncMFADevice"
                 ],
-                \"Resource\": \"arn:aws:iam::*:user/$${aws:username}\"
+                "Resource": "arn:aws:iam::*:user/$${aws:username}"
             },
             {
-                \"Sid\": \"DenyAllExceptListedIfNoMFA\",
-                \"Effect\": \"Deny\",
-                \"NotAction\": [
-                    \"iam:CreateVirtualMFADevice\",
-                    \"iam:EnableMFADevice\",
-                    \"iam:GetUser\",
-                    \"iam:ListMFADevices\",
-                    \"iam:ListVirtualMFADevices\",
-                    \"iam:ResyncMFADevice\",
-                    \"sts:GetSessionToken\"
+                "Sid": "DenyAllExceptListedIfNoMFA",
+                "Effect": "Deny",
+                "NotAction": [
+                    "iam:CreateVirtualMFADevice",
+                    "iam:EnableMFADevice",
+                    "iam:GetUser",
+                    "iam:ListMFADevices",
+                    "iam:ListVirtualMFADevices",
+                    "iam:ResyncMFADevice",
+                    "sts:GetSessionToken"
                 ],
-                \"Resource\": \"*\",
-                \"Condition\": {
-                    \"BoolIfExists\": {
-                        \"aws:MultiFactorAuthPresent\": \"false\"
+                "Resource": "*",
+                "Condition": {
+                    "BoolIfExists": {
+                        "aws:MultiFactorAuthPresent": "false"
                     }
                 }
             }
@@ -660,13 +660,13 @@ queries:
         POLICY
         }
 
-        output \"user_password_map\" {
-          # Outputs a map in the format {\"mondoo-test@mondoo.com\": <PGPEncryptedPassword>, \"mondoo-test2@mondoo.com\": <PGPEncryptedPassword>}
+        output "user_password_map" {
+          # Outputs a map in the format {"mondoo-test@mondoo.com": <PGPEncryptedPassword>, "mondoo-test2@mondoo.com": <PGPEncryptedPassword>}
           value = { for k, v in aws_iam_user_login_profile.mondoo_test_users_profile : k => v.password }
         }
 
-        output \"user_qr_map\" {
-          # Outputs a map in the format {\"mondoo-test@mondoo.com\": <QRCode>, \"mondoo-test2@mondoo.com\": <QRCode>}
+        output "user_qr_map" {
+          # Outputs a map in the format {"mondoo-test@mondoo.com": <QRCode>, "mondoo-test2@mondoo.com": <QRCode>}
           value = { for k, v in aws_iam_virtual_mfa_device.mondoo_test_mfa : k => v.qr_code_png }
         }
         ```
@@ -682,7 +682,7 @@ queries:
         3. In the **User Name** list, select the name of the intended MFA user.
         4. select the **Security credentials** tab. Next to Assigned MFA device, select **Manage**.
         5. In the Manage MFA Device wizard, select **Virtual MFA device** and then select **Continue**.
-        6. IAM generates and displays configuration information for the virtual MFA device, including a QR code graphic. The graphic represents the \"secret configuration key\" available for manual entry on devices that do not support QR codes.
+        6. IAM generates and displays configuration information for the virtual MFA device, including a QR code graphic. The graphic represents the "secret configuration key" available for manual entry on devices that do not support QR codes.
         7. Open your virtual MFA app. For a list of apps you can use to host virtual MFA devices, read [Multi-Factor Authentication](https://aws.amazon.com/iam/features/mfa/).
         8. If the virtual MFA app supports multiple virtual MFA devices or accounts, select the option to create a new virtual MFA device or account.
         9. Determine whether the MFA app supports QR codes, and then either:
@@ -699,7 +699,7 @@ queries:
 
         ```bash
         aws iam create-virtual-mfa-device \\
-          --virtual-mfa-device-name \"mondoo.test@mondoo.com\" \\
+          --virtual-mfa-device-name "mondoo.test@mondoo.com" \\
           --outfile ./QRCode.png \\
           --bootstrap-method QRCodePNG
         ```
@@ -708,8 +708,8 @@ queries:
 
         ```bash
         aws iam enable-mfa-device \\
-          --user-name \"mondoo.test@mondoo.com\" \\
-          --serial-number \"arn:aws:iam::123456976749:mfa/mondoo.test@mondoo.com\" \\
+          --user-name "mondoo.test@mondoo.com" \\
+          --serial-number "arn:aws:iam::123456976749:mfa/mondoo.test@mondoo.com" \\
           --authentication-code1 123456 \\
           --authentication-code2 654321
         ```
@@ -742,11 +742,11 @@ queries:
         ```mql
         aws.iam.groups.where: [
           0: {
-            name: \"MyUserGroup\"
-            id: \"AGPASSOFBMF7OMHVGHACB\"
+            name: "MyUserGroup"
+            id: "AGPASSOFBMF7OMHVGHACB"
             createDate: 2022-01-11 18:19:26 +0000 UTC
             usernames: []
-            arn: \"arn:aws:iam::177043759486:group/MyUserGroup\"
+            arn: "arn:aws:iam::177043759486:group/MyUserGroup"
           }
         ]
         ```
@@ -839,24 +839,24 @@ queries:
         ```mql
         aws.iam.users.where: [
           0: {
-            arn: \"arn:aws:iam::1234567890987:user/1234567890987-alice\"
-            name: \"1234567890987-alice\"
+            arn: "arn:aws:iam::1234567890987:user/1234567890987-alice"
+            name: "1234567890987-alice"
             attachedPolicies: []
             policies: [
-              0: \"excess_policy\"
+              0: "excess_policy"
             ]
           }
           1: {
-            arn: \"arn:aws:iam::1234567890987:user/maria\"
-            name: \"maria\"
+            arn: "arn:aws:iam::1234567890987:user/maria"
+            name: "maria"
             attachedPolicies: [
               0: aws.iam.policy id = arn:aws:iam::1234567890987:policy/ec2-instance-connect-sendssh
             ]
             policies: []
           }
           2: {
-            arn: \"arn:aws:iam::1234567890987:user/bobby\"
-            name: \"bobby\"
+            arn: "arn:aws:iam::1234567890987:user/bobby"
+            name: "bobby"
             attachedPolicies: [
               0: aws.iam.policy id = arn:aws:iam::1234567890987:policy/terraform20210901011436036200000004
             ]
@@ -897,7 +897,7 @@ queries:
 
         ```mql
         aws.ec2.securityGroups.where(
-          name == \"default\"
+          name == "default"
         ).where(
           ipPermissions.length != 0
           || ipPermissionsEgress.length != 0
@@ -911,18 +911,18 @@ queries:
           0: {
             ipPermissions: [
               0: {
-                id: \"sg-0bd4b1ef47132d3de-0\"
+                id: "sg-0bd4b1ef47132d3de-0"
                 fromPort: 0
                 toPort: 0
-                ipProtocol: \"-1\"
+                ipProtocol: "-1"
                 ipv6Ranges: []
                 ipRanges: []
               }
             ]
             ipPermissionsEgress: []
-            name: \"default\"
-            region: \"eu-north-1\"
-            id: \"sg-0bd4b1ef47132d3de\"
+            name: "default"
+            region: "eu-north-1"
+            id: "sg-0bd4b1ef47132d3de"
           }
         ]
         ```
@@ -931,7 +931,7 @@ queries:
 
         Terraform provides the resource `aws_default_security_group` which, unlike other Terraform resources, has these effects in the state of the infrastructure:
 
-        - \"Adopts\" the default security group for the provided `vpc_id`.
+        - "Adopts" the default security group for the provided `vpc_id`.
         - Removes all inbound (ingress) and outbound (egress) rules for the security group.
 
         To remediate this check using Terraform, apply the following logic for every region the account has access to by aliasing the providers.
@@ -939,17 +939,17 @@ queries:
         Note: You must create a new security group for all VPCs in order to reassign any resources that previously used (or were created with) the default security groups.
 
         ```hcl
-        provider \"aws\" {
-          alias  = \"us_east_1\"
-          region = \"us-east-1\"
+        provider "aws" {
+          alias  = "us_east_1"
+          region = "us-east-1"
         }
 
-        data \"aws_vpcs\" \"us_east_1\" {
+        data "aws_vpcs" "us_east_1" {
           provider = aws.us_east_1
         }
 
-        resource \"aws_security_group\" \"replacement_for_default\" {
-          name     = \"AllowOrDenySomething\"
+        resource "aws_security_group" "replacement_for_default" {
+          name     = "AllowOrDenySomething"
           for_each = toset(data.aws_vpcs.us_east_1.ids)
           vpc_id   = each.value
           ingress {
@@ -960,7 +960,7 @@ queries:
           }
         }
 
-        resource \"aws_default_security_group\" \"us_east_1\" {
+        resource "aws_default_security_group" "us_east_1" {
           for_each = toset(data.aws_vpcs.us_east_1.ids)
           vpc_id   = each.value
           provider = aws.us_east_1
@@ -1006,8 +1006,8 @@ queries:
 
         ```bash
         aws ec2 create-security-group \\
-          --description \"AllowOrDenySomething\" \\
-          --group-name \"AllowOrDenySomething\" \\
+          --description "AllowOrDenySomething" \\
+          --group-name "AllowOrDenySomething" \\
           --vpc-id <value>
         ```
 
@@ -1304,7 +1304,7 @@ queries:
         3. Run this query to return a list of all running EC2 instances across all enabled regions that along with the `instanceId`, `region`, and the configured `publicIp`:
 
         ```mql
-        aws.ec2.instances.where( state = \"running\" && publicIp != \"\" ) { instanceId region tags publicIp }
+        aws.ec2.instances.where( state = "running" && publicIp != "" ) { instanceId region tags publicIp }
         ```
 
         Example output:
@@ -1312,14 +1312,14 @@ queries:
         ```mql
         aws.ec2.instances.where: [
           0: {
-            instanceId: \"i-0070af411a515f14a\"
+            instanceId: "i-0070af411a515f14a"
             tags: {
-              Environment: \"windows-development-vpc\"
-              Name: \"win19-dev-workstation-106e1f1c\"
-              Terraform: \"true\"
+              Environment: "windows-development-vpc"
+              Name: "win19-dev-workstation-106e1f1c"
+              Terraform: "true"
             }
-            publicIp: \"54.55.222.9\"
-            region: \"us-east-1\"
+            publicIp: "54.55.222.9"
+            region: "us-east-1"
           }
         ]
         ```
@@ -1329,7 +1329,7 @@ queries:
         Use the `associate_public_ip_address = false` argument with the `aws_instance` resource to ensure EC2 instances are provisioned without a public IP address:
 
         ```hcl
-        resource \"aws_instance\" \"no_public_ip\" {
+        resource "aws_instance" "no_public_ip" {
           ...
           associate_public_ip_address = false
         }
@@ -1479,12 +1479,12 @@ queries:
           ```mql
           aws.vpcs.where: [
             0: {
-              arn: \"arn:aws:vpc:eu-north-1:053121068929:id/vpc-0c3955e3d04d2e09a\"
+              arn: "arn:aws:vpc:eu-north-1:053121068929:id/vpc-0c3955e3d04d2e09a"
               flowLogs: []
-              id: \"vpc-0c3955e3d04d2e09a\"
+              id: "vpc-0c3955e3d04d2e09a"
               isDefault: true
-              region: \"eu-north-1\"
-              state: \"available\"
+              region: "eu-north-1"
+              state: "available"
               tags: {}
             }
             ...
@@ -1520,19 +1520,19 @@ queries:
         terraform {
           required_providers {
             awsutils = {
-              source = \"cloudposse/awsutils\"
+              source = "cloudposse/awsutils"
             }
           }
         }
 
         # Create one for each region
-        provider \"awsutils\" {
-          alias  = \"ap_northeast_1\"
-          region = \"ap-northeast-1\"
+        provider "awsutils" {
+          alias  = "ap_northeast_1"
+          region = "ap-northeast-1"
         }
 
         # Create one for each region - the creation of this resource will delete the default resources
-        resource \"awsutils_default_vpc_deletion\" \"us_east_1\" {
+        resource "awsutils_default_vpc_deletion" "us_east_1" {
           provider = awsutils.us_east_1
         }
         ```
@@ -1540,95 +1540,95 @@ queries:
         To enable flow logs for VPCs with customer-managed KMS keys:
 
         ```hcl
-        data \"aws_caller_identity\" \"current\" {}
+        data "aws_caller_identity" "current" {}
 
-        resource \"aws_kms_key\" \"vpc_flowlog\" {
-          description         = \"Key to provide encryption to VPC Flow Logs\"
+        resource "aws_kms_key" "vpc_flowlog" {
+          description         = "Key to provide encryption to VPC Flow Logs"
           enable_key_rotation = true
           policy = jsonencode({
-            Version = \"2012-10-17\"
+            Version = "2012-10-17"
             Statement = [
               {
-                Effect = \"Allow\"
+                Effect = "Allow"
                 Action = [
-                  \"kms:Encrypt*\",
-                  \"kms:Decrypt*\",
-                  \"kms:ReEncrypt*\",
-                  \"kms:GenerateDataKey*\",
-                  \"kms:Describe*\"
+                  "kms:Encrypt*",
+                  "kms:Decrypt*",
+                  "kms:ReEncrypt*",
+                  "kms:GenerateDataKey*",
+                  "kms:Describe*"
                 ]
                 Principal = {
-                  Service = \"logs.<region>.amazonaws.com\"
+                  Service = "logs.<region>.amazonaws.com"
                 }
-                Resource = \"arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:key/*\"
+                Resource = "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:key/*"
               },
               {
-                Sid    = \"Enable IAM User Permissions\"
-                Effect = \"Allow\"
+                Sid    = "Enable IAM User Permissions"
+                Effect = "Allow"
                 Principal = {
-                  \"AWS\" : \"arn:aws:iam::${data.aws_caller_identity.current.account_id}:root\"
+                  "AWS" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
                 }
-                Action   = \"kms:*\"
-                Resource = \"*\"
+                Action   = "kms:*"
+                Resource = "*"
               }
             ]
           })
         }
 
-        resource \"aws_cloudwatch_log_group\" \"vpc_flowlog\" {
-          name              = \"VPCFlowLog\"
+        resource "aws_cloudwatch_log_group" "vpc_flowlog" {
+          name              = "VPCFlowLog"
           kms_key_id        = aws_kms_key.vpc_flowlog.arn
           retention_in_days = <value>
         }
 
-        resource \"aws_iam_role\" \"vpc_flowlog\" {
-          name = \"VPCFlowLog\"
+        resource "aws_iam_role" "vpc_flowlog" {
+          name = "VPCFlowLog"
 
           assume_role_policy = jsonencode({
-            Version = \"2012-10-17\"
+            Version = "2012-10-17"
             Statement = [
               {
-                Sid    = \"VPCFlowLog\"
-                Effect = \"Allow\"
+                Sid    = "VPCFlowLog"
+                Effect = "Allow"
                 Principal = {
-                  Service = \"vpc-flow-logs.amazonaws.com\"
+                  Service = "vpc-flow-logs.amazonaws.com"
                 }
-                Action = \"sts:AssumeRole\"
+                Action = "sts:AssumeRole"
               }
             ]
           })
         }
 
-        resource \"aws_iam_policy\" \"vpc_flowlog\" {
-          name = \"VpcFlowLog\"
+        resource "aws_iam_policy" "vpc_flowlog" {
+          name = "VpcFlowLog"
           policy = jsonencode({
-            Version = \"2012-10-17\"
+            Version = "2012-10-17"
             Statement = [
               {
                 Action = [
-                  \"logs:CreateLogGroup\",
-                  \"logs:CreateLogStream\",
-                  \"logs:PutLogEvents\",
-                  \"logs:DescribeLogGroups\",
-                  \"logs:DescribeLogStreams\",
+                  "logs:CreateLogGroup",
+                  "logs:CreateLogStream",
+                  "logs:PutLogEvents",
+                  "logs:DescribeLogGroups",
+                  "logs:DescribeLogStreams",
                 ],
-                Effect   = \"Allow\",
-                Resource = \"*\"
+                Effect   = "Allow",
+                Resource = "*"
               }
             ]
           })
         }
 
-        resource \"aws_iam_policy_attachment\" \"vpc_flowlog\" {
-          name       = \"${aws_iam_policy.vpc_flowlog.name}Attachment\"
+        resource "aws_iam_policy_attachment" "vpc_flowlog" {
+          name       = "${aws_iam_policy.vpc_flowlog.name}Attachment"
           roles      = [aws_iam_role.vpc_flowlog.id]
           policy_arn = aws_iam_policy.vpc_flowlog.arn
         }
 
-        resource \"aws_flow_log\" \"example\" {
+        resource "aws_flow_log" "example" {
           iam_role_arn    = aws_iam_role.vpc_flowlog.arn
           log_destination = aws_cloudwatch_log_group.vpc_flowlog.arn
-          traffic_type    = \"ALL\"
+          traffic_type    = "ALL"
           vpc_id          = aws_vpc.example.id
         }
         ```
@@ -1674,30 +1674,30 @@ queries:
 
         ```javascript
         {
-          \"Version\": \"2012-10-17\"
-          \"Statement\": [
+          "Version": "2012-10-17"
+          "Statement": [
             {
-              \"Effect\": \"Allow\"
-              \"Action\": [
-                \"kms:Encrypt*\",
-                \"kms:Decrypt*\",
-                \"kms:ReEncrypt*\",
-                \"kms:GenerateDataKey*\",
-                \"kms:Describe*\"
+              "Effect": "Allow"
+              "Action": [
+                "kms:Encrypt*",
+                "kms:Decrypt*",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:Describe*"
               ]
-              \"Principal\": {
-                \"Service\": \"logs.us-east-1.amazonaws.com\"
+              "Principal": {
+                "Service": "logs.us-east-1.amazonaws.com"
               }
-              \"Resource\": \"arn:aws:kms:*:<account_id>:key/*\"
+              "Resource": "arn:aws:kms:*:<account_id>:key/*"
             },
             {
-              \"Sid\": \"Enable IAM User Permissions\"
-              \"Effect\": \"Allow\"
-              \"Principal\": {
-                \"AWS\": \"arn:aws:iam::<account_id>:root\"
+              "Sid": "Enable IAM User Permissions"
+              "Effect": "Allow"
+              "Principal": {
+                "AWS": "arn:aws:iam::<account_id>:root"
               }
-              \"Action\": \"kms:*\"
-              \"Resource\": \"*\"
+              "Action": "kms:*"
+              "Resource": "*"
             }
           ]
         }
@@ -1705,7 +1705,7 @@ queries:
 
         ```bash
         aws kms create-key \\
-          --description \"Key to provide encryption to VPC Flow Logs\" \\
+          --description "Key to provide encryption to VPC Flow Logs" \\
           --policy file://key-policy.json
         ```
 
@@ -1720,18 +1720,18 @@ queries:
 
         ```javascript
         {
-          \"Version\": \"2012-10-17\"
-          \"Statement\": [
+          "Version": "2012-10-17"
+          "Statement": [
             {
-              \"Action\": [
-                \"logs:CreateLogGroup\",
-                \"logs:CreateLogStream\",
-                \"logs:PutLogEvents\",
-                \"logs:DescribeLogGroups\",
-                \"logs:DescribeLogStreams\"
+              "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams"
               ],
-              \"Effect\": \"Allow\",
-              \"Resource\": \"*\"
+              "Effect": "Allow",
+              "Resource": "*"
             }
           ]
         }
@@ -1741,8 +1741,8 @@ queries:
 
         ```bash
         aws iam create-role \\
-          --path \"/\" \\
-          --role-name \"VPCFlowLog\"
+          --path "/" \\
+          --role-name "VPCFlowLog"
         ```
 
         5. Attach the policy to the role:
@@ -1766,10 +1766,10 @@ queries:
         ```bash
         aws ec2 create-flow-logs \\
           --deliver-logs-permission-arn <iam_role_arn> \\
-          --traffic-type \"ALL\" \\
-          --resource-ids \"<list>\" \"<vpcs>\" \"<ids>\" \\
-          --resource-type \"VPC\" \\
-          --log-destination-type \"cloud-watch-logs\" \\
+          --traffic-type "ALL" \\
+          --resource-ids "<list>" "<vpcs>" "<ids>" \\
+          --resource-type "VPC" \\
+          --log-destination-type "cloud-watch-logs" \\
           --log-destination <arn_cloudwatch_log_group>
         ```
     refs:
@@ -1850,18 +1850,18 @@ queries:
             0: {
               tags: {}
               backups: []
-              arn: \"arn:aws:dynamodb:us-east-1:053121068929:table/GameScoresAutoscale\"
-              region: \"us-east-1\"
+              arn: "arn:aws:dynamodb:us-east-1:053121068929:table/GameScoresAutoscale"
+              region: "us-east-1"
               continuousBackups: {
-                ContinuousBackupsStatus: \"ENABLED\"
+                ContinuousBackupsStatus: "ENABLED"
                 PointInTimeRecoveryDescription: {
-                  EarliestRestorableDateTime: \"2022-08-02T18:54:51Z\"
-                  LatestRestorableDateTime: \"2022-08-03T15:38:43.954Z\"
-                  PointInTimeRecoveryStatus: \"ENABLED\"
+                  EarliestRestorableDateTime: "2022-08-02T18:54:51Z"
+                  LatestRestorableDateTime: "2022-08-03T15:38:43.954Z"
+                  PointInTimeRecoveryStatus: "ENABLED"
                 }
               }
               sseDescription: {}
-              name: \"GameScoresAutoscale\"
+              name: "GameScoresAutoscale"
               provisionedThroughput: {
                 LastDecreaseDateTime: null
                 LastIncreaseDateTime: null
@@ -1986,16 +1986,16 @@ queries:
         ```mql
         aws.rds.instances.where: [
           0: {
-            arn: \"arn:aws:rds:us-moonbase-2:12345:db:rds-12345-mondoo-demo\"
+            arn: "arn:aws:rds:us-moonbase-2:12345:db:rds-12345-mondoo-demo"
             tags: {
-              Environment: \"12345-mondoo-demo\"
-              Name: \"12345-mondoo-demo-rds\"
-              git_file: \"terraform/aws/db-app.tf\"
-              git_repo: \"mondoo-demo-environment\"
+              Environment: "12345-mondoo-demo"
+              Name: "12345-mondoo-demo-rds"
+              git_file: "terraform/aws/db-app.tf"
+              git_repo: "mondoo-demo-environment"
             }
-            region: \"us-moonbase-2\"
-            dbInstanceIdentifier: \"rds-12345-mondoo-demo\"
-            name: \"db1\"
+            region: "us-moonbase-2"
+            dbInstanceIdentifier: "rds-12345-mondoo-demo"
+            name: "db1"
           }
         ]
         ```
@@ -2005,15 +2005,15 @@ queries:
         Use the `aws_db_instance` resource to explicitly state that `publicly_accessible = false`:
 
         ```hcl
-        resource \"aws_db_instance\" \"pass_public_accessible\" {
+        resource "aws_db_instance" "pass_public_accessible" {
           allocated_storage    = 10
-          engine               = \"mysql\"
-          engine_version       = \"5.7\"
-          instance_class       = \"db.t3.micro\"
-          name                 = \"mydb\"
-          username             = \"foo\"
-          password             = \"foobarbaz\"
-          parameter_group_name = \"default.mysql5.7\"
+          engine               = "mysql"
+          engine_version       = "5.7"
+          instance_class       = "db.t3.micro"
+          name                 = "mydb"
+          username             = "foo"
+          password             = "foobarbaz"
+          parameter_group_name = "default.mysql5.7"
           skip_final_snapshot  = true
           publicly_accessible  = false
         }
@@ -2048,15 +2048,15 @@ queries:
 
         ```bash
         aws rds create-db-instance \\
-          --db-name \"production\" \\
-          --db-instance-identifier \"production-mysql-5-7\" \\
-          --db-instance-class \"db.t3.micro\" \\
-          --db-parameter-group-name \"default.mysql5.7\" \\
-          --engine \"mysql\" \\
-          --engine-version \"5.7\" \\
+          --db-name "production" \\
+          --db-instance-identifier "production-mysql-5-7" \\
+          --db-instance-class "db.t3.micro" \\
+          --db-parameter-group-name "default.mysql5.7" \\
+          --engine "mysql" \\
+          --engine-version "5.7" \\
           --allocated-storage 10 \\
-          --master-username \"mymasteruser\" \\
-          --master-user-password \"mysupersecretpasswordforthemasteruser\"
+          --master-username "mymasteruser" \\
+          --master-user-password "mysupersecretpasswordforthemasteruser"
         ```
     refs:
       - url: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html
@@ -2096,10 +2096,10 @@ queries:
           ```mql
           aws.redshift.clusters.where: [
             0: {
-              region: \"us-east-1\"
+              region: "us-east-1"
               publiclyAccessible: true
-              name: \"test-redshift-cluster\"
-              arn: \"arn:aws:redshift:us-east-1:053121068929:cluster/test-redshift-cluster\"
+              name: "test-redshift-cluster"
+              arn: "arn:aws:redshift:us-east-1:053121068929:cluster/test-redshift-cluster"
             }
           ]
           ```
@@ -2182,15 +2182,15 @@ queries:
         mondoo> aws.ec2.volumes.where( attachments.length == 0 ) {*}
         aws.ec2.volumes.where: [
           0: {
-            volumeType: \"gp2\"
+            volumeType: "gp2"
             attachments: []
-            availabilityZone: \"us-west-2a\"
+            availabilityZone: "us-west-2a"
             encrypted: false
-            id: \"vol-0f5661d9f9db6dd3a\"
-            arn: \"arn:aws:ec2:us-west-2:187043755555:volume/vol-0f5661d9f9db6dd3a\"
-            state: \"available\"
+            id: "vol-0f5661d9f9db6dd3a"
+            arn: "arn:aws:ec2:us-west-2:187043755555:volume/vol-0f5661d9f9db6dd3a"
+            state: "available"
             tags: {
-              Name: \"Unattached Test\"
+              Name: "Unattached Test"
             }
           }
         ]
@@ -2278,17 +2278,17 @@ queries:
         aws.efs.filesystems.where: [
           0: {
             tags: {
-              Name: \"12344375555-mondoo-demo-efs\"
-              git_file: \"terraform/aws/efs.tf\"
-              git_org: \"mondoolabs\"
-              git_repo: \"mondoo-demo-environment\"
+              Name: "12344375555-mondoo-demo-efs"
+              git_file: "terraform/aws/efs.tf"
+              git_org: "mondoolabs"
+              git_repo: "mondoo-demo-environment"
             }
-            id: \"fs-0a73947e541509f0e\"
-            region: \"us-west-2\"
-            name: \"12344375555-mondoo-demo-efs\"
+            id: "fs-0a73947e541509f0e"
+            region: "us-west-2"
+            name: "12344375555-mondoo-demo-efs"
             kmsKey: null
             encrypted: false
-            arn: \"arn:aws:elasticfilesystem:us-west-2:12344375555:file-system/fs-0a73947e541509f0e\"
+            arn: "arn:aws:elasticfilesystem:us-west-2:12344375555:file-system/fs-0a73947e541509f0e"
           }
         ]
         ```
@@ -2300,12 +2300,12 @@ queries:
         Note: `kms_key_id` attribute is optional, and a key will be created if you don't pass a KMS key ID.
 
         ```hcl
-        resource \"aws_efs_file_system\" \"encrypted-efs\" {
-          creation_token = \"my-kms-encrypted-efs\"
+        resource "aws_efs_file_system" "encrypted-efs" {
+          creation_token = "my-kms-encrypted-efs"
           encrypted      = true
-          kms_key_id     = \"arn:aws:kms:us-west-2:12344375555:key/16393ebd-3348-483f-b162-99b6648azz23\"
+          kms_key_id     = "arn:aws:kms:us-west-2:12344375555:key/16393ebd-3348-483f-b162-99b6648azz23"
           tags = {
-            Name = \"MyProduct\"
+            Name = "MyProduct"
           }
         }
         ```


### PR DESCRIPTION
These backslashes get rendered. Not sure why they're in there.