### PR TITLE
Fix AWS Security chapters to match their brands

### DIFF
--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -113,10 +113,10 @@ policies:
       - title: AWS EFS Filesystem
         checks:
           - uid: mondoo-aws-security-efs-encrypted-check
-      - title: AWS CloudWatch LogGroup
+      - title: AWS CloudWatch
         checks:
           - uid: mondoo-aws-security-cloudwatch-log-group-encrypted
-      - title: AWS ELB LoadBalancer
+      - title: AWS ELB Load Balancer
         checks:
           - uid: mondoo-aws-security-elb-deletion-protection-enabled
       - title: AWS ES Domain
@@ -125,7 +125,7 @@ policies:
       - title: AWS KMS Key
         checks:
           - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled
-      - title: AWS SageMaker NotebookInstance
+      - title: AWS SageMaker Notebook Instance
         checks:
           - uid: mondoo-aws-security-sagemaker-notebook-instance-kms-key-configured
       - title: AWS CloudTrail Trail
@@ -1646,7 +1646,8 @@ queries:
             ```
 
             Ensure S3 bucket policies do not allow public access:
-            ```
+
+            ```hcl
             resource "aws_s3_bucket_policy" "secure_policy" {
               bucket = aws_s3_bucket.my_bucket.id
               policy = jsonencode({


### PR DESCRIPTION
We had some names there that matched their APIs but not the actual product names