### PR TITLE
Improve descriptions for checks in the Linux Policy

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -17,7 +17,6 @@ benbi
 bigfish
 bigquery
 bonzo
-bootkits
 Bpcy
 bqowner
 btmp

--- a/core/mondoo-linux-security.mql.yaml
+++ b/core/mondoo-linux-security.mql.yaml
@@ -145,8 +145,7 @@ policies:
         checks:
           - uid: mondoo-linux-security-audit-log-storage-size-is-configured
           - uid: mondoo-linux-security-audit-logs-are-not-automatically-deleted
-          - uid: mondoo-linux-security-auditd-is-installed
-          - uid: mondoo-linux-security-auditd-service-is-enabled
+          - uid: mondoo-linux-security-auditd-is-installed-and-running
           - uid: mondoo-linux-security-auditing-for-processes-that-start-prior-to-auditd-is-enabled
           - uid: mondoo-linux-security-changes-to-system-administration-scope-sudoers-is-collected
           - uid: mondoo-linux-security-discretionary-access-control-permission-modification-events-are-collected
@@ -197,7 +196,20 @@ queries:
     mql: |
       package("aide").installed
     docs:
-      desc: Advanced Intrusion Detection Environment (AIDE) takes a snapshot of the filesystem state, including modification times, permissions, and file hashes. Administrators can then use this to compare against the current state of the filesystem to detect modifications to the system.
+      desc: |
+        This check verifies that the Advanced Intrusion Detection Environment (AIDE) is installed on a Linux system. AIDE functions as a file integrity checker that helps detect unauthorized changes to critical system files and configurations.
+
+        **Rationale:**
+
+        AIDE creates a database of cryptographic checksums for important system files and directories. Once initialized, AIDE can be used to scan the system and compare the current state of files against the known-good baseline. This process helps detect file tampering, rootkit installation, or configuration drift that may indicate a security breach.
+
+        Without a host-based file integrity monitoring (FIM) solution like AIDE, administrators may not be aware of changes to critical files made by malicious actors or unintended actions by privileged users. This lack of visibility undermines incident response, auditability, and system trustworthiness.
+
+        Installing AIDE contributes to the overall integrity assurance of a Linux system and supports compliance with standards such as:
+          - PCI-DSS Requirement 11.5
+          - NIST 800-53 (SI-7: Software, Firmware, and Information Integrity)
+
+        Ensuring AIDE is installed lays the foundation for host-based file integrity monitoring, which is a critical part of a defense-in-depth strategy for detecting intrusions and preserving system integrity.
       remediation: |-
         Run this command to install `aide`:
 
