### PR TITLE
Update titles + add descriptions in AWS policy

### DIFF
--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -396,7 +396,7 @@ queries:
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html
         title: Set an account password policy for IAM users
   - uid: mondoo-aws-security-access-keys-rotated
-    title: Ensure active access keys are rotated
+    title: Ensure IAM user access keys are rotated
     impact: 70
     props:
       - uid: mondooAWSSecurityMaxAccessKeyAge
@@ -407,7 +407,9 @@ queries:
       aws.iam.credentialReport.where(accessKey2Active == true && time.now - userCreationTime > props.mondooAWSSecurityMaxAccessKeyAge * time.day).all(time.now - accessKey2LastRotated < props.mondooAWSSecurityMaxAccessKeyAge * time.day)
     docs:
       desc: |
-        It is highly recommended that you regularly rotate (change) IAM user access keys to reduce the risk of unwanted access to your account. Change the value enforced in this check by modifying the mondooAWSSecurityMaxAccessKeyAge property.
+        It is highly recommended that AWS IAM user access keys be rotated regularly to minimize the risk of unauthorized access and credential compromise. Access keys that remain active for extended periods increase the likelihood of exposure through accidental leaks, insider threats, or malicious attacks. Regular rotation ensures that even if a key is compromised, its window of usefulness is limited, reducing the impact of potential security breaches.
+
+        By default this check enforces a 90 day rotation period. To change this value modify the `mondooAWSSecurityMaxAccessKeyAge` property.
       audit: |
         __cnspec shell__
 
