### PR TITLE
Remove fluff text about provider in the policy descriptions

### DIFF
--- a/community/mondoo-linux-operational-policy.mql.yaml
+++ b/community/mondoo-linux-operational-policy.mql.yaml
@@ -30,12 +30,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Prerequisites
 
         Remote scans of Linux hosts requires authentication such as SSH keys.

--- a/community/mondoo-linux-snmp-policy.mql.yaml
+++ b/community/mondoo-linux-snmp-policy.mql.yaml
@@ -30,12 +30,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Prerequisites
 
         Remote scans of Linux hosts requires authentication such as SSH keys.

--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -20,12 +20,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers, run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Prerequisites
 
         Remote scanning of AWS accounts with cnspec relies on the access key ID and secret access key configured for the AWS CLI. To learn how to configure these keys in the AWS CLI, read [Configuring the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).

--- a/core/mondoo-dns-security.mql.yaml
+++ b/core/mondoo-dns-security.mql.yaml
@@ -20,12 +20,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Scan a host
 
         ```bash

--- a/core/mondoo-edr-policy.mql.yaml
+++ b/core/mondoo-edr-policy.mql.yaml
@@ -39,12 +39,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Prerequisites
 
         Remote scans of windows hosts suitable authentication method such as winRM enabled or SSH keys.

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -20,12 +20,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Prerequisites
 
         Remote scans of Google Cloud Projects requires API credentials with access to the project.

--- a/core/mondoo-http-security.mql.yaml
+++ b/core/mondoo-http-security.mql.yaml
@@ -20,12 +20,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Scan a host
 
         ```bash

--- a/core/mondoo-kubernetes-best-practices.mql.yaml
+++ b/core/mondoo-kubernetes-best-practices.mql.yaml
@@ -20,12 +20,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Prerequisites
 
         Remote scans of Kubernetes clusters requires a `KUBECONFIG` with access to the cluster you want to scan.

--- a/core/mondoo-kubernetes-security.mql.yaml
+++ b/core/mondoo-kubernetes-security.mql.yaml
@@ -24,12 +24,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Prerequisites
 
         Remote scans of Kubernetes clusters requires a `KUBECONFIG` with access to the cluster you want to scan.

--- a/core/mondoo-linux-workstation-security.mql.yaml
+++ b/core/mondoo-linux-workstation-security.mql.yaml
@@ -34,12 +34,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Prerequisites
 
         Remote scans of Linux hosts requires authentication such as SSH keys.

--- a/core/mondoo-macos-security.mql.yaml
+++ b/core/mondoo-macos-security.mql.yaml
@@ -29,12 +29,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Prerequisites
 
         Remote scans of macOS hosts requires **Remote login** to be enabled in the System Preferences, along with a suitable authentication method such as SSH keys.

--- a/core/mondoo-ms365-security.mql.yaml
+++ b/core/mondoo-ms365-security.mql.yaml
@@ -19,12 +19,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Installation
 
         Remote scans of Microsoft 365 require API credentials with access to the subscription. Please follow the setup guide to create a Application registration and grant access to it:

--- a/core/mondoo-windows-security.mql.yaml
+++ b/core/mondoo-windows-security.mql.yaml
@@ -29,12 +29,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Prerequisites
 
         Remote scans of Windows hosts require an authentication method such as winRM or SSH keys.

--- a/core/mondoo-windows-workstation-security.mql.yaml
+++ b/core/mondoo-windows-workstation-security.mql.yaml
@@ -32,12 +32,6 @@ policies:
 
         Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
 
-        For a complete list of providers run:
-
-        ```bash
-        cnspec scan --help
-        ```
-
         ### Prerequisites
 
         Remote scans of Linux hosts requires authentication such as SSH keys.


### PR DESCRIPTION
This isn't something we need to mention in the descriptions. It's something that should be in the docs (which it is)