@@ -227,7 +239,7 @@ queries:
         aideinit
         ```
   - uid: mondoo-linux-security-filesystem-integrity-is-regularly-checked
-    title: Ensure filesystem integrity is regularly checked
+    title: Ensure filesystem integrity is regularly checked using AIDE
     impact: 50
     filters: |
       asset.kind != "container-image"
@@ -237,7 +249,19 @@ queries:
       command("crontab -u root -l | grep aide").stdout.lines.where(/^[^#]/).any(_.contains("aide.conf --check")) ||
       service('aidecheck').enabled
     docs:
-      desc: Periodic checking of the filesystem integrity is needed to detect changes to the filesystem.
+      desc: |
+        This check verifies that AIDE (Advanced Intrusion Detection Environment) is actively used to perform regular integrity scans of the filesystem. It ensures that an AIDE database has been initialized and that periodic checks are scheduled and executed.
+
+        **Rationale:**
+
+        Installing AIDE alone is not sufficient to protect a system from unauthorized changes. To be effective, AIDE must be routinely run to compare the current system state against its known-good baseline. Regular execution of these checks helps detect file tampering, unauthorized modifications, and early signs of compromise—especially in sensitive directories like /etc, /bin, and /sbin.
+
+        If AIDE is not executed on a regular basis:
+          - Integrity violations may go undetected, exposing the system to persistent threats such as rootkits or malware.
+          - Audit logs and incident response efforts may be incomplete due to a lack of timely data.
+          - Organizations may fail to meet compliance requirements that mandate proactive monitoring of system integrity.
+
+        Regular integrity checks serve as a crucial early warning mechanism that strengthens security posture by enabling timely investigation and response.
       remediation: |-
         ### To run aide using cron
 
@@ -310,7 +334,24 @@ queries:
         parse.ini("/etc/systemd/coredump.conf").sections['Coredump']['Storage'] == 'none'
       }
     docs:
-      desc: A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user.
+      desc: |
+        This check verifies that core dumps are restricted on the system by setting appropriate limits in `/etc/security/limits.conf`, configuring the `fs.suid_dumpable` kernel parameter, and ensuring the `coredump` service (if installed) is properly configured. These settings prevent unauthorized or excessive core dump creation, especially for set-user-ID (SUID) programs.
+
+        **Rationale:**
+
+        Core dumps capture the memory contents of a process at the time it crashes. While useful for debugging, core dumps can expose sensitive information such as passwords, cryptographic keys, or proprietary application logic—especially if generated by privileged or network-facing applications.
+
+        By default, systems may allow core dumps for all processes, including those with elevated privileges. If unrestricted:
+          - Attackers could exploit this to gain access to in-memory secrets.
+          - Users could accidentally or intentionally generate core dumps containing sensitive information.
+          - Storage systems could become overwhelmed by large or repeated core files, leading to denial-of-service risks.
+
+        To mitigate this, three key protections should be enforced:
+          - A hard limit of 0 core file size in /etc/security/limits.conf to block core dumps for all users by default.
+          - Setting the fs.suid_dumpable kernel parameter to 0 to disable core dumps for SUID programs, which typically run with elevated privileges.
+          - Properly configuring the coredump service (if installed) with ProcessSizeMax=0 and Storage=none to prevent systemd-based core dump handling from storing crash data.
+
+        Restricting core dumps helps preserve the confidentiality of system memory, prevents unnecessary disk usage, and protects against inadvertent leakage of sensitive data.
       remediation: |-
         Add the following line to `/etc/security/limits.conf` or a `/etc/security/limits.d/` file:
 
@@ -353,7 +394,19 @@ queries:
     mql: |
       kernel.parameters["kernel.randomize_va_space"] == 2
     docs:
-      desc: Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process.
+      desc: |
+        This check verifies that Address Space Layout Randomization (ASLR) is enabled by confirming that the kernel parameter kernel.randomize_va_space is set to 2, which enforces full randomization of memory regions.
+
+        **Rationale:**
+
+        ASLR is a memory protection technique that randomizes the location of key data areas in a process's address space, such as the stack, heap, and libraries. This unpredictability makes it significantly harder for attackers to exploit memory corruption vulnerabilities, such as buffer overflows, since they cannot reliably guess the locations of critical functions or data structures in memory.
+
+        When ASLR is disabled or misconfigured:
+          - Exploits that rely on fixed memory addresses become easier to execute.
+          - Attackers may leverage known memory layouts to bypass protections like stack canaries, non-executable memory (NX), and control flow integrity.
+          - Systems become more susceptible to privilege escalation, remote code execution, and other forms of memory-based attacks.
+
+        Setting kernel.randomize_va_space to 2 enables full ASLR, providing the strongest level of memory layout unpredictability and helping to enforce modern exploit mitigation strategies on Linux systems.
       remediation: |-
         Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
@@ -372,7 +425,17 @@ queries:
     mql: |
       package("prelink").installed == false
     docs:
-      desc: The `prelink` command changes binaries in an attempt to decrease their startup time. Prelinking can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc.
+      desc: |
+        This check verifies that the prelink package is not installed on the system. The prelink utility modifies ELF binaries to optimize program load times by precomputing memory locations for shared libraries. While this can improve performance, it also introduces security risks and interferes with other critical system protections.
+
+        **Rationale:**
+
+        Disabling prelink helps ensure the reliability of security tools and strengthens system integrity protections. When prelink is active:
+          - It modifies binaries on disk, which can prevent tools like AIDE from detecting unauthorized tampering because legitimate prelink changes obscure unauthorized ones.
+          - It can negate security mechanisms such as Address Space Layout Randomization (ASLR) by fixing memory address locations in advance, undermining this key exploit mitigation technique.
+          - It increases the system's attack surface by introducing complexity and modifying binaries in ways that may be exploited or misunderstood by defenders.
+
+        Removing prelink eliminates this unnecessary risk, ensures compatibility with file integrity monitoring tools, and supports consistent enforcement of modern memory protection strategies.
       remediation: |-
         Run these commands to restore binaries to normal and uninstall `prelink`:
 
@@ -395,7 +458,19 @@ queries:
     mql: |
       packages.none(name == /^xserver-xorg.*/ || name == /^xorg-x11/ || name == /^xserver/)
     docs:
-      desc: The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows to run programs and various add-ons. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login.
+      desc: |
+        This check verifies that the X Window System is not installed on the host. It scans for common packages associated with X, such as xserver-xorg, xorg-x11, and other display server components.
+
+        **Rationale:**
+
+        The X Window System provides a graphical user interface (GUI) that enables users to interact with applications through windows, menus, and graphical controls. While useful for desktop environments, it is generally unnecessary—and potentially risky—on servers or hardened systems that do not require graphical interfaces.
+
+        Keeping the X Window System installed on a server can:
+          - Introduce unnecessary software components and services, increasing the system's attack surface.
+          - Add network-facing daemons that may not be actively monitored or patched, creating potential entry points for attackers.
+          - Consume additional system resources that could otherwise be allocated to critical services.
+
+        On headless or server-class Linux systems, the X Window System should be removed unless explicitly required. Removing it aligns with the principle of least functionality, ensuring only essential software is installed and reducing the opportunity for exploitation.
       remediation: |-
         Run this command to remove the X Windows System packages:
 
@@ -425,7 +500,17 @@ queries:
       service("avahi-daemon").enabled == false
       service("avahi-daemon").running == false
     docs:
-      desc: Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine.
+      desc: |
+        This check verifies that the avahi-daemon service is neither running nor enabled on the system. Avahi is a zeroconf (zero-configuration networking) implementation that supports multicast DNS (mDNS) and DNS Service Discovery (DNS-SD), allowing devices to automatically discover each other on local networks.
+
+        **Rationale:**
+
+        While convenient in desktop or home environments, Avahi is rarely needed on production servers or hardened enterprise systems. When enabled, the Avahi daemon broadcasts services and listens for network announcements, which can:
+          - Expose unnecessary information about the system to local network peers.
+          - Increase the system's attack surface through unneeded services.
+          - Allow unauthorized devices to detect and interact with the host without explicit configuration.
+
+        In secure environments, it is a best practice to disable Avahi unless explicitly required for functionality. Stopping and disabling the avahi-daemon service helps enforce the principle of least functionality and reduces the risk of unintended network exposure.
       remediation: |-
         Run this command to stop and disable `avahi-daemon`:
 
@@ -450,7 +535,17 @@ queries:
       service("cups").enabled == false
       service("cups").running == false
     docs:
-      desc: The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability.
+      desc: |
+        This check verifies that the Common Unix Printing System (CUPS) service is neither running nor enabled on the system. CUPS provides printing capabilities for local and network printers and includes web-based administration tools.
+
+        **Rationale:**
+
+        CUPS is typically unnecessary on hardened servers or cloud-hosted Linux systems where printing services are not required. If left running:
+          - It may expose the system to remote exploitation, especially if administrative interfaces are accessible over the network.
+          - It increases the overall attack surface by introducing a network-accessible daemon.
+          - Unused services like CUPS can be leveraged in lateral movement or privilege escalation scenarios, particularly if misconfigured or unpatched.
+
+        Disabling CUPS aligns with the principle of least functionality and helps reduce the number of services available for exploitation. It is recommended to stop and disable the service unless printing capabilities are explicitly required for the system's role.
       remediation: |-
         Run this command to stop and disable `cups`:
 
@@ -479,7 +574,19 @@ queries:
       service("dhcpd").enabled == false
       service("dhcpd").running == false
     docs:
-      desc: The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses.
+      desc: |
+        This check verifies that the DHCP server service (dhcpd) is neither running nor enabled on the system.
+
+        **Rationale:**
+
+        The Dynamic Host Configuration Protocol (DHCP) allows systems to dynamically assign IP addresses and other network configuration parameters to devices on a network. While essential in network infrastructure roles, DHCP servers are rarely required on general-purpose Linux systems or production servers.
+
+        Running a DHCP server where it is not explicitly needed can:
+          - Lead to IP address conflicts and unpredictable network behavior.
+          - Allow unauthorized clients to obtain network configuration from an untrusted source.
+          - Expose the host to exploitation if the service is vulnerable or misconfigured.
+
+        Disabling unused services like dhcpd reduces the system's attack surface and aligns with the principle of least functionality. On systems that are not intended to serve as DHCP servers, the service should be fully disabled to prevent accidental exposure or misuse.
       remediation: |-
         Run this command to stop and disable `dhcpd`:
 
@@ -496,7 +603,19 @@ queries:
       service("slapd").enabled == false
       service("slapd").running == false
     docs:
-      desc: The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database.
+      desc: |
+        This check verifies that the LDAP server service (slapd) is neither running nor enabled on the system.
+
+        **Rationale:**
+
+        The Lightweight Directory Access Protocol (LDAP) server provides centralized directory services for managing user identities, authentication data, and configuration information across a network. While useful in enterprise environments that require directory-based access management, an LDAP server is rarely needed on general-purpose Linux systems unless explicitly part of the infrastructure design.
+
+        If an unnecessary LDAP server is running:
+          - It may expose sensitive directory information to the network.
+          - It increases the system's attack surface by introducing a network-accessible service.
+          - It can be misused or targeted by attackers to enumerate user accounts, perform unauthorized lookups, or exploit known vulnerabilities.
+
+        To reduce risk and enforce the principle of least functionality, the slapd service should be stopped and disabled on systems that are not intended to serve directory services. This helps limit exposure and strengthens the host's overall security posture.
       remediation: |-
         Run this command to stop and disable `slapd`:
 
@@ -515,7 +634,19 @@ queries:
       service("rpcbind").enabled == false
       service("rpcbind").running == false
     docs:
-      desc: The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network.
+      desc: |
+        This check verifies that the NFS (nfs) and RPC (rpcbind) services are not running and are disabled from starting at boot. These services are commonly used to share directories across systems on a network using the Network File System (NFS) protocol.
+
+        **Rationale:**
+
+        NFS and RPC are powerful but legacy components of networked UNIX environments. They introduce significant security risks when enabled unnecessarily, particularly on systems not explicitly configured as file servers or requiring remote filesystem mounts.
+
+        When NFS and RPC are active:
+          - They open multiple ports and expose services that can be discovered and potentially exploited.
+          - RPC-based services may leak metadata about system configurations or mount points.
+          - Misconfigurations or vulnerabilities in these services can be used for privilege escalation, lateral movement, or data exfiltration.
+
+        Disabling NFS and RPC services on systems where they are not required reduces unnecessary network exposure, aligns with the principle of least functionality, and helps harden systems against remote access threats.
       remediation: |-
         Run these commands to stop and disable `nfs` and `rpcbind`:
 
@@ -537,7 +668,19 @@ queries:
       service("bind9").enabled == false
       service("bind9").running == false
     docs:
-      desc: The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network.
+      desc: |
+        This check verifies that DNS server services such as named (BIND) or bind9 are not running and are disabled on the system.
+
+        **Rationale:**
+
+        DNS servers provide name resolution services by mapping domain names to IP addresses. While essential in network infrastructure roles, running a DNS server on systems that are not explicitly intended to serve DNS requests introduces unnecessary risk.
+
+        If a DNS server is unintentionally left active:
+          - It may expose internal network details or zone files to unauthorized users.
+          - It can be used in DNS amplification attacks if misconfigured.
+          - It increases the system's attack surface through open ports and additional daemon processes.
+
+        Disabling DNS server services on systems that are not authoritative or caching resolvers aligns with the principle of least functionality. This reduces exposure to misconfiguration, limits available network services, and strengthens the host's security posture.
       remediation: |-
         Run this command to stop and disable BIND:
 
@@ -562,9 +705,18 @@ queries:
       service("pure-ftpd").running == false
     docs:
       desc: |-
-        File Transfer Protocol (FTP) servers enables the transfer of files between computers over a network, supporting file upload, download, and management.
+        This check verifies that common FTP server services—vsftpd, proftpd, and pure-ftpd—are not running and are disabled on the system.
 
-        FTP transmits data—including usernames and passwords—in plaintext. If possible use more secure protocols such as FTPS or SFTP, which encrypt the entire session, ensuring that sensitive information and files remain secure from unauthorized access.
+        **Rationale:**
+
+        FTP servers enable file transfer over a network but do so using plaintext for both data and credentials, making them inherently insecure. When enabled without encryption or proper controls, FTP services are vulnerable to:
+          - Credential theft through packet sniffing
+          - Unauthorized file access or modification
+          - Abuse in reconnaissance and data exfiltration by attackers
+
+        In most environments, FTP has been replaced by more secure alternatives like SFTP or FTPS, which encrypt both authentication and file transfer traffic. Unless explicitly required, running an FTP server introduces unnecessary risk and increases the system's attack surface.
+
+        Disabling vsftpd, proftpd, and pure-ftpd helps enforce the principle of least functionality by ensuring that legacy, insecure services are not inadvertently exposed or abused.
       remediation: |-
         Run this command to stop and disable `vsftpd`, `proftpd`, and `pure-ftpd`:
 
@@ -591,7 +743,19 @@ queries:
       service("nginx").enabled == false
       service("nginx").running == false
     docs:
-      desc: HTTP or web servers provide the ability to host web site content.
+      desc: |
+        This check verifies that common HTTP server services such as httpd, apache2, and nginx are not running and are disabled on the system.
+
+        **Rationale:**
+
+        HTTP servers provide web hosting functionality and are often exposed to the network, making them high-value targets for attackers. Unless the system is explicitly intended to serve web content, running these services introduces unnecessary security risk.
+
+        If left enabled:
+          - HTTP servers can expose sensitive files or administrative interfaces.
+          - They may contain unpatched vulnerabilities that are remotely exploitable.
+          - Misconfigurations can lead to data leakage, privilege escalation, or unauthorized access.
+
+        Disabling web servers like Apache and NGINX on systems where they are not required aligns with the principle of least functionality. This reduces the system's attack surface and helps ensure that only essential services are active and maintained.
       remediation: |-
         Run these commands to stop and disable web servers:
 
@@ -616,7 +780,19 @@ queries:
       service("cyrus-imapd").enabled == false
       service("cyrus-imapd").running == false
     docs:
-      desc: '`dovecot` and `cyrus-imapd` are open source IMAP and POP3 servers for Linux.'
+      desc: |
+        This check verifies that common IMAP and POP3 email server services such as dovecot and cyrus-imapd are not running and are disabled from starting at boot.
+
+        **Rationale:**
+
+        IMAP (Internet Message Access Protocol) and POP3 (Post Office Protocol) servers are used to deliver email messages to clients. These services are typically deployed in environments where systems are designated as mail servers. On general-purpose Linux systems or hardened servers, they are rarely required and introduce unnecessary risk if left enabled.
+
+        Running IMAP or POP3 servers where not needed can:
+          - Expose authentication services and mail data to the network.
+          - Increase the system's attack surface via potentially unpatched or misconfigured mail daemons.
+          - Create compliance and privacy issues if email data is improperly stored or transmitted.
+
+        To minimize exposure, systems that do not explicitly require mail delivery services should have dovecot, cyrus-imapd, and similar services disabled. This approach supports the principle of least functionality and reduces the risk of unauthorized access or system compromise.
       remediation: |-
         Run this command to stop and disable `dovecot` and `cyrus-imapd`:
 
@@ -638,7 +814,19 @@ queries:
       service("smb").running == false
       service("smbd").running == false
     docs:
-      desc: The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users can mount these directories and file systems as letter drives on their systems.
+      desc: |
+        This check verifies that the Samba services (smb and smbd) are not running and are disabled on the system.
+
+        **Rationale:**
+
+        Samba provides file and print sharing capabilities for interoperability between Linux and Windows systems using the SMB/CIFS protocol. While useful in mixed OS environments that require shared resources, Samba is unnecessary—and potentially risky—on systems that are not intended to serve files or printers over the network.
+
+        If Samba is enabled where not needed:
+          - It introduces network-facing services that can be discovered and targeted by attackers.
+          - Misconfigurations or outdated Samba versions may allow unauthorized access or remote code execution.
+          - It increases the system's attack surface and may expose internal file systems unintentionally.
+
+        To minimize unnecessary exposure, Samba should be disabled on systems that do not explicitly require Windows-compatible file sharing. This approach supports a least functionality model and helps reduce the risk of data leakage or compromise.
       remediation: |-
         Run this command to stop and disable `smb` and `smbd` services:
 
@@ -660,7 +848,19 @@ queries:
       service("tinyproxy").enabled == false
       service("tinyproxy").running == false
     docs:
-      desc: Squid and Tinyproxy are HTTP proxy servers used to proxy and potentially anonymize HTTP traffic through other hosts.
+      desc: |
+        This check verifies that HTTP proxy services such as squid and tinyproxy are not running and are disabled on the system.
+
+        **Rationale:**
+
+        HTTP proxy servers are used to forward client requests to destination servers, often to enable caching, access control, or anonymization of traffic. While valuable in network perimeter or gateway roles, proxy services are rarely needed on general-purpose Linux systems or hardened servers.
+
+        If an HTTP proxy service is enabled unnecessarily:
+          - It may relay traffic without proper filtering or monitoring, exposing the system to misuse or abuse.
+          - Misconfigured proxies can be exploited to bypass security controls, leak sensitive information, or allow unauthorized access to internal networks.
+          - Proxy daemons increase the system's attack surface through open ports and additional network logic.
+
+        To reduce risk, squid, tinyproxy, and similar services should be stopped and disabled unless the system is explicitly designed to function as a proxy server. This limits unnecessary service exposure and aligns with best practices for host hardening.
       remediation: |-
         Run this command to stop and disable `squid` and `tinyproxy`:
 
@@ -680,7 +880,19 @@ queries:
       service("snmpd").enabled == false
       service("snmpd").running == false
     docs:
-      desc: The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system.
+      desc: |
+        This check verifies that the SNMP server service (snmpd) is not running and is disabled on the system.
+
+        **Rationale:**
+
+        The Simple Network Management Protocol (SNMP) is used for monitoring and managing network devices. While SNMP can be valuable in infrastructure environments that require centralized device monitoring, it is rarely needed on general-purpose Linux systems or non-networking servers.
+
+        If the SNMP service is enabled unnecessarily:
+          - It may expose system and network information to unauthorized users, especially if default community strings are not changed.
+          - SNMPv1 and SNMPv2c transmit data in plaintext, making them vulnerable to interception and misuse.
+          - Misconfigured or unmonitored SNMP services can be leveraged for network reconnaissance or as part of broader attack campaigns.
+
+        To reduce the risk of information disclosure and limit unnecessary network services, snmpd should be stopped and disabled on systems that are not specifically designated for SNMP-based monitoring. This supports the principle of least functionality and strengthens the system's security posture.
       remediation: |-
         Run this command to stop and disable `snmpd`:
 
@@ -702,8 +914,22 @@ queries:
       }
       ports.listening.where(address != "127.0.0.1" && address != "[::1]").none(port == 25)
     docs:
-      desc: Mail Transfer Agents (MTA), such as Exim and Postfix, listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail.
+      desc: |
+        This check verifies that the system's mail transfer agent (MTA), such as Postfix or Exim, is configured to accept and process email only from the local host, rather than listening on external network interfaces.
+
+        **Rationale:**
+
+        Mail transfer agents are used to route and deliver email messages. On most Linux systems, an MTA is installed by default to handle local system notifications, such as cron job outputs or security alerts. However, if the MTA is configured to listen on external interfaces, it may unintentionally expose the system to external email traffic.
+
+        Allowing remote connections to a local MTA can:
+          - Turn the system into an open relay if not properly secured.
+          - Increase the attack surface by exposing the MTA to brute-force attacks, spoofed messages, or software vulnerabilities.
+          - Introduce compliance concerns if email flows are not properly audited or encrypted.
+
+        Configuring the MTA to listen only on the loopback interface (127.0.0.1) ensures it serves only local applications and users. This reduces exposure, limits attack vectors, and aligns with security best practices for systems that are not intended to function as full email servers.
       remediation: |-
+        **For Postfix**
+
         Edit `/etc/postfix/main.cf` and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below:
 
         ```
