### PR TITLE
🧹 Rework the GCP/Azure descriptions for the policies page

### DIFF
--- a/core/mondoo-azure-security.mql.yaml
+++ b/core/mondoo-azure-security.mql.yaml
@@ -13,59 +13,12 @@ policies:
       - name: Mondoo, Inc
         email: hello@mondoo.com
     docs:
-      desc: |-
-        The Mondoo Microsoft Azure Security policy provides guidance for establishing minimum recommended security and operational best practices for Microsoft Azure.
-
-        ## Getting Started
-
-        Step 1: Download and Install cnspec
-        Download the latest version of cnspec from the official releases page. (https://releases.mondoo.com/cnspec/)
-
-          **Example for Ubuntu System:**
-
-            Download cnspec_10.11.1_linux_amd64.tar.gz.
-            Extract the archive:
-
-            ```bash
-            tar -xvf cnspec_10.11.1_linux_amd64.tar.gz
-            ```
-            This command unpacks the cnspec binary, which you can now use to scan your Azure environment.
-
-        Step 2: Authentication to Azure
-        There are two primary methods to authenticate cnspec to your Azure environments:
-
-        **a. Azure CLI Login**
-
-        ```bash
-        az login
-        ```
-
-        Once logged in, you can scan your Azure environment using the policy bundle:
-
-        ```bash
-        cnspec scan azure --subscription <subscription_id> --policy-bundle mondoo-azure-security.mql.yaml
-        ```
-
-        To run MQL commands individually in an interactive session:
-
-        ```bash
-        cnspec shell azure --subscription <subscription_id>
-        ```
-
-        **b. Azure AD App Registration**
-
-        Set up an Azure AD application registration for cnspec with the appropriate permissions as per the instructions on Mondoo Docs. Follow the instructions on https://mondoo.com/docs/platform/infra/cloud/azure/azure-integration-scan-subscription/ to set up this app.
-        Use the following command to initiate a scan with the Azure AD application:
-
-        ```bash
-        cnspec scan azure --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id> --policy-bundle mondoo-azure-security.mql.yaml
-        ```
+      desc: |
+        The Mondoo Azure Security policy is designed to identify critical misconfigurations that could leave your Azure infrastructure vulnerable to attackers. This policy helps organizations detect and remediate security risks before they can be exploited, reducing the likelihood of unauthorized access, data breaches, privilege escalation, and operational disruptions.
 
         ## Join the community!
 
-        Our goal is to build policies that are simple to deploy, accurate, and actionable.
-
-        If you have any suggestions for how to improve this policy or need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
+        Our goal is to build policies that are simple to deploy, accurate, and actionable. This policy is open-source and we welcome contributions from the community, whether it's adding new checks, refining existing ones, or providing feedback. If you have suggestions to improve this policy, visit our [cnspec-policies repository](https://github.com/mondoohq/cnspec-policies).
     groups:
       - title: Azure Core
         filters: |

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -13,46 +13,12 @@ policies:
       - name: Mondoo, Inc
         email: hello@mondoo.com
     docs:
-      desc: |-
-        The Mondoo Google Cloud Security policy provides guidance for establishing minimum recommended security and operational best practices for Google Cloud.
-
-        ## Remote scan
-
-        Remote scans use cnspec providers to retrieve on-demand scan results without having to install any agents.
-
-        ### Prerequisites
-
-        Remote scans of Google Cloud Projects requires API credentials with access to the project.
-
-        ### Scan a GCP project
-
-        Open a terminal and authenticate with Google Cloud:
-
-        ```bash
-        gcloud auth login
-        ```
-
-        Run a scan of a GCP project:
-
-        ```bash
-        cnspec scan gcp
-        ```
-
-        To target a specific project:
-
-        ```bash
-        gcloud config set project <project_id>
-        ```
-
-        ```bash
-        cnspec scan gcp
-        ```
+      desc: |
+        The Mondoo Google Cloud (GCP) Security policy is designed to identify critical misconfigurations that could leave your Google Cloud infrastructure vulnerable to attackers. This policy helps organizations detect and remediate security risks before they can be exploited, reducing the likelihood of unauthorized access, data breaches, privilege escalation, and operational disruptions.
 
         ## Join the community!
 
-        Our goal is to build policies that are simple to deploy, accurate, and actionable.
-
-        If you have any suggestions for how to improve this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
+        Our goal is to build policies that are simple to deploy, accurate, and actionable. This policy is open-source and we welcome contributions from the community, whether it's adding new checks, refining existing ones, or providing feedback. If you have suggestions to improve this policy, visit our [cnspec-policies repository](https://github.com/mondoohq/cnspec-policies).
     groups:
       - title: GCP Project
         filters: |


### PR DESCRIPTION
Focus on why you should use these not how to do CLI scans