### PR TITLE
:broom: Mondoo Azure fix: Ensure that activity log alerts exist for the commands Create, Update, and Delete Network Security Group

### DIFF
--- a/core/mondoo-azure-security.mql.yaml
+++ b/core/mondoo-azure-security.mql.yaml
@@ -4,7 +4,7 @@
 policies:
   - uid: mondoo-azure-security
     name: Mondoo Microsoft Azure Security
-    version: 2.0.2
+    version: 2.0.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -1303,7 +1303,7 @@ queries:
     title: Ensure that activity log alerts exist for the commands Create, Update, and Delete Network Security Group
     impact: 80
     mql: |
-      azure.subscription.monitor.activityLog.alerts.where(actions != empty).any(conditions.any(equals == "Microsoft.Authorization/policyAssignments/write" && fieldName == "operationName"))
+      azure.subscription.monitor.activityLog.alerts.where(actions != empty).any(conditions.any(equals == "Microsoft.Network/networkSecurityGroups/write" && fieldName == "operationName"))
       azure.subscription.monitor.activityLog.alerts.where(actions != empty).any(conditions.any(equals == "Microsoft.Network/networkSecurityGroups/delete" && fieldName == "operationName"))
     docs:
       desc: |


### PR DESCRIPTION
Fixes one Azure check