@@ -714,6 +940,23 @@ queries:
 
         ```bash
         systemctl restart postfix
+        ```
+
+        **For Exim4 (Debian/Ubuntu)**
+
+        Edit the Exim4 configuration file, typically located at `/etc/exim4/update-exim4.conf.conf``. Find the line that sets `dc_local_interfaces` and modify it to the following:
+
+        ```
+        dc_local_interfaces='127.0.0.1 ; ::1'
+        ```
+
+        This configuration limits Exim4 to listening only on the loopback IPv4 and IPv6 interfaces.
+
+        After making the change, regenerate the Exim4 runtime configuration and restart the service:
+
+        ```bash
+        update-exim4.conf
+        systemctl restart exim4
         ```
   - uid: mondoo-linux-security-nis-server-is-not-enabled
     title: Ensure NIS server is stopped and not enabled
@@ -726,7 +969,19 @@ queries:
       service("nis").enabled == false
       service("nis").running == false
     docs:
-      desc: The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files.
+      desc: |
+        This check verifies that the Network Information Service (NIS) server services, such as ypserv or nis, are not running and are disabled on the system.
+
+        **Rationale:**
+
+        NIS (formerly known as Yellow Pages) is a legacy directory service protocol used to centrally manage user accounts and configuration data across multiple systems. While once common in UNIX environments, NIS has significant security limitations and has been largely replaced by more secure alternatives like LDAP or Kerberos.
+
+        If the NIS server is enabled unnecessarily:
+          - It may transmit sensitive data such as usernames and password hashes in plaintext.
+          - NIS lacks modern authentication and encryption mechanisms, making it highly susceptible to eavesdropping and spoofing attacks.
+          - Running NIS services can expose the system to unauthorized access or information disclosure, especially in mixed or untrusted networks.
+
+        On systems that are not explicitly designated to serve as NIS servers, ypserv, nis, and related services should be stopped and disabled. This helps enforce the principle of least functionality and significantly reduces the system's vulnerability to legacy protocol risks.
       remediation: |-
         Run this command to stop and disable `ypserv` and `nis` services:
 
@@ -750,10 +1005,19 @@ queries:
       service("rlogin.socket").running == false
       service("rexec.socket").running == false
     docs:
-      desc: |-
-        `rsh`, sometimes referred to as Remote Shell, is a command-line client/server suite or tools (rsh, rlogin, and rcp) used to execute commands on a remote machine.
+      desc: |
+        This check verifies that the Remote Shell (rsh) server services—specifically rsh.socket, rlogin.socket, and rexec.socket—are not running and are disabled on the system.
 
-        `rsh` is inherently insecure because it transmits data, including passwords, in plaintext over the network, making it vulnerable to interception and includes weak host-based authentication. If possible use more secure commands such as SSH, which encrypt the entire session, ensuring that sensitive information and files remain secure from unauthorized access.
+        **Rationale:**
+
+        The rsh suite (which includes rsh, rlogin, and rexec) provides remote command execution and login capabilities over a network. However, these services transmit data, including credentials, in plaintext and rely on weak authentication mechanisms based on hostname and user trust relationships.
+
+        If rsh services are enabled:
+          - They expose sensitive data to interception, making the system vulnerable to credential theft.
+          - Host-based trust mechanisms (like .rhosts) can be easily bypassed or misconfigured, allowing unauthorized access.
+          - They increase the system's attack surface and may be exploited for lateral movement in a compromised environment.
+
+        Because of these risks, rsh is considered obsolete and should be replaced with secure alternatives such as SSH. Disabling rsh, rlogin, and rexec services helps prevent unauthorized remote access and aligns with modern security best practices for system hardening.
       remediation: |-
         Run these commands to stop and disable `rsh`, `rlogin`, and `rexec`:
 
@@ -776,9 +1040,18 @@ queries:
       service("telnet.socket").running == false
     docs:
       desc: |-
-        Telnet is a protocol used to connect and manage remote computers via command-line interfaces over a network. It is considered insecure because it transmits data, including login credentials, in plaintext, making it vulnerable to interception and unauthorized access.
+        This check verifies that the Telnet server service (telnet.socket) is not running and is disabled on the system.
 
-        If possible use more secure commands such as SSH, which encrypt the entire session, ensuring that sensitive information and files remain secure from unauthorized access.
+        **Rationale:**
+
+        Telnet is an older protocol used for remote command-line access over a network. It transmits all data—including usernames and passwords—in plaintext, making it highly insecure for modern environments. Any system using Telnet is vulnerable to eavesdropping, session hijacking, and credential theft.
+
+        If the Telnet server is enabled:
+          - It exposes the system to man-in-the-middle attacks due to the lack of encryption.
+          - Credentials and session data can be intercepted by any attacker with network access.
+          - It creates a significant attack surface that can be exploited by automated tools or targeted threats.
+
+        Modern systems should use secure alternatives such as SSH, which encrypt all communications. Disabling Telnet services on systems where they are not explicitly required strengthens the host's security posture and reduces the risk of unauthorized access.
       remediation: |-
         Run this command to stop and disable telnet:
 
@@ -795,7 +1068,19 @@ queries:
       service("tftp.socket").enabled == false
       service("tftp.socket").running == false
     docs:
-      desc: Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot machines from a boot server.
+      desc: |
+        This check verifies that the Trivial File Transfer Protocol (TFTP) server service (tftp.socket) is not running and is disabled on the system.
+
+        **Rationale:**
+
+        TFTP is a simple, lightweight file transfer protocol typically used for tasks such as bootstrapping diskless workstations or network appliances. It lacks authentication, encryption, and access control mechanisms, making it highly insecure for general-purpose or internet-connected systems.
+
+        If the TFTP server is enabled:
+          - Files can be read or written without authentication, leading to data leakage or unauthorized modification.
+          - Attackers can use TFTP to upload malicious payloads or exfiltrate sensitive files.
+          - It may serve as an entry point for lateral movement in network-based attacks, especially in environments with legacy devices.
+
+        Unless TFTP is explicitly required for a specific, isolated use case, the service should be stopped and disabled. Removing unnecessary TFTP services reduces the system's attack surface and aligns with best practices for minimizing unauthenticated network protocols.
       remediation: |-
         Run this command to stop and disable tftp:
 
@@ -812,7 +1097,19 @@ queries:
       service("rsyncd").enabled == false
       service("rsyncd").running == false
     docs:
-      desc: The `rsyncd` service can be used to synchronize files between systems over network links.
+      desc: |
+        This check verifies that the rsyncd service, which enables the rsync daemon for file synchronization over the network, is not running and is disabled on the system.
+
+        **Rationale:**
+
+        The rsync daemon allows systems to synchronize files with remote hosts. While useful in backup and replication workflows, running rsyncd as a service introduces a network-accessible endpoint that may expose files or directories if not properly secured.
+
+        If the rsync service is enabled unnecessarily:
+          - It can expose sensitive files to unauthorized access, especially if authentication is misconfigured or absent.
+          - It increases the system's attack surface by opening a network port that could be targeted for exploitation.
+          - Unrestricted or anonymous rsync configurations can lead to data exfiltration or integrity compromise.
+
+        Unless the system is explicitly configured to serve files via rsyncd, the service should be disabled. This aligns with the principle of least functionality and helps prevent accidental exposure of file data to untrusted networks.
       remediation: |-
         Run this command to stop and disable `rsync`:
 
@@ -831,7 +1128,15 @@ queries:
       service("talkd").enabled == false
       service("talkd").running == false
     docs:
-      desc: The talk software allows users to send and receive messages across systems through a terminal session. The talk client (allows initiate of talk sessions) is installed by default.
+      desc: |
+        The talk protocol enables real-time text-based communication between users on UNIX systems. The talk server (talkd or ntalk) listens for incoming connection requests and facilitates terminal-to-terminal chat sessions. However, this protocol is outdated and lacks encryption or strong authentication mechanisms.
+
+        If the talk server is enabled:
+          - It exposes the system to network-based attacks through an unnecessary and insecure service.
+          - Messages are transmitted in plaintext, allowing for potential interception and eavesdropping.
+          - The service increases the system's attack surface and may be abused for denial-of-service attacks or unauthorized user messaging.
+
+        Since modern environments use more secure communication tools, talk services should be disabled on systems where they are not explicitly required. This minimizes risk and helps enforce a minimal, hardened system configuration.
       remediation: |-
         Run this command to stop and disable talk:
 
@@ -854,7 +1159,19 @@ queries:
       kernel.parameters['net.ipv6.conf.all.forwarding'] == 0
         || kernel.parameters['net.ipv6.conf.all.forwarding'] == null
     docs:
-      desc: The `net.ipv4.ip_forward` and `net.ipv6.conf.all.forwarding` flags are used to tell the system whether it can forward packets or not.
+      desc: |
+        This check verifies that IP forwarding is disabled by confirming that the kernel parameters net.ipv4.ip_forward and net.ipv6.conf.all.forwarding are set to 0.
+
+        **Rationale:**
+
+        IP forwarding allows a system to route network packets between interfaces, effectively enabling it to act as a router. While necessary for certain network infrastructure roles, IP forwarding is not appropriate for general-purpose servers, workstations, or systems that are not explicitly configured to route traffic.
+
+        If IP forwarding is enabled unnecessarily:
+          - The system could be used to redirect or intercept network traffic, intentionally or accidentally.
+          - It increases the risk of network misconfiguration, data leakage, or man-in-the-middle attacks.
+          - It may violate segmentation and isolation policies in secure environments.
+
+        Disabling IP forwarding ensures the system cannot forward packets between networks, reducing the potential for misuse or compromise. This helps maintain clear boundaries between network zones and supports a more secure and predictable system configuration.
       remediation: |-
         Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
@@ -885,7 +1202,19 @@ queries:
       kernel.parameters['net.ipv4.conf.default.send_redirects'] == 0
         || kernel.parameters['net.ipv4.conf.default.send_redirects'] == null
     docs:
-      desc: ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host-only configuration), there is no need to send redirects.
+      desc: |
+        This check verifies that the system is configured to not send ICMP redirect messages by ensuring the kernel parameters `net.ipv4.conf.all.send_redirects` and `net.ipv4.conf.default.send_redirects` are set to `0`.
+
+        **Rationale:**
+
+        ICMP redirect messages are used by routers to inform hosts of a more efficient route for reaching a destination. However, on systems that are not functioning as routers, this feature is unnecessary and can introduce security risks.
+
+        If packet redirect sending is enabled:
+          - The system could inadvertently influence the routing behavior of other devices on the network.
+          - Malicious actors could exploit redirect functionality to reroute traffic through compromised or untrusted devices.
+          - It increases the complexity and unpredictability of network traffic flow, complicating security monitoring and enforcement.
+
+        Disabling the ability to send ICMP redirects on non-router systems prevents unauthorized route manipulation and supports secure, well-defined network behavior. This reduces the risk of traffic interception or redirection by adversaries.
       remediation: |-
         Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
@@ -917,7 +1246,19 @@ queries:
       kernel.parameters['net.ipv6.conf.default.accept_source_route'] == 0
         || kernel.parameters['net.ipv6.conf.default.accept_source_route'] == null
     docs:
-      desc: In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used.
+      desc: |
+        This check verifies that the system is configured to reject source-routed packets by ensuring the kernel parameters `net.ipv4.conf.all.accept_source_route`, `net.ipv4.conf.default.accept_source_route`, `net.ipv6.conf.all.accept_source_route`, and `net.ipv6.conf.default.accept_source_route` are set to `0`.
+
+        **Rationale:**
+
+        Source routing allows the sender of a packet to specify the exact path it should take through the network. While this feature was designed for network troubleshooting, it is rarely used in modern environments and poses significant security risks.
+
+        If source-routed packets are accepted:
+          - Attackers can bypass network routing controls and firewall rules by crafting packets with arbitrary paths.
+          - It enables traffic spoofing and man-in-the-middle attacks by redirecting data through attacker-controlled systems.
+          - It undermines network segmentation and isolation policies.
+
+        Disabling acceptance of source-routed packets ensures that the system only processes packets routed according to the network's standard path selection, reducing the risk of exploitation and reinforcing a secure network posture.
       remediation: |-
         Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
@@ -955,7 +1296,19 @@ queries:
       kernel.parameters['net.ipv6.conf.default.accept_redirects'] == 0
         || kernel.parameters['net.ipv6.conf.default.accept_redirects'] == null
     docs:
-      desc: ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables. By setting `net.ipv4.conf.all.accept_redirects` and `net.ipv6.conf.all.accept_redirects` to 0, the system will not accept any ICMP redirect messages, and therefore, won't allow outsiders to update the system's routing tables.
+      desc: |
+        This check verifies that the system is configured to reject ICMP redirect messages by ensuring the kernel parameters `net.ipv4.conf.all.accept_redirects`, `net.ipv4.conf.default.accept_redirects`, `net.ipv6.conf.all.accept_redirects`, and `net.ipv6.conf.default.accept_redirects` are set to `0`.
+
+        **Rationale:**
+
+        ICMP redirect messages are used by routers to inform hosts of a better route for reaching a destination. While intended to optimize network traffic, accepting these messages on non-router systems can introduce serious security risks.
+
+        If ICMP redirects are accepted:
+          - Attackers can exploit this to alter the routing table of a host, redirecting traffic through malicious devices.
+          - It creates opportunities for man-in-the-middle attacks, traffic interception, or denial-of-service.
+          - It makes network traffic paths unpredictable and harder to audit or monitor effectively.
+
+        Disabling ICMP redirect acceptance ensures that the system maintains static and trusted routing behavior, helping to preserve network integrity and defend against unauthorized routing changes.
       remediation: |-
         Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
@@ -989,7 +1342,19 @@ queries:
       kernel.parameters['net.ipv4.conf.default.secure_redirects'] == 0
         || kernel.parameters['net.ipv4.conf.default.secure_redirects'] == null
     docs:
-      desc: Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system and are likely to be secure.
+      desc: |
+        This check verifies that the system is configured to reject secure ICMP redirect messages by ensuring the kernel parameters `net.ipv4.conf.all.secure_redirects` and `net.ipv4.conf.default.secure_redirects` are set to `0`.
+
+        **Rationale:**
+
+        Secure ICMP redirects are a variant of ICMP redirect messages that are accepted only from gateways listed in the system's default gateway table. While they are intended to provide safer route optimization, accepting any form of redirect introduces risk by allowing remote influence over local routing decisions.
+
+        If secure ICMP redirects are accepted:
+          - An attacker controlling or spoofing a default gateway could influence traffic paths.
+          - It increases the likelihood of man-in-the-middle attacks by rerouting data through malicious intermediaries.
+          - It undermines the reliability of static routing configurations and may conflict with security controls or monitoring systems.
+
+        Disabling acceptance of secure ICMP redirects ensures that routing updates are not accepted dynamically from potentially compromised gateways. This strengthens network security by enforcing a more predictable and tightly controlled routing posture.
       remediation: |-
         Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
@@ -1015,7 +1380,19 @@ queries:
       kernel.parameters['net.ipv4.conf.all.log_martians'] == 1
       kernel.parameters['net.ipv4.conf.default.log_martians'] == 1
     docs:
-      desc: When enabled, this feature logs packets with un-routable source addresses to the kernel log.
+      desc: |
+        This check verifies that the system is configured to log suspicious or malformed packets by ensuring the kernel parameters `net.ipv4.conf.all.log_martians` and `net.ipv4.conf.default.log_martians` are set to `1`.
+
+        **Rationale:**
+
+        Martian packets are packets with impossible or invalid source addresses, such as those that should not appear on the public internet or within specific segments of a private network. Logging these packets helps administrators detect potential misconfigurations or malicious activity, such as spoofed traffic or scanning attempts.
+
+        If logging of suspicious packets is not enabled:
+          - Unusual or invalid network traffic may go undetected, reducing visibility into potential reconnaissance or attack attempts.
+          - Misconfigured hosts or routing issues may persist without notice, leading to degraded performance or security gaps.
+          - Incident response and forensic analysis capabilities are weakened due to lack of log data.
+
+        Enabling logging for martian packets provides valuable insights into unusual traffic patterns and supports early detection of threats or misconfigurations. This improves network observability and supports a proactive security posture.
       remediation: |-
         Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` or in /etc/ufw/sysctl.conf file:
 
