### PR TITLE
⭐️ ingress nightmare vulnerability detection

### DIFF
--- a/core/vulnerabilities/mondoo-k8s-nginx-ingress-vulnerability.mql.yaml
+++ b/core/vulnerabilities/mondoo-k8s-nginx-ingress-vulnerability.mql.yaml
@@ -1,0 +1,82 @@
+# Copyright (c) Mondoo, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+policies:
+  - uid: mondoo-k8s-nginx-ingress-vulnerability
+    name: IngressNightmare Vulnerability (CVE-2024–3094)
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: k8s
+    authors:
+      - name: Mondoo, Inc
+        email: hello@mondoo.com
+    docs:
+      desc: |
+        Security researchers at Wiz discovered "IngressNightmare," a series of critical vulnerabilities (CVE-2025-1097, CVE-2025-1098, CVE-2025-24514, CVE-2025-1974) with a 9.8 CVSS score in the Ingress NGINX Controller for Kubernetes. The vulnerabilities allow unauthenticated remote code execution through the controller's admission webhook, potentially giving attackers access to all secrets across all Kubernetes namespaces and enabling complete cluster takeover.
+        
+        Users should update to Ingress NGINX Controller version 1.12.1 or 1.11.5 immediately, or temporarily disable the admission controller component if updating isn't possible. Only [Ingress NGINX Controller for Kubernetes](https://github.com/kubernetes/ingress-nginx) is affected by this vulnerability. The NGINX web server itself as well as [NGINX and NGINX Plus Ingress Controllers for Kubernetes ](https://github.com/nginx/kubernetes-ingress/) is not affected.
+        
+        This policy checks for the presence of the vulnerable Ingress NGINX Controller version.
+        
+        To run this policy against a Kubernetes cluster:
+        
+        ```bash
+        cnspec scan k8s -f ./mondoo-k8s-nginx-ingress-vulnerability.mql.yaml
+        ```
+    groups:
+      - filters: asset.family.contains("k8s")
+        checks:
+          - uid: mondoo-k8s-nginx-ingress-vulnerability-fixed-ingress-nginx
+queries:
+  - uid: mondoo-k8s-nginx-ingress-vulnerability-fixed-ingress-nginx
+    title: Ensure no vulnerably Ingress NGINX Controller for Kubernetes is installed
+    docs:
+      desc: |
+        The vulnerabilities allow unauthenticated remote code execution through the controller's admission webhook, potentially giving attackers access to all secrets across all Kubernetes namespaces and enabling complete cluster takeover.
+        
+        Users should update to Ingress NGINX Controller version 1.12.1 or 1.11.5 immediately, or temporarily disable the admission controller component if updating isn't possible.
+      audit: |
+        Run the following command and verify that no vulnerable versions are installed:
+        
+        ```
+        kubectl get pods --all-namespaces --selector app.kubernetes.io/name=ingress-nginx --output yaml
+        ```
+      remediation: |
+        Update to the latest version of ingress-nginx. You can install the latest version via:
+        
+        ```shell
+        helm upgrade --install ingress-nginx ingress-nginx \
+          --repo https://kubernetes.github.io/ingress-nginx \
+          --namespace ingress-nginx --create-namespace
+        ```
+        
+        If you do not use helm, the documentation describes alternative instructions for [installing the Ingress NGINX Controller for Kubernetes](https://kubernetes.github.io/ingress-nginx/deploy/).
+    refs:
+      - url: https://github.com/kubernetes/kubernetes/issues/131005
+        title: CVE-2025-24513
+      - url: https://github.com/kubernetes/kubernetes/issues/131006
+        title: CVE-2025-24514
+      - url: https://github.com/kubernetes/kubernetes/issues/131007
+        title: CVE-2025-1097
+      - url: https://github.com/kubernetes/kubernetes/issues/131008
+        title: CVE-2025-1098
+      - url: https://github.com/kubernetes/kubernetes/issues/131009
+        title: CVE-2025-1974
+      - url: https://www.wiz.io/blog/ingress-nginx-kubernetes-vulnerabilities
+        title: "IngressNightmare: 9.8 Critical Unauthenticated Remote Code Execution Vulnerabilities in Ingress NGINX"
+    variants:
+      - uid: mondoo-k8s-nginx-ingress-vulnerability-fixed-ingress-nginx-cluster
+  - uid: mondoo-k8s-nginx-ingress-vulnerability-fixed-ingress-nginx-cluster
+    filters: asset.platform == 'k8s-cluster'
+    mql: |
+      # check that no vulnerable version prior 1.11.5 is installed
+      k8s.deployments.where(labels["app.kubernetes.io/name"] == "ingress-nginx").none( 
+        version( labels["app.kubernetes.io/version"] ) < version("1.11.5")
+      )
+
+      # check that no vulnerable version 1.12.x is installed
+      k8s.deployments.where(labels["app.kubernetes.io/name"] == "ingress-nginx").none( 
+        version( labels["app.kubernetes.io/version"] ) > version("1.12.0") && version( labels["app.kubernetes.io/version"] ) < version("1.12.1")
+      )


### PR DESCRIPTION
This PR adds a policy to identify vulnerable version of [ingress-nginx)](https://github.com/kubernetes/ingress-nginx)

- [CVE-2025-24513](https://github.com/kubernetes/kubernetes/issues/131005)
- [CVE-2025-24514](https://github.com/kubernetes/kubernetes/issues/131006)
- [CVE-2025-1097](https://github.com/kubernetes/kubernetes/issues/131007)
- [CVE-2025-1098](https://github.com/kubernetes/kubernetes/issues/131008)
- [CVE-2025-1974](https://github.com/kubernetes/kubernetes/issues/131009)