@@ -424,28 +426,28 @@ queries:
         ```mql
         aws.iam.credentialReport.where: [
           0: {
-            accessKey1LastRotated: 2021-09-01 01:32:29 +0000 +0000
+            accessKey1LastRotated: 2024-09-01 01:32:29 +0000 +0000
             accessKey2LastRotated: Never
             accessKey1Active: true
             accessKey2Active: false
             properties[user]: "jimmy"
           }
           1: {
-            accessKey1LastRotated: 2021-09-09 19:16:35 +0000 +0000
+            accessKey1LastRotated: 2024-09-09 19:16:35 +0000 +0000
             accessKey2LastRotated: Never
             accessKey1Active: true
             accessKey2Active: false
             properties[user]: "robert"
           }
           2: {
-            accessKey1LastRotated: 2021-06-15 07:18:34 +0000 +0000
+            accessKey1LastRotated: 2024-06-15 07:18:34 +0000 +0000
             accessKey2LastRotated: Never
             accessKey1Active: true
             accessKey2Active: false
             properties[user]: "johnpaul"
           }
           3: {
-            accessKey1LastRotated: 2021-09-29 21:53:04 +0000 +0000
+            accessKey1LastRotated: 2024-09-29 21:53:04 +0000 +0000
             accessKey2LastRotated: Never
             accessKey1Active: true
             accessKey2Active: false
@@ -1297,7 +1299,8 @@ queries:
       - uid: mondoo-aws-security-ec2-instance-no-public-ip-all
       - uid: mondoo-aws-security-ec2-instance-no-public-ip-single
     docs:
-      desc: EC2 instances with public IP addresses are at an increased risk of compromise. It is recommended that EC2 instances not be configured with a public IP address.
+      desc: |
+        It is highly recommended that AWS EC2 instances do not have an Elastic IP (EIP) attached unless absolutely necessary, as public IP exposure increases the attack surface and potential security risks. Instances with public IP addresses are directly accessible from the internet, making them vulnerable to brute-force attacks, exploitation of software vulnerabilities, and denial-of-service (DoS) attacks.
       audit: |
         __cnspec shell__
 
@@ -2362,7 +2365,7 @@ queries:
     mql: |
       aws.es.domains.all(encryptionAtRestEnabled == true)
   - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled
-    title: Ensure rotation for customer created CMKs is enabled
+    title: Ensure rotation for customer managed keys (CMKs) is enabled
     impact: 80
     mql: |
       aws.kms.keys
@@ -2374,6 +2377,9 @@ queries:
     impact: 50
     mql: |
       aws.sagemaker.notebookInstances.all(details.kmsKey != empty)
+    docs:
+      desc: |
+        It is highly recommended that AWS SageMaker notebooks be configured to use AWS Key Management Service (KMS) keys to encrypt data at rest. By enabling KMS encryption, organizations can ensure that sensitive data, including machine learning models, datasets, and notebook outputs, are protected from unauthorized access. Without KMS encryption, data stored in SageMaker could be vulnerable to potential breaches or insider threats.
   - uid: mondoo-aws-security-cloud-trail-encryption-enabled
     title: Ensure CloudTrail trails are configured to use the server-side encryption KMS
     impact: 70

--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -2365,7 +2365,7 @@ queries:
     mql: |
       aws.es.domains.all(encryptionAtRestEnabled == true)
   - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled
-    title: Ensure rotation for customer managed keys (CMKs) is enabled
+    title: Ensure rotation for customer-managed keys (CMKs) is enabled
     impact: 80
     mql: |
       aws.kms.keys

--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -409,7 +409,7 @@ queries:
       desc: |
         It is highly recommended that AWS IAM user access keys be rotated regularly to minimize the risk of unauthorized access and credential compromise. Access keys that remain active for extended periods increase the likelihood of exposure through accidental leaks, insider threats, or malicious attacks. Regular rotation ensures that, even if a key is compromised, its window of usefulness is limited. This reduces the impact of potential security breaches.
 
-        By default this check enforces a 90 day rotation period. To change this value modify the `mondooAWSSecurityMaxAccessKeyAge` property.
+        By default this check enforces a 90 day rotation period. To change this value, modify the `mondooAWSSecurityMaxAccessKeyAge` property.
       audit: |
         __cnspec shell__
 

--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -1300,7 +1300,7 @@ queries:
       - uid: mondoo-aws-security-ec2-instance-no-public-ip-single
     docs:
       desc: |
-        It is highly recommended that AWS EC2 instances do not have an Elastic IP (EIP) attached unless absolutely necessary, as public IP exposure increases the attack surface and potential security risks. Instances with public IP addresses are directly accessible from the internet, making them vulnerable to brute-force attacks, exploitation of software vulnerabilities, and denial-of-service (DoS) attacks.
+        It is highly recommended that AWS EC2 instances not have Elastic IPs (EIPs) attached unless absolutely necessary. Public IP exposure increases the attack surface and potential security risks. Instances with public IP addresses are directly accessible from the internet, making them vulnerable to brute-force attacks, exploitation of software vulnerabilities, and denial-of-service (DoS) attacks.
       audit: |
         __cnspec shell__
 

--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -407,7 +407,7 @@ queries:
       aws.iam.credentialReport.where(accessKey2Active == true && time.now - userCreationTime > props.mondooAWSSecurityMaxAccessKeyAge * time.day).all(time.now - accessKey2LastRotated < props.mondooAWSSecurityMaxAccessKeyAge * time.day)
     docs:
       desc: |
-        It is highly recommended that AWS IAM user access keys be rotated regularly to minimize the risk of unauthorized access and credential compromise. Access keys that remain active for extended periods increase the likelihood of exposure through accidental leaks, insider threats, or malicious attacks. Regular rotation ensures that even if a key is compromised, its window of usefulness is limited, reducing the impact of potential security breaches.
+        It is highly recommended that AWS IAM user access keys be rotated regularly to minimize the risk of unauthorized access and credential compromise. Access keys that remain active for extended periods increase the likelihood of exposure through accidental leaks, insider threats, or malicious attacks. Regular rotation ensures that, even if a key is compromised, its window of usefulness is limited. This reduces the impact of potential security breaches.
 
         By default this check enforces a 90 day rotation period. To change this value modify the `mondooAWSSecurityMaxAccessKeyAge` property.
       audit: |

--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -2379,7 +2379,7 @@ queries:
       aws.sagemaker.notebookInstances.all(details.kmsKey != empty)
     docs:
       desc: |
-        It is highly recommended that AWS SageMaker notebooks be configured to use AWS Key Management Service (KMS) keys to encrypt data at rest. By enabling KMS encryption, organizations can ensure that sensitive data, including machine learning models, datasets, and notebook outputs, are protected from unauthorized access. Without KMS encryption, data stored in SageMaker could be vulnerable to potential breaches or insider threats.
+        It is highly recommended that AWS SageMaker notebooks be configured to use AWS Key Management Service (KMS) keys to encrypt data at rest. By enabling KMS encryption, you can ensure that sensitive data, including machine learning models, datasets, and notebook outputs, are protected from unauthorized access. Without KMS encryption, data stored in SageMaker could be vulnerable to potential breaches or insider threats.
   - uid: mondoo-aws-security-cloud-trail-encryption-enabled
     title: Ensure CloudTrail trails are configured to use the server-side encryption KMS
     impact: 70


### PR DESCRIPTION
We had missing descriptions or descriptions that lacked the *why* for the recommendations.