@@ -1042,7 +1419,19 @@ queries:
     mql: |
       kernel.parameters['net.ipv4.icmp_echo_ignore_broadcasts'] == 1
     docs:
-      desc: Setting `net.ipv4.icmp_echo_ignore_broadcasts` to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses.
+      desc: |
+        This check verifies that the system is configured to ignore ICMP echo requests sent to broadcast or multicast addresses by ensuring the kernel parameter `net.ipv4.icmp_echo_ignore_broadcasts` is set to `1`.
+
+        **Rationale:**
+
+        ICMP echo requests sent to broadcast addresses can be used in amplification attacks, such as the Smurf attack, where a single ICMP request can generate a large volume of responses from multiple hosts. This can lead to denial-of-service conditions for targeted systems or network segments.
+
+        If broadcast ICMP requests are not ignored:
+          - The system may be exploited as part of a distributed denial-of-service (DDoS) attack.
+          - Network resources may be consumed by processing and responding to unnecessary or malicious requests.
+          - Attackers can use broadcast ICMP traffic to map networks or identify live hosts.
+
+        Ignoring broadcast ICMP requests reduces the likelihood that the system can be leveraged in amplification attacks and helps maintain the integrity and availability of the network. This is particularly important in environments where network resources are limited or where systems are exposed to untrusted networks.
       remediation: |-
         Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
