### PR TITLE
✨ lint prod and edge + nightly

### DIFF
--- a/.github/workflows/lint-edge.yaml
+++ b/.github/workflows/lint-edge.yaml
@@ -1,0 +1,35 @@
+---
+name: "(edge) Lint Policies"
+
+on: workflow_call
+
+jobs:
+  cnspec-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Lint cnspec policies and output SARIF
+        uses: mondoohq/actions/cnspec-lint@edge-latest
+        with:
+          path: .
+          output-file: "results.sarif"
+      - name: Install jq
+        run: sudo apt-get install jq
+      - name: Display SARIF file content
+        run: cat results.sarif
+      - name: Upload SARIF results file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+      - name: Check SARIF file content
+        id: check_sarif
+        run: |
+          echo "Checking SARIF file content..."
+          RESULTS_EMPTY=$(cat results.sarif | jq '.runs[0].results | length == 0')
+          if [ "$RESULTS_EMPTY" = "true" ]; then
+            echo "SARIF file content is as expected. No results found."
+          else
+            echo "SARIF file contains results, indicating issues were found. Please review the SARIF file content below for more details, or check the 'Security' tab for alerts once the file has been uploaded."
+            exit 1
+          fi

--- a/.github/workflows/lint-prod.yaml
+++ b/.github/workflows/lint-prod.yaml
@@ -1,0 +1,34 @@
+---
+name: "(prod) Lint Policies"
+
+on: workflow_call
+
+jobs:
+  cnspec-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Lint cnspec policies and output SARIF
+        uses: mondoohq/actions/cnspec-lint@main
+        with:
+          path: .
+          output-file: "results.sarif"
+      - name: Install jq
+        run: sudo apt-get install jq
+      - name: Display SARIF file content
+        run: cat results.sarif
+      - name: Upload SARIF results file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+      - name: Check SARIF file content
+        run: |
+          echo "Checking SARIF file content..."
+          RESULTS_EMPTY=$(cat results.sarif | jq '.runs[0].results | length == 0')
+          if [ "$RESULTS_EMPTY" = "true" ]; then
+            echo "SARIF file content is as expected. No results found."
+          else
+            echo "SARIF file contains results, indicating issues were found. Please review the SARIF file content below for more details, or check the 'Security' tab for alerts once the file has been uploaded."
+            exit 1
+          fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,35 +9,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Lint cnspec policies and output SARIF
-        uses: mondoohq/actions/cnspec-lint@main
-        with:
-          path: .
-          output-file: "results.sarif"
-      - name: Install jq
-        run: sudo apt-get install jq
-      - name: Display SARIF file content
-        run: cat results.sarif
-      - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
-      - name: Check SARIF file content
-        id: check_sarif
-        run: |
-          echo "Checking SARIF file content..."
-          RESULTS_EMPTY=$(cat results.sarif | jq '.runs[0].results | length == 0')
-          if [ "$RESULTS_EMPTY" = "true" ]; then
-            echo "SARIF file content is as expected. No results found."
-          else
-            echo "SARIF file contains results, indicating issues were found. Please review the SARIF file content below for more details, or check the 'Security' tab for alerts once the file has been uploaded."
-            exit 1
-          fi
+  lint-prod:
+    uses: ./.github/workflows/lint-prod.yaml
+
+  lint-edge:
+    uses: ./.github/workflows/lint-edge.yaml
 
   license-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,42 @@
+name: "(nightly) cnspec-policies"
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+env:
+  # C07QZDJFF89 == #release-coordination
+  SLACK_BOT_CHANNEL_ID: "C07QZDJFF89"
+
+jobs:
+  lint-prod:
+    uses: ./.github/workflows/lint-prod.yaml
+
+  lint-edge:
+    uses: ./.github/workflows/lint-edge.yaml
+
+  notify:
+    needs: [lint-prod, lint-edge]
+    runs-on: ubuntu-latest
+    if : ${{ always() && failure() }}
+    steps:
+      - uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "${{ env.SLACK_BOT_CHANNEL_ID }}"
+            ts: "${{ steps.slack.outputs.ts }}"
+            text: "GitHub Actions Run"
+            attachments:
+              - color: "#FF0000"
+                blocks:
+                  - type: "section"
+                    fields:
+                      - type: "mrkdwn"
+                        text: "<${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}|${{ github.workflow }}>"
+                      - type: "mrkdwn"
+                        text: "<@channel> This needs attention!"
+                      - type: "mrkdwn"
+                        text: "*Status:*\n`Failure`"
+


### PR DESCRIPTION
* Add a new workflow that runs the `cnspec` linter from `edge`
* Move the lint workflow to be named prod for the released `cnspec` linter
* Run both workflows on every PR or merge to `main`
* Add new `nightly` workflow to detect regressions and publish a message to Slack on failure