### PR TITLE
Improve the GCP policy

### DIFF
--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -20,32 +20,36 @@ policies:
 
         Our goal is to build policies that are simple to deploy, accurate, and actionable. This policy is open-source and we welcome contributions from the community, whether it's adding new checks, refining existing ones, or providing feedback. If you have suggestions to improve this policy, visit our [cnspec-policies repository](https://github.com/mondoohq/cnspec-policies).
     groups:
-      - title: GCP Project
+      - title: Cloud Storage
         checks:
-          - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account
-          - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api
-          - uid: mondoo-gcp-security-block-project-wide-ssh-keys-enabled-vm-instances
-          - uid: mondoo-gcp-security-oslogin-enabled-project
           - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible
           - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled
-          - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed
-          - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls
-          - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled
-          - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled
-          - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose
-          - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled
-          - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled
-          - uid: mondoo-gcp-security-compute-instances-no-public-ip
-          - uid: mondoo-gcp-security-compute-instances-no-default-service-account
+      - title: Compute Engine Instances
+        checks:
+          - uid: mondoo-gcp-security-block-project-wide-ssh-keys-enabled-vm-instances
           - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys
           - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled
+          - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled
+          - uid: mondoo-gcp-security-compute-instances-no-default-service-account
+          - uid: mondoo-gcp-security-compute-instances-no-public-ip
+          - uid: mondoo-gcp-security-compute-instances-oslogin-enabled
           - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled
           - uid: mondoo-gcp-security-compute-instances-vtpm-enabled
-          - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled
-          - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed
-          - uid: mondoo-gcp-security-cloud-sql-sql-server-instances-not-publicly-exposed
+          - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account
+          - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api
+      - title: Cloud SQL
+        checks:
+          - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls
+          - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed
+          - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled
+          - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled
           - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls
+          - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed
+          - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled
+          - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled
+          - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose
           - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls
+          - uid: mondoo-gcp-security-cloud-sql-sql-server-instances-not-publicly-exposed
     scoring_system: highest impact
 queries:
   - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account
@@ -60,7 +64,7 @@ queries:
       desc: |
         This check ensures that Google Cloud Compute Engine instances are not configured to use the default service account (-compute@developer.gserviceaccount.com). Instead, instances should use custom service accounts with only the permissions required for their specific function, adhering to the principle of least privilege.
 
-        Why this matters
+        **Why this matters**
 
         When the Compute Engine API is enabled on a new Google Cloud project, Google automatically creates a default Compute Engine service account with the IAM Editor role. This account has broad permissions across many Google Cloud services and is frequently used by default unless explicitly overridden:
           •	Using the default service account grants more privileges than most applications require, increasing the risk of privilege escalation or lateral movement in the event of compromise.
@@ -118,9 +122,9 @@ queries:
             10. Select **START**.
         - id: cli
           desc: |
-            **gcloud cli**
+            **gcloud CLI**
 
-            To update the service account using the `gcloud` cli:
+            To update the service account using the `gcloud` CLI:
 
             1. Stop the instance:
 
@@ -183,7 +187,7 @@ queries:
       desc: |
         This check ensures that Google Cloud Compute Engine instances are not provisioned with full access to all Google Cloud APIs. Instead, instances should be assigned custom service accounts with narrowly scoped permissions, adhering to the principle of least privilege.
 
-        Why this matters
+        **Why this matters**
 
         By default, when creating a Compute Engine instance, users can assign it “Allow full access to all Cloud APIs”, granting unrestricted access to most Google Cloud services. This setting is overly permissive and introduces significant security risk:
           •	It allows the instance to interact with nearly any Google Cloud API, regardless of the workload's actual needs.
@@ -242,9 +246,9 @@ queries:
             10. Select **START**.
         - id: cli
           desc: |
-            **gcloud cli**
+            **gcloud CLI**
 
-            To update the service account using the `gcloud` cli:
+            To update the service account using the `gcloud` CLI:
 
             1. Stop the instance:
 
@@ -313,7 +317,7 @@ queries:
       desc: |
         This check ensures that Google Cloud Platform (GCP) projects are configured to use instance-specific SSH keys rather than project-wide SSH keys. This approach limits the impact of credential compromise and supports strong access control at the individual virtual machine level.
 
-        Why this matters
+        **Why this matters**
 
         GCP allows SSH keys to be defined at the project level, enabling access to all Compute Engine instances within the project. While this simplifies SSH key management, it introduces significant security risks:
           •	If a project-wide SSH key is compromised, an attacker may gain access to every VM in the project.