@@ -1065,7 +1454,19 @@ queries:
     mql: |
       kernel.parameters['net.ipv4.icmp_ignore_bogus_error_responses'] == 1
     docs:
-      desc: Setting `icmp_ignore_bogus_error_responses` to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages.
+      desc: |
+        This check verifies that the system is configured to ignore bogus ICMP error responses by ensuring the kernel parameter `net.ipv4.icmp_ignore_bogus_error_responses` is set to `1`.
+
+        **Rationale:**
+
+        Bogus ICMP error responses are non-compliant or malformed ICMP messages that do not correspond to any legitimate traffic. These can be generated accidentally by misconfigured devices or intentionally by attackers attempting to disrupt or confuse network communications.
+
+        If bogus ICMP responses are not ignored:
+          - The system may log unnecessary or misleading error messages, cluttering logs and making it harder to identify real issues.
+          - Attackers may exploit this setting to flood logs or trigger unstable behavior in poorly configured systems.
+          - It may lead to resource exhaustion or degradation of network performance in environments with high volumes of invalid traffic.
+
+        By ignoring bogus ICMP error responses, the system avoids reacting to malformed or irrelevant network messages, helping to maintain cleaner logs and more stable network operations.
       remediation: |-
         Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
@@ -1089,7 +1490,19 @@ queries:
       kernel.parameters['net.ipv4.conf.all.rp_filter'] == 1
       kernel.parameters['net.ipv4.conf.default.rp_filter'] == 1
     docs:
-      desc: Setting `net.ipv4.conf.all.rp_filter`and `net.ipv4.conf.default.rp_filter` to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if `log_martians` is set).
+      desc: |
+        This check verifies that reverse path filtering is active by ensuring the kernel parameters `net.ipv4.conf.all.rp_filter` and `net.ipv4.conf.default.rp_filter` are set to `1`.
+
+        **Rationale:**
+
+        Reverse Path Filtering is a security mechanism that helps prevent IP spoofing by verifying that the source of a packet has a valid route back to the receiving interface. If a packet arrives on an interface and the system would not use that same interface to reach the source IP, the packet is dropped.
+
+        If reverse path filtering is not enabled:
+          - Spoofed packets with forged source addresses may be accepted, allowing attackers to bypass basic network controls.
+          - Systems may become vulnerable to reflection and amplification attacks.
+          - It undermines the reliability of source-based filtering and complicates network traffic analysis.
+
+        Enabling reverse path filtering ensures the system performs sanity checks on incoming traffic, which helps prevent IP spoofing and enhances the integrity of network communications. It is an important safeguard in both perimeter and internal network environments.
       remediation: |-
         Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
@@ -1114,7 +1527,19 @@ queries:
     mql: |
       kernel.parameters['net.ipv4.tcp_syncookies'] == 1
     docs:
-      desc: When `tcp_syncookies` is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN\|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the system to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue.
+      desc: |
+        This check verifies that the system is configured to use TCP SYN cookies by ensuring the kernel parameter `net.ipv4.tcp_syncookies` is set to `1`.
+
+        **Rationale:**
+
+        TCP SYN cookies are a defense mechanism against SYN flood attacks, a type of denial-of-service (DoS) attack where an attacker sends a large number of TCP connection requests without completing the handshake. This consumes server resources and can prevent legitimate users from establishing connections.
+
+        When SYN cookies are enabled:
+          - The system avoids allocating memory for incomplete TCP handshakes by encoding connection information into the TCP sequence number.
+          - It allows the server to continue responding to new connection requests even when the SYN backlog is full.
+          - It helps maintain availability and resilience under high connection request loads or malicious activity.
+
+        Without SYN cookies, systems are more susceptible to resource exhaustion during a SYN flood. Enabling this feature strengthens the host's ability to withstand network-based denial-of-service attempts and helps ensure reliable TCP service availability.
       remediation: |-
         Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
@@ -1140,7 +1565,19 @@ queries:
       kernel.parameters['net.ipv6.conf.default.accept_ra'] == 0
         || kernel.parameters['net.ipv6.conf.default.accept_ra'] == null
     docs:
