### PR TITLE
🧹 Rework the AWS Security policy to focus on *why* you want it

### DIFF
--- a/core/mondoo-aws-security.mql.yaml
+++ b/core/mondoo-aws-security.mql.yaml
@@ -14,52 +14,27 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        The Mondoo AWS Security policy provides guidance for establishing minimum recommended security and operational best practices for Amazon Web Services (AWS). The checks in this policy bundle are based on AWS's Operational Best Practices recommendations as part of the [AWS Config conformance packs](https://docs.aws.amazon.com/config/latest/developerguide/conformance-packs.html).
+        The Mondoo AWS Security policy is designed to identify critical misconfigurations that could leave your AWS infrastructure vulnerable to attackers. This policy helps organizations detect and remediate security risks before they can be exploited, reducing the likelihood of unauthorized access, data breaches, privilege escalation, and operational disruptions.
 
-        ## Remote scan
+        This policy provides security checks across key AWS services, uncovering misconfigurations that could put critical resources at risk, particularly those exposed to the public internet:
 
-        Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
-
-        ### Prerequisites
-
-        Remote scanning of AWS accounts with cnspec relies on the access key ID and secret access key configured for the AWS CLI. To learn how to configure these keys in the AWS CLI, read [Configuring the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
-
-        ### Scan an AWS account
-
-        This command scans all enabled regions in an AWS account:
-
-        ```bash
-        cnspec scan aws
-        ```
-
-        ### Scan a single AWS region
-
-        To specify a single region to scan with cnspec, use the `--region` flag with the AWS region code:
-
-        ```bash
-        cnspec scan aws --region us-west-2
-        ```
-
-        For a complete list of AWS region codes, read [Regions and Zones](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html).
-
-        ### Scan an AWS account using a specific profile
-
-        If multiple AWS profiles are configured for the AWS CLI, you can target a specific profile by setting the `AWS_PROFILE` environment variable or the `--profile` command line flag.
-
-        ```bash
-        export AWS_PROFILE=my-profile
-        cnspec scan aws
-        ```
-
-        ```bash
-        cnspec scan aws --profile my-profile
-        ```
+        - Identity and Access Management (IAM)
+        - Lambda
+        - Simple Storage Service (S3)
+        - Virtual Private Cloud (VPCs)
+        - DynamoDB
+        - Relational Database Service (RDS) & Redshift
+        - Elastic Compute Cloud (EC2) instances & storage
+        - Elastic File System (EFS)
+        - CloudWatch
+        - Elastic Load Balancers (ELBs)
+        - Elasticsearch (OpenSearch Service)
+        - SageMaker
+        - CloudTrail
 
         ## Join the community!
 
-        Our goal is to build policies that are simple to deploy, accurate, and actionable.
-
-        If you have any suggestions for how to improve this policy or need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
+        Our goal is to build policies that are simple to deploy, accurate, and actionable. This policy is open-source and we welcome contributions from the community, whether it's adding new checks, refining existing ones, or providing feedback. If you have suggestions to improve this policy, visit our [cnspec-policies repository](https://github.com/mondoohq/cnspec-policies).
     groups:
       - title: AWS IAM
         checks:
@@ -113,7 +88,7 @@ policies:
       - title: AWS ELB Load Balancer
         checks:
           - uid: mondoo-aws-security-elb-deletion-protection-enabled
-      - title: AWS ES Domain
+      - title: AWS Elasticsearch Domain
         checks:
           - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest
       - title: AWS KMS Key


### PR DESCRIPTION
This is going to be seen in the policies page so focusing on how to manually scan is not helpful here. We have docs that cover those scenarios better anyway. Focus on *what* the user gets from this policy and *why* they should enable it.