@@ -375,7 +379,7 @@ queries:
           desc: |
             **Using CLI** `gcloud cli`
 
-            To update an instance using the `gcloud` cli:
+            To update an instance using the `gcloud` CLI:
 
             1. Update the instance:
 
@@ -406,19 +410,19 @@ queries:
 
 
 
-  - uid: mondoo-gcp-security-oslogin-enabled-project
+  - uid: mondoo-gcp-security-compute-instances-oslogin-enabled
     title: Ensure oslogin is enabled for compute instances
     impact: 70
     variants:
-      - uid: mondoo-gcp-security-oslogin-enabled-project-single
-      - uid: mondoo-gcp-security-oslogin-enabled-project-terraform-hcl
-      - uid: mondoo-gcp-security-oslogin-enabled-project-terraform-plan
-      - uid: mondoo-gcp-security-oslogin-enabled-project-terraform-state
+      - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-single
+      - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-hcl
+      - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-plan
+      - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-state
     docs:
       desc: |
         This check ensures that OS Login is enabled on Google Cloud Platform (GCP) Compute Engine instances to manage SSH access through IAM roles rather than relying on SSH keys stored in project or instance metadata. OS Login improves access control, auditability, and security by centralizing identity-based SSH authentication.
 
-        Why this matters
+        **Why this matters**
 
         By default, SSH access to GCP Compute Engine instances is managed using manually added SSH keys in project or instance metadata. This method has several limitations:
           •	SSH keys are difficult to track, audit, and revoke, especially in large or dynamic environments.
@@ -492,23 +496,23 @@ queries:
             5. Select **SAVE**.
         - id: console
           desc: |
-            **gcloud cli**
+            **gcloud CLI**
 
-            To update OS Login for a project using the `gcloud` cli:
+            To update OS Login for a project using the `gcloud` CLI:
 
             ```bash
             gcloud compute project-info add-metadata --metadata enable-oslogin=TRUE
             ```
 
-            To update OS Login for an existing instance using the `gcloud` cli:
+            To update OS Login for an existing instance using the `gcloud` CLI:
 
             ```bash
             gcloud compute instances add-metadata INSTANCE_NAME --metadata enable-oslogin=TRUE
             ```
-  - uid: mondoo-gcp-security-oslogin-enabled-project-single
+  - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-single
     filters: asset.platform == 'gcp-compute-instance'
     mql: gcp.compute.instance.metadata['enable-oslogin'] == true
-  - uid: mondoo-gcp-security-oslogin-enabled-project-terraform-hcl
+  - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_instance' || nameLabel == 'google_compute_project_metadata')
     mql: |
@@ -521,7 +525,7 @@ queries:
       terraform.resources.where(nameLabel == 'google_compute_project_metadata').all(
         arguments.metadata['enable-oslogin'] == 'TRUE'
       )
-  - uid: mondoo-gcp-security-oslogin-enabled-project-terraform-plan
+  - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-plan
     filters: |
       asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_compute_instance' || type == 'google_compute_project_metadata')
     mql: |
@@ -534,7 +538,7 @@ queries:
       terraform.plan.resourceChanges.where(type == 'google_compute_project_metadata').all(
         change.after.metadata['enable-oslogin'] == 'TRUE'
       )
-  - uid: mondoo-gcp-security-oslogin-enabled-project-terraform-state
+  - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-state
     filters: |
       asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_compute_instance' || type == 'google_compute_project_metadata')
     mql: |
@@ -562,7 +566,7 @@ queries:
       desc: |
         This check ensures that Google Cloud Storage buckets do not have IAM bindings or ACLs that grant access to the allUsers or allAuthenticatedUsers principals. These principals represent unauthenticated and broadly authenticated public access, which significantly increases the risk of unintentional data exposure.
 
-        Why this matters
+        **Why this matters**
 
         In Google Cloud, the allUsers principal allows anyone on the internet to access a resource without authentication, while allAuthenticatedUsers allows access to any user with a Google account. Assigning these principals to a Cloud Storage bucket—either directly via IAM roles or indirectly through legacy ACLs—exposes data to a much broader audience than intended.
 
@@ -614,7 +618,7 @@ queries:
             5. Select **Confirm**.
         - id: cli
           desc: |
-            **gcloud cli**
+            **gcloud CLI**
 
             To update public access configuration using the `gcloud` cli, ensure `allUsers` and `allAuthenticatedUsers` are not set by removing them:
 
@@ -698,7 +702,7 @@ queries:
             5. In the pop-up menu that appears, select **Save**.
         - id: cli
           desc: |