-      desc: This setting disables the system's ability to accept IPv6 router advertisements.
+      desc: |
+        This check verifies that the system is configured to reject IPv6 router advertisements by ensuring the kernel parameters `net.ipv6.conf.all.accept_ra` and `net.ipv6.conf.default.accept_ra` are set to `0`.
+
+        **Rationale:**
+
+        IPv6 router advertisements (RAs) are used by routers to inform hosts about network configuration settings, such as default gateways and prefix information. While useful in dynamic network environments, accepting unsolicited RAs on systems that are not mobile or router-dependent can introduce security risks.
+
+        If IPv6 router advertisements are accepted:
+          - Malicious or misconfigured devices on the network could inject rogue RAs, redirecting traffic or altering host routing tables.
+          - Attackers could exploit this to perform man-in-the-middle attacks, traffic interception, or denial-of-service.
+          - It undermines predictable network configuration and may conflict with security policies that rely on static or managed routing.
+
+        Disabling acceptance of IPv6 router advertisements helps ensure that routing configuration is controlled explicitly, reducing the likelihood of unauthorized or harmful route changes on the host.
       remediation: |-
         Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/` file:
 
@@ -1156,45 +1593,56 @@ queries:
         sysctl -w net.ipv6.conf.default.accept_ra=0
         sysctl -w net.ipv6.route.flush=1
         ```
-  - uid: mondoo-linux-security-auditd-is-installed
-    title: Ensure auditd is installed
+  - uid: mondoo-linux-security-auditd-is-installed-and-running
+    title: Ensure auditd is installed, enabled, and running
     impact: 50
     mql: |
       package("auditd").installed && package("audispd-plugins").installed
       || package("audit").installed || package("audit-libs").installed
+      service("auditd").enabled
+      service("auditd").running
     docs:
-      desc: |-
-        `auditd` is the user space component to the Linux Auditing System. It's responsible for writing audit records to the disk.
-      remediation: |-
-        Run this command to install `auditd`:
+      desc: |
+        This check verifies that the auditd package is installed on the system and that the auditd service is both enabled and running.
 
-        ### RHEL/Fedora/Amazon Linux and derivatives
+        **Rationale:**
+
+        auditd is the core component of the Linux Auditing System, responsible for collecting, processing, and writing audit records to disk. These records provide detailed visibility into system-level activities such as user logins, file access, command execution, and permission changes.
+
+        Ensuring that auditd is installed and actively running is essential for:
+          - Capturing a reliable audit trail of security-relevant events.
+          - Supporting forensic investigations and incident response efforts.
+          - Meeting regulatory and organizational compliance requirements that mandate audit logging.
+          - Detecting suspicious or unauthorized behavior on the system in near real time.
+
+        If auditd is not installed, or if the service is disabled or inactive:
+          - No audit logs will be recorded, creating blind spots in system monitoring.
+          - Critical evidence may be lost during or after an attack.
+          - The system may fall out of compliance with standards that require audit functionality.
+
+        By installing and enabling auditd, organizations ensure consistent audit logging is in place, improving accountability and strengthening overall system security.
+      remediation: |-
+        ### Install auditd
+
+        **RHEL/Fedora/Amazon Linux and derivatives**
 
         ```bash
         dnf install audit audit-libs
         ```
 
-        ### Debian/Ubuntu and derivatives
+        **Debian/Ubuntu and derivatives**
 
         ```bash
         apt-get install auditd audispd-plugins
         ```
 
-        ### SLES and openSUSE
+        **SLES and openSUSE**
 
         ```bash
         zypper install audit
         ```
-  - uid: mondoo-linux-security-auditd-service-is-enabled
-    title: Ensure auditd service is enabled
-    impact: 50
-    mql: |
-      service("auditd").enabled
-    docs:
-      desc: |-
-        Turn on the `auditd` daemon to record system events.
-      remediation: |-
-        Run this command to enable `auditd`:
+
+        ### Enable auditd
 
         ```bash
         systemctl --now enable auditd
@@ -1222,8 +1670,19 @@ queries:
         default: false
       }
     docs:
-      desc: |-
-        Configure `grub2` so that processes that are capable of being audited can be audited even if they start up prior to `auditd` startup.
+      desc: |
+        This check verifies that the system's GRUB bootloader is configured to pass the audit=1 kernel parameter, which ensures that auditing is enabled from the earliest stages of system initialization—even before the auditd daemon starts.
+
+        **Rationale:**
+
+        By default, some processes may start before auditd is initialized, especially during early boot. Without early auditing enabled, actions taken by these processes can go unrecorded, creating a blind spot in audit logs and weakening the system's ability to track critical events.
+
+        If the audit=1 kernel parameter is not set:
+          - Early-boot processes such as init systems, kernel modules, or startup scripts may execute without being logged.
+          - Attackers or misconfigurations could exploit this window to perform actions undetected.
+          - The system's audit trail may be incomplete, undermining trust in audit data and complicating incident response or compliance reviews.
+
+        Adding audit=1 to the GRUB configuration ensures that the Linux kernel begins generating audit records as soon as it starts, capturing all auditable activity regardless of when auditd is fully initialized. This enhances the completeness and integrity of audit logging across the system lifecycle.
       remediation: |-
         Edit `/etc/default/grub` and add `audit=1` to `GRUB_CMDLINE_LINUX`:
 
@@ -1235,11 +1694,19 @@ queries:
 
         ### RHEL/Fedora/Amazon Linux and derivatives
 
+        For BIOS systems:
+
         ```bash
         grub2-mkconfig -o /boot/grub2/grub.cfg
         ```
-        **Note:**
-        The path looks different for UEFI systems.
+
+        For UEFI systems:
+
+        ```bash
+        grub2-mkconfig -o /boot/efi/EFI/<distribution>/grub.cfg
+        ```
+
+        Replace `<distribution>` with your distribution's directory name (e.g., `centos`, `redhat`, `fedora`).
 
         ### Debian/Ubuntu and derivatives
 
@@ -1255,7 +1722,19 @@ queries:
         parse.ini(_).params["max_log_file"] > 0
       }
     docs:
-      desc: Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started.
+      desc: |
+        This check verifies that the auditd configuration specifies a maximum storage size for audit logs by ensuring the `max_log_file` parameter in `/etc/audit/auditd.conf` is set to a value greater than zero.
+
+        **Rationale:**
+
+        The `max_log_file` setting defines the maximum size (in megabytes) that an audit log file can grow before it is rotated. Without this limit, audit logs can consume excessive disk space, leading to system performance degradation or failures—especially on systems with limited storage or extensive auditing.
+
+        If audit log size is not properly configured:
+          - Log files may grow indefinitely and fill the disk, potentially causing services to fail or the system to become unresponsive.
+          - Critical audit data may be lost if the system cannot write to a full disk.
+          - Administrators may be unaware of abnormal log volume trends, missing opportunities for early detection of suspicious activity.
+
+        Configuring max_log_file helps maintain system stability by preventing uncontrolled log growth. It also supports log management practices such as automated rotation and retention policies, ensuring that audit data remains available without jeopardizing system operations.
       remediation: |-
         Set the following parameter in `/etc/audit/auditd.conf` in accordance with site policy:
 
@@ -1277,8 +1756,19 @@ queries:
         parse.ini(_).params["max_log_file_action"].downcase == "keep_logs"
       }
     docs:
-      desc: |-
-        The `max_log_file_action` setting determines how to handle the audit log file reaching the max file size. A value of `keep_logs` will rotate the logs but never delete old logs.
+      desc: |
+        This check verifies that the system is configured to retain audit logs by ensuring the `max_log_file_action` parameter in `/etc/audit/auditd.conf`` is set to `keep_logs`.
+
+        **Rationale:**
+
+        The `max_log_file_action` setting controls how auditd behaves when an audit log file reaches its maximum size. Setting it to keep_logs ensures that old logs are preserved rather than deleted or overwritten, supporting long-term retention and forensic traceability.
+
+        If audit logs are automatically deleted:
+          - Critical historical data may be lost, undermining the ability to investigate past events or security incidents.
+          - Organizations may fall out of compliance with regulatory requirements that mandate audit log retention.
+          - Incident response efforts may be hindered by incomplete log records.
+
+        By configuring auditd to preserve logs, the system ensures that valuable audit data is available when needed for security analysis, compliance reviews, or legal investigation. This supports a more robust and accountable auditing strategy.
       remediation: |-
         Set the following parameter in `/etc/audit/auditd.conf`:
 
@@ -1307,7 +1797,18 @@ queries:
       }
     docs:
       desc: |-
-        The `auditd` daemon can be configured to halt the system when the audit logs are full.
+        This check verifies that the system is configured to disable itself when audit logs are full by ensuring the `space_left_action` and `admin_space_left_action` parameters in `/etc/audit/auditd.conf` are set to appropriate values.
+
+        **Rationale:**
+
+        The `space_left_action` setting determines what action auditd takes when disk space for audit logs is low. The `admin_space_left_action` setting specifies the action when space is critically low. Setting these to halt or single ensures that the system does not continue operating with potentially compromised logging capabilities.
+
+        If the system does not disable itself when audit logs are full:
+          - Crucial audit data may be lost, leading to gaps in security monitoring.
+          - The system may continue to operate without proper oversight, increasing the risk of undetected malicious activity.
+          - Compliance with regulatory requirements for audit logging may be jeopardized.
+
+        Configuring these parameters helps ensure that the system maintains a secure state and that audit logging remains functional, even under adverse conditions.
       remediation: |-
         Set the following parameters in `/etc/audit/auditd.conf`:
 
@@ -1335,8 +1836,22 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/sudoers\.d(\/?)\s+\-p\s+wa\s+\-k\s+scope(\s+)?$/))
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/sudoers(\/?)\s+\-p\s+wa\s+\-k\s+scope(\s+)?$/))
     docs:
-      desc: |-
-        Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the `sudo` command to execute privileged commands, it is possible to monitor changes in scope. The file `/etc/sudoers` will be written to when the file or its attributes have changed. The audit records will be tagged with the identifier "scope."
+      desc: |
+        This check verifies that auditd is configured to monitor changes to the system administration scope (sudoers). The parameters below track changes to files associated with sudoers.
+
+        - The file `/etc/sudoers` is the main configuration file for sudo.
+        - The `/etc/sudoers.d/` directory contains additional configuration files for sudo.
+
+        **Rationale:**
+
+        Monitoring changes to the sudoers file and its associated directory is critical for maintaining system security. Unauthorized modifications can lead to privilege escalation, unauthorized access, or other malicious activities.
+
+        If monitoring is not enabled:
+          - Changes to sudo permissions may go undetected, allowing unauthorized users to gain elevated privileges.
+          - It becomes difficult to track who made changes and when, complicating incident response efforts.
+          - The system may fall out of compliance with security policies or regulatory requirements.
+
+        By ensuring that changes to the sudoers file and directory are monitored, organizations can maintain a secure environment and quickly respond to potential threats.
       remediation: |-
         Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -1375,44 +1890,20 @@ queries:
       - uid: mondoo-linux-security-login-and-logout-events-are-collected-debian
       - uid: mondoo-linux-security-login-and-logout-events-are-collected-rhel
       - uid: mondoo-linux-security-login-and-logout-events-are-collected-other
-  - uid: mondoo-linux-security-login-and-logout-events-are-collected-debian
-    filters: asset.family.contains("debian")
-    mql: |
-      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/lastlog/)
-      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/faillog/)
-      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/tallylog/)
-      props.mondooLinuxSecurityAuditFiles.flat.unique.where(_ == /\/var\/log\/faillog|\/var\/log\/lastlog|\/var\/log\/tallylog/).all(
-        split("-").contains(/p wa/)
-          && split(" ").containsAll(["-k","logins"])
-            || split(" ").containsAll(["-F","key=logins"])
-      )
-  - uid: mondoo-linux-security-login-and-logout-events-are-collected-rhel
-    filters: asset.family.contains("redhat") || asset.platform == "amazonlinux"
-    mql: |
-      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/run\/faillock/)
-      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/lastlog/)
-      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/tallylog/)
-      props.mondooLinuxSecurityAuditFiles.flat.unique.where(_ == /\/var\/run\/faillock|\/var\/log\/lastlog|\/var\/log\/tallylog/).all(
-        split("-").contains(/p wa/)
-          && split(" ").containsAll(["-k","logins"])
-            || split(" ").containsAll(["-F","key=logins"])
-      )
-  - uid: mondoo-linux-security-login-and-logout-events-are-collected-other
-    filters: asset.family.contains(/redhat|debian/) == false && asset.platform != "amazonlinux"
-    mql: |
-      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/lastlog/)
-      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/tallylog/)
-      props.mondooLinuxSecurityAuditFiles.flat.unique.where(_ == /\/var\/log\/lastlog|\/var\/log\/tallylog/).all(
-        split("-").contains(/p wa/)
-          && split(" ").containsAll(["-k","logins"])
-            || split(" ").containsAll(["-F","key=logins"])
-      )
     docs:
-      desc: |-
-        Monitor login and logout events. The parameters below track changes to files associated with login/logout events.
+      desc: |
+        This check verifies that auditd is configured to monitor login and logout events. The parameters in this section track changes to the files associated with login and logout events. The file `/var/log/lastlog` tracks the last login of each user. The file `/var/log/tallylog` tracks failed login attempts. The file `/var/run/faillock` is used by the `pam_faillock` module to track failed authentication attempts. All audit records will be tagged with the identifier "logins."
 
-        - The file `/var/log/lastlog` maintain records of the last time a user successfully logged in.
-        - The `/var/run/faillog/` directory maintains records of login failures via the `pam_faillog` module.
+        **Rationale:**
+
+        Monitoring login and logout events is critical for maintaining system security. Unauthorized access attempts or successful logins by malicious actors can lead to data breaches, privilege escalation, or other security incidents.
+
+        If monitoring is not enabled:
+          - Unauthorized login attempts may go undetected, allowing attackers to gain access to the system.
+          - Legitimate user activity may be obscured, complicating incident response efforts.
+          - The system may fall out of compliance with security policies or regulatory requirements.
+
+        By ensuring that login and logout events are monitored, organizations can maintain a secure environment and quickly respond to potential threats. This is particularly important in environments with sensitive data or critical infrastructure.
       remediation: |-
         Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -1451,6 +1942,38 @@ queries:
         ```bash
         if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi
         ```
+  - uid: mondoo-linux-security-login-and-logout-events-are-collected-debian
+    filters: asset.family.contains("debian")
+    mql: |
+      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/lastlog/)
+      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/faillog/)
+      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/tallylog/)
+      props.mondooLinuxSecurityAuditFiles.flat.unique.where(_ == /\/var\/log\/faillog|\/var\/log\/lastlog|\/var\/log\/tallylog/).all(
+        split("-").contains(/p wa/)
+          && split(" ").containsAll(["-k","logins"])
+            || split(" ").containsAll(["-F","key=logins"])
+      )
+  - uid: mondoo-linux-security-login-and-logout-events-are-collected-rhel
+    filters: asset.family.contains("redhat") || asset.platform == "amazonlinux"
+    mql: |
+      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/run\/faillock/)
+      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/lastlog/)
+      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/tallylog/)
+      props.mondooLinuxSecurityAuditFiles.flat.unique.where(_ == /\/var\/run\/faillock|\/var\/log\/lastlog|\/var\/log\/tallylog/).all(
+        split("-").contains(/p wa/)
+          && split(" ").containsAll(["-k","logins"])
+            || split(" ").containsAll(["-F","key=logins"])
+      )
+  - uid: mondoo-linux-security-login-and-logout-events-are-collected-other
+    filters: asset.family.contains(/redhat|debian/) == false && asset.platform != "amazonlinux"
+    mql: |
+      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/lastlog/)
+      props.mondooLinuxSecurityAuditFiles.flat.unique.any(_ == /\/var\/log\/tallylog/)
+      props.mondooLinuxSecurityAuditFiles.flat.unique.where(_ == /\/var\/log\/lastlog|\/var\/log\/tallylog/).all(
+        split("-").contains(/p wa/)
+          && split(" ").containsAll(["-k","logins"])
+            || split(" ").containsAll(["-F","key=logins"])
+      )
   - uid: mondoo-linux-security-session-initiation-information-is-collected
     title: Ensure session initiation information is collected
     impact: 50
@@ -1466,7 +1989,18 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-w\s+\/var\/log\/btmp\s+\-p\s+wa\s+\-k\s+(logins|session)(\s+)?$/))
     docs:
       desc: |-
-        Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file `/var/run/utmp` tracks all currently logged in users. All audit records will be tagged with the identifier "session." The `/var/log/wtmp` file tracks logins, logouts, shutdown, and reboot events. The file `/var/log/btmp` keeps track of failed login attempts and can be read by entering the command `/usr/bin/last -f /var/log/btmp`. All audit records will be tagged with the identifier "logins."
+        This check verifies that the system is configured to record session start events in the audit logs, ensuring that audit rules are in place to track successful login sessions using the auditd subsystem.
+
+        **Rationale:**
+
+        Capturing session initiation information—such as user logins and terminal access—is essential for establishing a complete record of user activity. These events mark the beginning of user interactions with the system and provide vital context for analyzing subsequent actions.
+
+        If session initiation is not logged:
+          •	User activity cannot be reliably correlated to specific sessions, weakening audit trails.
+          •	Security incidents such as unauthorized access or lateral movement may go undetected.
+          •	Compliance with security standards and regulatory frameworks that require session logging may be compromised.
+
+        By ensuring session start events are audited, organizations gain visibility into who accessed the system and when, supporting effective monitoring, incident investigation, and user accountability. This forms a foundational element of audit-based security controls.
       remediation: |-
         Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -1522,7 +2056,18 @@ queries:
       )
     docs:
       desc: |-