-            **gcloud cli**
+            **gcloud CLI**
 
             ```bash
             # Enable uniform bucket-level access
@@ -794,10 +798,10 @@ queries:
             **Using the Google Cloud Console**
 
             1.  Access the Cloud SQL Instances overview page in the Google Cloud Console: https://console.cloud.google.com/sql/instances
-            2.  Click on the name of the target instance to view its configuration details.
+            2.  Select the name of the target instance to view its configuration details.
             3.  Navigate to the **Connections** settings tab.
             4.  Under the **Networking** section, locate and uncheck the box labeled **Public IP**.
-            5.  Confirm the modification by clicking the **Save** button.
+            5.  Confirm the modification by selecting the **Save** button.
 
             **Prevention:**
 
@@ -872,7 +876,7 @@ queries:
         **Using the Google Cloud Console**
 
         1.  Navigate to the Cloud SQL Instances page: https://console.cloud.google.com/sql/instances
-        2.  Click on the name of the MySQL instance you want to audit.
+        2.  Select the name of the MySQL instance you want to audit.
         3.  Select the **Connections** tab.
         4.  Go to the **Security** sub-tab.
         5.  Verify that the checkbox for **Allow only SSL connections** is checked.
@@ -898,11 +902,11 @@ queries:
             **Using the Google Cloud Console**
 
             1.  Access the Cloud SQL Instances overview page: https://console.cloud.google.com/sql/instances
-            2.  Click the name of the target MySQL instance.
+            2.  Select the name of the target MySQL instance.
             3.  Navigate to the **Connections** tab, then the **Security** sub-tab.
             4.  Check the box labeled **Allow only SSL connections**.
             5.  If it is disabled go to **Security** and check **Allow only SSL connections**
-            5.  Click **Save** to apply the change. *Note: This may trigger an instance restart.*
+            5.  Select **Save** to apply the change. *Note: This may trigger an instance restart.*
 
             **Prevention:**
 
@@ -1041,11 +1045,11 @@ queries:
 
             1.  Go to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target MySQL instance.
-            3.  Click **Edit**.
+            3.  Select **Edit**.
             4.  Scroll down to the **Flags** section.
-            5.  If the flag isn't present, click **Add item**.
+            5.  If the flag isn't present, select **Add item**.
             6.  Choose `skip_show_database` from the dropdown and set its value to `on`. If the flag exists but is `off`, change its value to `on`.
-            7.  Click **Save**. Review the **Flags** section on the instance overview page to confirm.
+            7.  Select **Save**. Review the **Flags** section on the instance overview page to confirm.
         - id: cli
           desc: |
             **Using the Google Cloud CLI**
@@ -1170,11 +1174,11 @@ queries:
 
             1.  Go to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target MySQL instance.
-            3.  Click **Edit**.
+            3.  Select **Edit**.
             4.  Scroll down to the **Flags** section.
-            5.  If the flag isn't present, click **Add item**.
+            5.  If the flag isn't present, select **Add item**.
             6.  Choose `local_infile` from the dropdown and set its value to `off`. If the flag exists but is `on`, change its value to `off`.
-            7.  Click **Save**. Review the **Flags** section on the instance overview page to confirm.
+            7.  Select **Save**. Review the **Flags** section on the instance overview page to confirm.
         - id: cli
           desc: |
             **Using the Google Cloud CLI**
@@ -1299,11 +1303,11 @@ queries:
 
             1.  Go to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target PostgreSQL instance.
-            3.  Click **Edit**.
+            3.  Select **Edit**.
             4.  Scroll down to the **Flags** section.
-            5.  If the flag isn't present, click **Add item**.
+            5.  If the flag isn't present, select **Add item**.
             6.  Choose `log_error_verbosity` from the dropdown and set its value to `default` or `verbose`. If the flag exists but is set to `terse`, change its value.
-            7.  Click **Save**. Review the **Flags** section on the instance overview page to confirm.
+            7.  Select **Save**. Review the **Flags** section on the instance overview page to confirm.
         - id: cli
           desc: |
             **Using the Google Cloud CLI**
@@ -1434,11 +1438,11 @@ queries:
 
             1.  Go to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target PostgreSQL instance.
-            3.  Click **Edit**.
+            3.  Select **Edit**.
             4.  Scroll down to the **Flags** section.
-            5.  If the flag isn't present, click **Add item**.
+            5.  If the flag isn't present, select **Add item**.
             6.  Choose `log_connections` from the dropdown and set its value to `on`. If the flag exists but is `off`, change its value to `on`.
-            7.  Click **Save**. Review the **Flags** section on the instance overview page to confirm.
+            7.  Select **Save**. Review the **Flags** section on the instance overview page to confirm.
         - id: cli
           desc: |
             **Using the Google Cloud CLI**
@@ -1562,11 +1566,11 @@ queries:
 
             1.  Go to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target PostgreSQL instance.
-            3.  Click **Edit**.
+            3.  Select **Edit**.
             4.  Scroll down to the **Flags** section.
-            5.  If the flag isn't present, click **Add item**.
+            5.  If the flag isn't present, select **Add item**.
             6.  Choose `log_disconnections` from the dropdown and set its value to `on`. If the flag exists but is `off`, change its value to `on`.
-            7.  Click **Save**. Review the **Flags** section on the instance overview page to confirm.
+            7.  Select **Save**. Review the **Flags** section on the instance overview page to confirm.
         - id: cli
           desc: |
             **Using the Google Cloud CLI**
@@ -1726,13 +1730,13 @@ queries:
             **From Google Cloud Console**
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-            2. Click the name of the target instance to open its details page.
-            3. Click the `Edit` button at the top.
+            2. Select the name of the target instance to open its details page.
+            3. Select the `Edit` button at the top.
             4. Scroll down to the `Network interfaces` section.
-            5. For the relevant network interface, click the pencil icon to edit it.
+            5. For the relevant network interface, select the pencil icon to edit it.
             6. Set the `External IP` dropdown menu to `None`.
-            7. Click `Done` to close the network interface settings.
-            8. Click `Save` at the bottom of the page to apply the changes.
+            7. Select `Done` to close the network interface settings.
+            8. Select `Save` at the bottom of the page to apply the changes.
 
             **Prevention:**
             Utilize the Organization Policy `constraints/compute.vmExternalIpAccess` to restrict or deny the assignment of external IP addresses to VMs across your organization or specific folders/projects. Configure this policy at: [https://console.cloud.google.com/orgpolicies/compute-vmExternalIpAccess](https://console.cloud.google.com/orgpolicies/compute-vmExternalIpAccess)
@@ -1810,7 +1814,7 @@ queries:
         **From Google Cloud Console**
 
         1. Navigate to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-        2. Click on the name of an instance to view its details.
+        2. Select on the name of an instance to view its details.
         3. Locate the `API and identity management` section.
         4. Verify that the `Service account` listed is **not** the default Compute Engine service account (which follows the pattern `[PROJECT_NUMBER]-compute@developer.gserviceaccount.com`). Repeat for all relevant instances.
 
@@ -1882,13 +1886,13 @@ queries:
             **From Google Cloud Console**
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-            2. Click the name of the instance you want to modify.
-            3. Click the `STOP` button at the top and confirm. Wait for the instance to stop completely.
-            4. Once stopped, click the `EDIT` button.
+            2. Select the name of the instance you want to modify.
+            3. Select the `STOP` button at the top and confirm. Wait for the instance to stop completely.
+            4. Once stopped, Select the `Edit` button.
             5. Scroll down to the `API and identity management` section.
             6. In the `Service account` dropdown, select a suitable custom service account. If needed, create a new service account with appropriate permissions first via the `IAM & Admin` -> `Service Accounts` page.
-            7. Click `Save` at the bottom.
-            8. Click the `START / RESUME` button at the top to restart the instance.
+            7. Select `Save` at the bottom.
+            8. Select the `START / RESUME` button at the top to restart the instance.
         - id: cli
           desc: |
             **From Google Cloud CLI**
@@ -1961,7 +1965,7 @@ queries:
         **From Google Cloud Console**
 
         1. Navigate to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-        2. Click on the name of the instance you want to check.
+        2. Select on the name of the instance you want to check.
         3. Scroll down to the `SSH Keys` section.
         4. Verify that the checkbox labeled `Block project-wide SSH keys` is checked. Repeat for all relevant instances.
 
@@ -2014,11 +2018,11 @@ queries:
             **From Google Cloud Console**
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-            2. Click the name of the instance to modify.
-            3. Click the `Edit` button at the top.
+            2. Select the name of the instance to modify.
+            3. Select the `Edit` button at the top.
             4. Scroll down to the `SSH Keys` section (it might be under `Security and access` or a similar heading).
             5. Check the box for `Block project-wide SSH keys`.
-            6. Click `Save` at the bottom of the page.
+            6. Select `Save` at the bottom of the page.
             7. Repeat these steps for all instances where project-wide keys should be blocked.
         - id: cli
           desc: |
@@ -2089,7 +2093,7 @@ queries:
         **From Google Cloud Console**
 
         1. Navigate to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-        2. Click on the name of an N2D instance (or other supported type) to view its details.
+        2. Select the name of an N2D instance (or other supported type) to view its details.
         3. Look for the `Confidential VM service` status indicator within the instance properties.
         4. Ensure the status shows as `Enabled` or `On`.
 
@@ -2152,13 +2156,13 @@ queries:
             **From Google Cloud Console**
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-            2. Click `CREATE INSTANCE`.
+            2. Select `CREATE INSTANCE`.
             3. Configure the instance settings (name, region, zone).
             4. Select a supported machine type from the N2D series (or other applicable types) under `Machine configuration`.
             5. Scroll down to the `Confidential VM service` section.
             6. Check the box labeled `Enable the Confidential Computing service on this VM instance`. Note that this usually requires setting the `On host maintenance` policy to `Terminate VM instance`.
             7. Configure other settings as needed (boot disk, networking, etc.).
-            8. Click `Create`.
+            8. Select `Create`.
         - id: cli
           desc: |
             The Confidential VM service can only be activated when creating a new VM instance. It cannot be enabled on an existing instance.
@@ -2239,7 +2243,7 @@ queries:
         **From Google Cloud Console**
 
         1. Navigate to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-        2. Click on the name of the instance you want to check.
+        2. Select the name of the instance you want to check.
         3. In the `VM instance details` page, locate the `Shielded VM` section.
         4. Verify that the `Secure Boot` toggle or status indicator shows `Enabled` or `On`.
 
@@ -2301,13 +2305,13 @@ queries:
             **From Google Cloud Console**
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-            2. Click the name of the instance to modify.
-            3. If the instance is running, click `STOP` and confirm. Wait for it to stop.
-            4. Click `EDIT`.
+            2. Select the name of the instance to modify.
+            3. If the instance is running, select `STOP` and confirm. Wait for it to stop.
+            4. Select `EDIT`.
             5. Scroll to the `Shielded VM` section.
             6. Check the box or toggle the switch to enable `Secure Boot`. Enabling Secure Boot typically requires vTPM and Integrity Monitoring to also be enabled or automatically enabled alongside it.
-            7. Click `Save`.
-            8. Click `START / RESUME` to restart the instance.
+            7. Select `Save`.
+            8. Select `START / RESUME` to restart the instance.
 
             **Prevention:**
             Enforce the use of Shielded VMs for all new instances by configuring the `constraints/compute.requireShieldedVm` Organization Policy. Manage this policy at: [https://console.cloud.google.com/iam-admin/orgpolicies/compute-requireShieldedVm](https://console.cloud.google.com/iam-admin/orgpolicies/compute-requireShieldedVm). See documentation for details: [https://cloud.google.com/security/shielded-cloud/shielded-vm#organization-policy-constraint](https://cloud.google.com/security/shielded-cloud/shielded-vm#organization-policy-constraint).
@@ -2394,7 +2398,7 @@ queries:
         **From Google Cloud Console**
 
         1. Navigate to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-        2. Click on the name of the instance you want to check.
+        2. Select the name of the instance you want to check.
         3. In the `VM instance details` page, find the `Shielded VM` section.
         4. Verify that the `vTPM` toggle or status indicator shows `Enabled` or `On`.
 
@@ -2456,8 +2460,8 @@ queries:
             **From Google Cloud Console**
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-            2. Click the name of the instance to modify.
-            3. If the instance is running, click `STOP` and confirm. Wait for it to stop completely.
+            2. Select the name of the instance to modify.
+            3. If the instance is running, select `STOP` and confirm. Wait for it to stop completely.
             4. Click `EDIT`.
             5. Scroll down to the `Shielded VM` section.
             6. Check the box or toggle the switch to enable `vTPM`.
@@ -2550,7 +2554,7 @@ queries:
         **From Google Cloud Console**
 
         1. Navigate to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-        2. Click on the name of the instance you want to check.
+        2. Select the name of the instance you want to check.
         3. In the `VM instance details` page, locate the `Shielded VM` section.
         4. Verify that the `Integrity Monitoring` toggle or status indicator shows `Enabled` or `On`.
 
@@ -2612,8 +2616,8 @@ queries:
             **From Google Cloud Console**
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-            2. Click the name of the instance to modify.
-            3. If the instance is running, click `STOP` and confirm. Wait for it to stop completely.
+            2. Select the name of the instance to modify.
+            3. If the instance is running, select `STOP` and confirm. Wait for it to stop completely.
             4. Click `EDIT`.
             5. Scroll down to the `Shielded VM` section.
             6. Ensure `vTPM` is enabled.
@@ -2723,10 +2727,10 @@ queries:
             **Using the Google Cloud Console**
 
             1.  Access the Cloud SQL Instances overview page in the Google Cloud Console: https://console.cloud.google.com/sql/instances
-            2.  Click on the name of the target PostgreSQL instance to view its configuration details.
+            2.  Select the name of the target PostgreSQL instance to view its configuration details.
             3.  Navigate to the **Connections** settings tab.
             4.  Under the **Networking** section, locate and uncheck the box labeled **Public IP**.
-            5.  Confirm the modification by clicking the **Save** button.
+            5.  Confirm the modification by selecting the **Save** button.
 
             **Prevention:**
 
@@ -2853,10 +2857,10 @@ queries:
             **Using the Google Cloud Console**
 
             1.  Access the Cloud SQL Instances overview page in the Google Cloud Console: https://console.cloud.google.com/sql/instances
-            2.  Click on the name of the target SQL Server instance to view its configuration details.
+            2.  Select the name of the target SQL Server instance to view its configuration details.
             3.  Navigate to the **Connections** settings tab.
             4.  Under the **Networking** section, locate and uncheck the box labeled **Public IP**.
-            5.  Confirm the modification by clicking the **Save** button.
+            5.  Confirm the modification by selecting the **Save** button.
 
             **Prevention:**
 
@@ -2960,7 +2964,7 @@ queries:
         **Using the Google Cloud Console**
 
         1.  Navigate to the Cloud SQL Instances page: https://console.cloud.google.com/sql/instances
-        2.  Click on the name of the PostgreSQL instance you want to audit.
+        2.  Select the name of the PostgreSQL instance you want to audit.
         3.  Select the **Connections** tab.
         4.  Go to the **Security** sub-tab.
         5.  Verify that the checkbox for **Allow only SSL connections** is checked.
@@ -2986,11 +2990,11 @@ queries:
             **Using the Google Cloud Console**
 
             1.  Access the Cloud SQL Instances overview page: https://console.cloud.google.com/sql/instances
-            2.  Click the name of the target PostgreSQL instance.
+            2.  Select the name of the target PostgreSQL instance.
             3.  Navigate to the **Connections** tab, then the **Security** sub-tab.
             4.  Check the box labeled **Allow only SSL connections**.
             5.  If it is disabled go to **Security** and check **Allow only SSL connections**
-            5.  Click **Save** to apply the change. *Note: This may trigger an instance restart.*
+            5.  Select **Save** to apply the change. *Note: This may trigger an instance restart.*
 
             **Prevention:**
 
@@ -3094,7 +3098,7 @@ queries:
         **Using the Google Cloud Console**
 
         1.  Navigate to the Cloud SQL Instances page: https://console.cloud.google.com/sql/instances
-        2.  Click on the name of the SQL Server instance you want to audit.
+        2.  Select the name of the SQL Server instance you want to audit.
         3.  Select the **Connections** tab.
         4.  Go to the **Security** sub-tab.
         5.  Verify that the checkbox for **Allow only SSL connections** is checked.
@@ -3120,11 +3124,11 @@ queries:
             **Using the Google Cloud Console**
 
             1.  Access the Cloud SQL Instances overview page: https://console.cloud.google.com/sql/instances
-            2.  Click the name of the target SQL Server instance.
+            2.  Select the name of the target SQL Server instance.
             3.  Navigate to the **Connections** tab, then the **Security** sub-tab.
             4.  Check the box labeled **Allow only SSL connections**.
             5.  If it is disabled go to **Security** and check **Allow only SSL connections**
-            5.  Click **Save** to apply the change. *Note: This may trigger an instance restart.*
+            5.  Select **Save** to apply the change. *Note: This may trigger an instance restart.*
 
             **Prevention:**
 

--- a/core/mondoo-gcp-security.mql.yaml
+++ b/core/mondoo-gcp-security.mql.yaml
@@ -1043,7 +1043,7 @@ queries:
           desc: |
             **Using the Google Cloud Console**
 
-            1.  Go to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
+            1.  Navigate to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target MySQL instance.
             3.  Select **Edit**.
             4.  Scroll down to the **Flags** section.
@@ -1172,7 +1172,7 @@ queries:
           desc: |
             **Using the Google Cloud Console**
 
-            1.  Go to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
+            1.  Navigate to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target MySQL instance.
             3.  Select **Edit**.
             4.  Scroll down to the **Flags** section.
@@ -1301,7 +1301,7 @@ queries:
           desc: |
             **Using the Google Cloud Console**
 
-            1.  Go to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
+            1.  Navigate to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target PostgreSQL instance.
             3.  Select **Edit**.
             4.  Scroll down to the **Flags** section.
@@ -1436,7 +1436,7 @@ queries:
           desc: |
             **Using the Google Cloud Console**
 
-            1.  Go to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
+            1.  Navigate to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target PostgreSQL instance.
             3.  Select **Edit**.
             4.  Scroll down to the **Flags** section.
@@ -1564,7 +1564,7 @@ queries:
           desc: |
             **Using the Google Cloud Console**
 
-            1.  Go to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
+            1.  Navigate to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target PostgreSQL instance.
             3.  Select **Edit**.
             4.  Scroll down to the **Flags** section.
@@ -1727,7 +1727,7 @@ queries:
             ```
         - id: console
           desc: |