-        Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the `adjtimex` (tune kernel clock), `settimeofday` (Set time, using timeval and timezone structures) `stime` (using seconds since 1/1/1970) or `clock_settime` (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the `/var/log/audit.log` file upon exit, tagging the records with the identifier "time-change"
+        This check verifies that the audit system is configured to log all events that change the system’s date and time settings, including modifications to the system clock and timezone.
+
+        **Rationale:**
+
+        Accurate system time is critical for security auditing, log correlation, and incident investigation. If an attacker or unauthorized user alters the system time, it can obscure malicious activity, disrupt monitoring tools, and compromise the integrity of audit logs.
+
+        If changes to date and time settings are not audited:
+          •	Malicious modifications may go unnoticed, allowing attackers to hide their tracks.
+          •	Log timestamps may become unreliable, complicating forensic analysis.
+          •	Compliance with standards that require time synchronization and audit log integrity may be violated.
+
+        By auditing all date and time modifications, administrators can detect tampering attempts, verify system integrity, and maintain a trustworthy timeline of system events. This ensures that audit logs remain a reliable source of truth during security reviews and investigations.
       remediation: |-
         For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`_
 
@@ -1581,7 +2126,18 @@ queries:
       appArmorSys || seLinuxSys
     docs:
       desc: |-
-        Monitor SELinux/AppArmor mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/selinux or /etc/apparmor and /etc/apparmor.d directories.
+        This check verifies that the audit system is configured to log changes to the system’s Mandatory Access Control (MAC) configurations, such as modifications to SELinux or AppArmor policies.
+
+        Rationale:
+
+        Mandatory Access Controls enforce strict rules about which subjects (users, processes) can access which objects (files, resources) beyond traditional discretionary permissions. Changes to MAC settings directly impact the system’s security posture and can either strengthen or weaken its defenses.
+
+        If modifications to MAC configurations are not audited:
+          •	Unauthorized or malicious changes may go undetected, potentially disabling key security mechanisms.
+          •	Administrators may be unaware of policy alterations that expose the system to privilege escalation or data leakage.
+          •	The system’s compliance with security frameworks requiring MAC enforcement may be compromised.
+
+        Logging events that alter SELinux modes, AppArmor profiles, or related configuration files helps ensure that all security policy changes are tracked and attributable. This supports continuous monitoring, strengthens control over access enforcement, and enhances trust in the system’s security model.
       remediation: |-
         Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -1649,7 +2205,6 @@ queries:
           && split(" ").containsAll(["-k","system-locale"])
             || split(" ").containsAll(["-F","key=system-locale"])
       )
-
   - uid: mondoo-linux-security-events-that-modify-the-systems-network-environment-are-collected-other
     filters: asset.family.contains(/redhat|debian/) == false
     mql: |
@@ -1671,8 +2226,19 @@ queries:
             || split(" ").containsAll(["-F","key=system-locale"])
       )
     docs:
-      desc: |-
-        Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the `/etc/issue` and `/etc/issue.net` files (messages displayed pre-login), `/etc/hosts` (file containing host names and associated IP addresses) and `/etc/sysconfig/network` (directory containing network interface scripts and configurations) files.
+      desc: |
+        This check verifies that the audit system is configured to record changes to key network configuration files and system identity settings by monitoring specific system calls and file paths.
+
+        **Rationale:**
+
+        Changes to the system's hostname, domain name, or core network-related files can alter how the system identifies itself and interacts with other hosts. These modifications may indicate reconfiguration, misconfiguration, or unauthorized tampering.
+
+        If these events are not audited:
+          •	Changes to system identity (via sethostname or setdomainname) may go untracked, affecting asset management and security visibility.
+          •	Modifications to files like `/etc/hosts`, `/etc/issue`, or `/etc/sysconfig/network` could enable social engineering, redirect network traffic, or disrupt connectivity.
+          •	Attackers may exploit these files to mask their activity or persist on the system.
+
+        By auditing the sethostname and setdomainname system calls and monitoring changes to `/etc/issue`, `/etc/issue.net`, `/etc/hosts`, and `/etc/sysconfig/network`, administrators can detect critical network and identity changes. This supports system integrity, operational consistency, and incident investigation efforts.
       remediation: |-
         For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -1776,16 +2342,18 @@ queries:
       )
     docs:
       desc: |-
-        Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The `chmod`, `fchmod` and `fchmodat` system calls affect the permissions associated with a file. The `chown`, `fchown`, `fchownat` and `lchown` system calls affect owner and group attributes on a file. The `setxattr`, `lsetxattr`, `fsetxattr` (set extended file attributes) and `removexattr`, `lremovexattr`, `fremovexattr` (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system user ids (auid >= 1000) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier "perm_mod."
+        This check verifies that changes to file permissions, attributes, ownership, and group are monitored. It ensures that system calls affecting these properties—such as `chmod`, `fchmod`, `fchmodat` (permissions), `chown`, `fchown`, `fchownat`, `lchown` (ownership), and `setxattr`, `lsetxattr`, `fsetxattr`, `removexattr`, `lremovexattr`, `fremovexattr` (extended attributes)—are audited.
 
-        **Note:**
-        Systems may have been customized to change the default UID_MIN. To confirm the UID_MIN for your system, run this command:
+        **Rationale:**
 
-        ```bash
-        awk '/^\s*UID_MIN/{print $2}' /etc/login.defs
-        ```
+        Monitoring changes to file permissions and attributes is critical for maintaining system security. Unauthorized or accidental modifications can lead to privilege escalation, data leakage, or system compromise.
 
-        If your systems' UID_MIN is not `1000`, replace `audit>=1000` with `audit>=<UID_MIN for your system>` in the Audit and Remediation procedures.
+        If these events are not audited:
+          - Changes to critical files may go undetected, exposing the system to potential threats.
+          - It becomes difficult to trace unauthorized actions or identify the source of configuration drift.
+          - Compliance with security standards requiring audit logging may be compromised.
+
+        By auditing these system calls, administrators can detect and respond to unauthorized changes, ensuring the integrity of file permissions and attributes.
       remediation: |-
         For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -1859,17 +2427,19 @@ queries:
             || split("-").containsAll(["k perm_mod"])
       )
     docs:
-      desc: |-
-        Monitor for unsuccessful attempts to access files. The parameters below are associated with system calls that control creation ( `creat` ), opening ( `open`, `openat` ) and truncation ( `truncate`, `ftruncate` ) of files. An audit log record will only be written if the user is a non-privileged user (auid > = 1000), is not a Daemon event (auid=4294967295) and if the system call returned EACCES (permission denied to the file) or EPERM (some other permanent error associated with the specific system call). All audit records will be tagged with the identifier "access."
+      desc: |
+        This check verifies that the system is configured to monitor unsuccessful attempts to access files by auditing system calls such as `creat`, `open`, `openat`, `truncate`, and `ftruncate`. These system calls control the creation, opening, and truncation of files. The audit log will record events where the user is a non-privileged user (auid >= 1000), is not a daemon event (auid=4294967295), and the system call returned EACCES (permission denied) or EPERM (operation not permitted). All audit records will be tagged with the identifier "access."
 
-        **Note:**
-        Systems may have been customized to change the default UID_MIN. To confirm the UID_MIN for your system, run this command:
+        **Rationale:**
 
-        ```bash
-        awk '/^\s*UID_MIN/{print $2}' /etc/login.defs
-        ```
+        Monitoring unsuccessful file access attempts helps detect potential unauthorized access or misconfigurations. It provides visibility into failed attempts to create, open, or modify files, which may indicate malicious activity or user errors.
 
-        If your systems' UID_MIN is not `1000`, replace `audit>=1000` with `audit>=<UID_MIN for your system>` in the Audit and Remediation procedures.
+        If these events are not audited:
+          - Unauthorized access attempts may go unnoticed, increasing the risk of data breaches.
+          - Misconfigurations or permission issues may persist without detection.
+          - The system may fall out of compliance with security standards requiring audit logging.
+
+        By auditing these system calls, administrators can identify and respond to unauthorized access attempts, ensuring the integrity and security of the system.
       remediation: |-
         For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -1925,7 +2495,18 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-w\s+\/etc\/security\/opasswd\s+\-p\s+wa\s+\-k\s+identity(\s+)?$/))
     docs:
       desc: |-
-        Record events affecting the `group`, `passwd` (user IDs), `shadow` and `gshadow` (passwords) or `/etc/security/opasswd` (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier "identity" in the audit log file.
+        This check verifies that the system is configured to monitor changes to critical user and group management files, including `/etc/group`, `/etc/passwd`, `/etc/shadow`, `/etc/gshadow`, and `/etc/security/opasswd`. These files store information about user accounts, group memberships, and password policies.
+
+        **Rationale:**
+
+        Monitoring changes to these files is essential for maintaining system security. Unauthorized modifications can lead to privilege escalation, unauthorized access, or other malicious activities.
+
+        If monitoring is not enabled:
+          - Changes to user or group configurations may go undetected, exposing the system to potential threats.
+          - It becomes difficult to trace unauthorized actions or identify the source of configuration drift.
+          - The system may fall out of compliance with security standards requiring audit logging.
+
+        By ensuring that changes to these critical files are monitored, organizations can maintain a secure environment and quickly respond to potential threats.
       remediation: |-
         Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
@@ -1967,7 +2548,18 @@ queries:
       props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b64\s+\-S\s+mount\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+mounts(\s+)?$/)) || props.mondooLinuxSecurityAuditFiles.any(_.contains(/^(\s+)?\-a\s+always\,exit\s+\-F\s+arch\=b32\s+\-S\s+mount\s+\-F\s+auid\>\=1000\s+\-F\s+auid\!\=(4294967295|unset|-1)\s+\-k\s+mounts(\s+)?$/))
     docs:
       desc: |-
-        Monitor the use of the `mount` system call. The `mount` (and `umount`) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user
+        This check verifies that the system is configured to monitor successful file system mount events by auditing the `mount` system call. The audit log will record events where the user is a non-privileged user (auid >= 1000) and is not a daemon event (auid=4294967295). All audit records will be tagged with the identifier "mounts."
+
+        **Rationale:**
+
+        Monitoring successful file system mounts is critical for maintaining system security. Unauthorized or unexpected mounts can lead to data leakage, privilege escalation, or other malicious activities.
+
+        If these events are not audited:
+          - Unauthorized mounts may go unnoticed, exposing the system to potential threats.
+          - It becomes difficult to trace unauthorized actions or identify the source of configuration drift.
+          - The system may fall out of compliance with security standards requiring audit logging.
+
+        By ensuring that successful file system mount events are monitored, organizations can maintain a secure environment and quickly respond to potential threats.
       remediation: |-
         For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 


### PR DESCRIPTION
- Add descriptions that match our format and focus on why these checks matter
- Add remediation steps for exim4
- Collapse the two checks for auditd installed and enabled/running into one as that makes more sense from a why perspective
- Fix the docs for `Ensure login and logout events are collected` being in the wrong query (variant vs. main)
- Add remediation steps for UEFI systems



Signed-off-by: Tim Smith <tsmith84@gmail.com>