-            **From Google Cloud Console**
+            **Using Google Cloud Console**
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Select the name of the target instance to open its details page.
@@ -1883,7 +1883,7 @@ queries:
             }
         - id: console
           desc: |
-            **From Google Cloud Console**
+            **Using Google Cloud Console**
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Select the name of the instance you want to modify.
@@ -2015,7 +2015,7 @@ queries:
             ```
         - id: console
           desc: |
-            **From Google Cloud Console**
+            **Using Google Cloud Console**
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Select the name of the instance to modify.
@@ -2153,7 +2153,7 @@ queries:
           desc: |
             The Confidential VM service can only be activated when creating a new VM instance. It cannot be enabled on an existing instance.
 
-            **From Google Cloud Console**
+            **Using Google Cloud Console**
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Select `CREATE INSTANCE`.
@@ -2302,7 +2302,7 @@ queries:
           desc: |
             Secure Boot can only be enabled on instances using an OS image that supports Shielded VM features.
 
-            **From Google Cloud Console**
+            **Using Google Cloud Console**
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Select the name of the instance to modify.
@@ -2457,16 +2457,16 @@ queries:
           desc: |
             vTPM can only be enabled on instances using an OS image that supports Shielded VM features.
 
-            **From Google Cloud Console**
+            **Using Google Cloud Console**
 
-            1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
-            2. Select the name of the instance to modify.
-            3. If the instance is running, select `STOP` and confirm. Wait for it to stop completely.
-            4. Click `EDIT`.
-            5. Scroll down to the `Shielded VM` section.
-            6. Check the box or toggle the switch to enable `vTPM`.
-            7. Click `Save`.
-            8. Click `START / RESUME` to restart the instance.
+            1. Navigate to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
+            2. Locate and select the instance you want to modify.
+            3. If the instance is running, click `STOP` and confirm. Wait until the instance is fully stopped.
+            4. Click `EDIT` to modify the instance settings.
+            5. Scroll to the `Shielded VM` section.
+            6. Enable the `vTPM` option by checking the corresponding box or toggling the switch.
+            7. Click `Save` to apply the changes.
+            8. Restart the instance by clicking `START / RESUME`.
 
             **Prevention:**
             Mandate the use of Shielded VMs (which includes vTPM) for new instances via the `constraints/compute.requireShieldedVm` Organization Policy. Configure it at: [https://console.cloud.google.com/iam-admin/orgpolicies/compute-requireShieldedVm](https://console.cloud.google.com/iam-admin/orgpolicies/compute-requireShieldedVm). Refer to documentation: [https://cloud.google.com/security/shielded-cloud/shielded-vm#organization-policy-constraint](https://cloud.google.com/security/shielded-cloud/shielded-vm#organization-policy-constraint).
@@ -2613,7 +2613,7 @@ queries:
           desc: |
             Integrity Monitoring requires an instance using an OS image that supports Shielded VM features, and vTPM must also be enabled.
 
-            **From Google Cloud Console**
+            **Using Google Cloud Console**
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Select the name of the instance to modify.
@@ -2631,25 +2631,29 @@ queries:
           desc: |
             Integrity Monitoring requires an instance using an OS image that supports Shielded VM features, and vTPM must also be enabled.
 
-            **From Google Cloud CLI**
+            **Using Google Cloud CLI**
 
-            Ensure the instance uses a compatible image and has vTPM enabled. You can list public Shielded VM images:
+            1. Verify that the instance uses a compatible Shielded VM image. You can list public Shielded VM images that support Integrity Monitoring:
             ```bash
             gcloud compute images list --project gce-uefi-images --no-standard-images --filter="shieldedVmFeatures:(INTEGRITY_MONITORING)"
             ```
 
-            1. Stop the instance if it is running:
+            2. Stop the instance if it is currently running:
             ```bash
             gcloud compute instances stop INSTANCE_NAME --zone=ZONE
             ```
-            2. Update the instance to enable Integrity Monitoring (this command implicitly enables vTPM as well):
+
+            3. Update the instance to enable Integrity Monitoring. This command will also enable vTPM if it is not already enabled:
             ```bash
             gcloud compute instances update INSTANCE_NAME --zone=ZONE --shielded-vm-integrity-monitoring
             ```
-            3. Start the instance:
+
+            4. Start the instance after the update:
             ```bash
             gcloud compute instances start INSTANCE_NAME --zone=ZONE
             ```
+
+            Replace `INSTANCE_NAME` and `ZONE` with the appropriate values for your instance.
   - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-single
     filters: |
       asset.platform == 'gcp-compute-instance'
@@ -2703,38 +2707,43 @@ queries:
       audit: |
         **Using the Google Cloud Console**
 
-          1. Navigate to the Cloud SQL Instances page within the Google Cloud Console: https://console.cloud.google.com/sql/instances
-          2. Review each PostgreSQL instance listed. For every primary (non-replica) Second Generation instance, examine its networking details to confirm that a Private IP address is assigned and that no Public IP address (type: PRIMARY) is present.
+          1. Navigate to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
+          2. Review the list of PostgreSQL instances. For each primary (non-replica) Second Generation instance:
+             - Select the instance name to view its details.
+             - Navigate to the **Connections** tab.
+             - Confirm that a **Private IP** address is assigned and that no **Public IP** address (type: PRIMARY) is present.
 
-        ** Using the Google Cloud CLI **
+        **Using the Google Cloud CLI**
 
-          1. Obtain a list of all your Cloud SQL instances:
-
+          1. List all Cloud SQL instances in your project:
             ```bash
             gcloud sql instances list
             ```
 
-          2. For each PostgreSQL instance identified as `backendType: SECOND_GEN` and `instanceType: CLOUD_SQL_INSTANCE` (primary instance), retrieve its full configuration details. Read replicas (`instanceType: READ_REPLICA_INSTANCE`) inherit network settings, and First Generation instances do not support private IPs, so they can be skipped for this check.
-
+          2. For each PostgreSQL instance identified as `backendType: SECOND_GEN` and `instanceType: CLOUD_SQL_INSTANCE` (primary instance), retrieve its configuration details:
             ```bash
             gcloud sql instances describe INSTANCE_NAME
             ```
 
-          3. Inspect the `ipAddresses` section in the output for the instance. Verify that an entry exists with `type: PRIVATE`. Crucially, ensure there is no entry with `type: PRIMARY`, as this indicates a public IP address. While an instance can technically possess both during transitions, the secure state is having only the `PRIVATE` type assigned.
+          3. Inspect the `ipAddresses` section in the output:
+             - Ensure there is an entry with `type: PRIVATE`.
+             - Verify that no entry exists with `type: PRIMARY`, as this indicates a public IP address.
+
+          **Note:** Instances can temporarily have both private and public IPs during transitions. The secure state is when only the **PRIVATE** type is assigned.
       remediation:
         - id: console
           desc: |
             **Using the Google Cloud Console**
 
-            1.  Access the Cloud SQL Instances overview page in the Google Cloud Console: https://console.cloud.google.com/sql/instances
-            2.  Select the name of the target PostgreSQL instance to view its configuration details.
-            3.  Navigate to the **Connections** settings tab.
-            4.  Under the **Networking** section, locate and uncheck the box labeled **Public IP**.
-            5.  Confirm the modification by selecting the **Save** button.
+            1.  Navigate to the Cloud SQL Instances page in the Google Cloud Console: https://console.cloud.google.com/sql/instances.
+            2.  Select the name of the target PostgreSQL instance to open its configuration details.
+            3.  Navigate to the **Connections** tab.
+            4.  In the **Networking** section, uncheck the box labeled **Public IP** to disable public access.
+            5.  Click **Save** to apply the changes.
 
             **Prevention:**
 
-            To proactively enforce that new Cloud SQL instances are not created with public IP addresses, implement the `Restrict Public IP access on Cloud SQL instances` Organization Policy. You can configure this policy at: https://console.cloud.google.com/iam-admin/orgpolicies/sql-restrictPublicIp
+            To ensure new Cloud SQL instances are not created with public IP addresses, enforce the `Restrict Public IP access on Cloud SQL instances` Organization Policy. Configure this policy at: https://console.cloud.google.com/iam-admin/orgpolicies/sql-restrictPublicIp.
         - id: cli
           desc: |
             **Using the Google Cloud CLI**


### PR DESCRIPTION
- Use select vs. click in remediation content
- Uppercase CLI everywhere
- Add chapters
- Rename of the check UIDs to match our pattern