### PR TITLE
Improvements to the Microsoft policies

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -4,7 +4,6 @@ accesskey
 adjtimex
 adml
 admx
-AGPASSOFBMF
 AKIAIOSFODNN
 amz
 ANVA
@@ -17,7 +16,6 @@ auid
 benbi
 bigfish
 bigquery
-bonzo
 bpa
 Bpcy
 bqowner
@@ -87,7 +85,6 @@ hostpath
 idpuser
 iis
 Jalr
-johnpaul
 jsonencode
 jwks
 kickstart
@@ -96,7 +93,6 @@ linux
 localtime
 logfile
 logon
-logouts
 Lsa
 Lsass
 lsetxattr
@@ -106,7 +102,6 @@ MLE
 mpim
 MRx
 Mvc
-mydb
 nameid
 natd
 nft
@@ -116,7 +111,6 @@ ntalk
 NTE
 odata
 oidc
-OMHVGHACB
 opasswd
 openat
 openresty
@@ -167,12 +161,10 @@ softwareupdate
 SQLSERVER
 srv
 ssldir
-SSLv
 sudolog
 sugroup
 syncookies
 tallylog
-timeval
 tinyssh
 tmpfiles
 uefi
@@ -181,7 +173,6 @@ uniformbucketlevelaccess
 unlinkat
 userlist
 USLACKBOT
-utc
 vnc
 vtpm
 wallace

--- a/.github/actions/spelling/line_forbidden.patterns
+++ b/.github/actions/spelling/line_forbidden.patterns
@@ -286,6 +286,10 @@
 # Microsoft Products
 #
 
+# s.b. WinRM
+\bwinRM\b
+\bWin RM\b
+
 # s.b. Microsoft
 \bMicroSoft\b
 

--- a/.github/actions/spelling/line_forbidden.patterns
+++ b/.github/actions/spelling/line_forbidden.patterns
@@ -104,6 +104,54 @@
 # Product Names
 #
 
+# s.b. auditd
+\bAuditd\b
+
+# s.b. WatchGuard
+\bWatchguard\b
+
+# s.b. Airtable
+\bAirTable\b
+
+# s.b. Tailscale
+\bTailScale\b
+
+# s.b. TeamCity
+\bTeamcity\b
+
+# s.b. Bitbucket
+\bBitBucket\b
+
+# s.b. Logstash
+\bLogStash\b
+
+# s.b. CyberArk
+\bCyberark\b
+
+# s.b. Chef Infra Server
+\bChef Server\b
+
+# s.b. Chef Infra Client
+\bChef Client\b
+
+# s.b. containerd
+\bContainerd\b
+
+# s.b. systemd
+\bSystemd\b
+
+# s.b. OpenLDAP
+\bOpen LDAP\b
+
+# s.b. WebSphere
+\bWebsphere\b
+
+# s.b. JBoss
+\bJboss\b
+
+# s.b. WildFly
+\bWildfly\b
+
 # s.b. DigiCert
 \bDigicert\b
 
@@ -245,6 +293,9 @@
 \bnameserver\b
 \bnameservers\b
 
+# s.b. Nmap
+\b[Nn]Map\b
+
 #
 # Kubernetes Terms
 #
@@ -285,6 +336,9 @@
 #
 # Microsoft Products
 #
+
+# s.b. Entra ID
+\bEntraID\b
 
 # s.b. WinRM
 \bwinRM\b
@@ -568,6 +622,7 @@
 # s.b. Memorystore
 \bMemoryStore\b
 \bMemory Store\b
+\bMem[Ss]tore\b
 
 # s.b. Pub/Sub
 \bPubSub\b
@@ -588,9 +643,6 @@
 
 # s.b. Datastore
 \bDataStore\b
-
-# s.b. Memorystore
-\bMemoryStore\b
 
 #
 # Azure Products

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -117,5 +117,22 @@ db.\w{2}.\w*
 # rsa private keys
 MII[BCEJ]\w*
 
-# UID in MQL policy
+# ID data MQL policies / query packs
 - uid: \S*
+secret_id: \S*
+secret: \S*
+publicKeyData: \S*
+fingerprint: "\S*
+p=MII\S*
+BackupPlanVersion: "\S*
+id: "\S*
+pkix.extension id = \S*
+id="\S*
+
+# OCI config
+user=\S*
+fingerprint=\S*
+tenancy=\S*
+
+# Mondoo registration token https://rubular.com/r/3UzGvhUamOAa0U
+MONDOO_REGISTRATION_TOKEN='\S*'

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -29,12 +29,11 @@ jobs:
           checkout: true
           post_comment: 0
           dictionary_source_prefixes: '{"mondoo": "https://raw.githubusercontent.com/mondoohq/spellcheck-dictionary/main/", "cspell": "https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20230509/dictionaries/"}'
-          extra_dictionaries:
-            cspell:aws/aws.txt
+          extra_dictionaries: cspell:aws/aws.txt
+            cspell:companies/src/companies.txt
             cspell:filetypes/filetypes.txt
             cspell:software-terms/src/software-terms.txt
             cspell:software-terms/src/software-tools.txt
-            cspell:companies/src/companies.txt
             mondoo:mondoo_dictionary.txt
 
   comment:

--- a/core/mondoo-edr-policy.mql.yaml
+++ b/core/mondoo-edr-policy.mql.yaml
@@ -41,7 +41,7 @@ policies:
 
         ### Prerequisites
 
-        Remote scans of windows hosts suitable authentication method such as winRM enabled or SSH keys.
+        Remote scans of windows hosts suitable authentication method such as WinRM enabled or SSH keys.
 
         ### Scan a remote Windows (SSH authentication)
 

--- a/core/mondoo-windows-security.mql.yaml
+++ b/core/mondoo-windows-security.mql.yaml
@@ -51,35 +51,6 @@ policies:
         checks:
           - uid: mondoo-windows-security-always-prompt-for-password-upon-connection-is-set-to-enabled
           - uid: mondoo-windows-security-apply-uac-restrictions-to-local-accounts-on-network-logons-is-set-to-enabled
-          - uid: mondoo-windows-security-audit-account-lockout-is-set-to-include-failure
-          - uid: mondoo-windows-security-audit-application-group-management-is-set-to-success-and-failure
-          - uid: mondoo-windows-security-audit-audit-policy-change-is-set-to-include-success
-          - uid: mondoo-windows-security-audit-authentication-policy-change-is-set-to-include-success
-          - uid: mondoo-windows-security-audit-authorization-policy-change-is-set-to-include-success
-          - uid: mondoo-windows-security-audit-credential-validation-is-set-to-success-and-failure
-          - uid: mondoo-windows-security-audit-detailed-file-share-is-set-to-include-failure
-          - uid: mondoo-windows-security-audit-file-share-is-set-to-success-and-failure
-          - uid: mondoo-windows-security-audit-force-audit-policy-subcategory-settings-windows-vista-or-later-to-override
-          - uid: mondoo-windows-security-audit-group-membership-is-set-to-include-success
-          - uid: mondoo-windows-security-audit-ipsec-driver-is-set-to-success-and-failure
-          - uid: mondoo-windows-security-audit-logoff-is-set-to-include-success
-          - uid: mondoo-windows-security-audit-logon-is-set-to-success-and-failure
-          - uid: mondoo-windows-security-audit-mpssvc-rule-level-policy-change-is-set-to-success-and-failure
-          - uid: mondoo-windows-security-audit-other-logonlogoff-events-is-set-to-success-and-failure
-          - uid: mondoo-windows-security-audit-other-object-access-events-is-set-to-success-and-failure
-          - uid: mondoo-windows-security-audit-other-policy-change-events-is-set-to-include-failure
-          - uid: mondoo-windows-security-audit-other-system-events-is-set-to-success-and-failure
-          - uid: mondoo-windows-security-audit-pnp-activity-is-set-to-include-success
-          - uid: mondoo-windows-security-audit-process-creation-is-set-to-include-success
-          - uid: mondoo-windows-security-audit-removable-storage-is-set-to-success-and-failure
-          - uid: mondoo-windows-security-audit-security-group-management-is-set-to-include-success
-          - uid: mondoo-windows-security-audit-security-state-change-is-set-to-include-success
-          - uid: mondoo-windows-security-audit-security-system-extension-is-set-to-include-success
-          - uid: mondoo-windows-security-audit-sensitive-privilege-use-is-set-to-success-and-failure
-          - uid: mondoo-windows-security-audit-shut-down-system-immediately-if-unable-to-log-security-audits
-          - uid: mondoo-windows-security-audit-special-logon-is-set-to-include-success
-          - uid: mondoo-windows-security-audit-system-integrity-is-set-to-success-and-failure
-          - uid: mondoo-windows-security-audit-user-account-management-is-set-to-success-and-failure
           - uid: mondoo-windows-security-configure-smb-v1-client-driver-is-set-to-enabled-disable-driver-recommended
           - uid: mondoo-windows-security-configure-smb-v1-server-is-set-to-disabled
           - uid: mondoo-windows-security-do-not-allow-com-port-redirection-is-set-to-enabled
@@ -125,6 +96,39 @@ policies:
           - uid: mondoo-windows-security-turn-off-multicast-name-resolution-is-set-to-enabled
           - uid: mondoo-windows-security-wdigest-authentication-is-set-to-disabled
           - uid: mondoo-windows-security-additional-LSA-protection
+      - title: Auditing
+        filters: |
+          asset.family.contains('windows')
+        checks:
+          - uid: mondoo-windows-security-audit-account-lockout-is-set-to-include-failure
+          - uid: mondoo-windows-security-audit-application-group-management-is-set-to-success-and-failure
+          - uid: mondoo-windows-security-audit-audit-policy-change-is-set-to-include-success
+          - uid: mondoo-windows-security-audit-authentication-policy-change-is-set-to-include-success
+          - uid: mondoo-windows-security-audit-authorization-policy-change-is-set-to-include-success
+          - uid: mondoo-windows-security-audit-credential-validation-is-set-to-success-and-failure
+          - uid: mondoo-windows-security-audit-detailed-file-share-is-set-to-include-failure
+          - uid: mondoo-windows-security-audit-file-share-is-set-to-success-and-failure
+          - uid: mondoo-windows-security-audit-force-audit-policy-subcategory-settings-windows-vista-or-later-to-override
+          - uid: mondoo-windows-security-audit-group-membership-is-set-to-include-success
+          - uid: mondoo-windows-security-audit-ipsec-driver-is-set-to-success-and-failure
+          - uid: mondoo-windows-security-audit-logoff-is-set-to-include-success
+          - uid: mondoo-windows-security-audit-logon-is-set-to-success-and-failure
+          - uid: mondoo-windows-security-audit-mpssvc-rule-level-policy-change-is-set-to-success-and-failure
+          - uid: mondoo-windows-security-audit-other-logonlogoff-events-is-set-to-success-and-failure
+          - uid: mondoo-windows-security-audit-other-object-access-events-is-set-to-success-and-failure
+          - uid: mondoo-windows-security-audit-other-policy-change-events-is-set-to-include-failure
+          - uid: mondoo-windows-security-audit-other-system-events-is-set-to-success-and-failure
+          - uid: mondoo-windows-security-audit-pnp-activity-is-set-to-include-success
+          - uid: mondoo-windows-security-audit-process-creation-is-set-to-include-success
+          - uid: mondoo-windows-security-audit-removable-storage-is-set-to-success-and-failure
+          - uid: mondoo-windows-security-audit-security-group-management-is-set-to-include-success
+          - uid: mondoo-windows-security-audit-security-state-change-is-set-to-include-success
+          - uid: mondoo-windows-security-audit-security-system-extension-is-set-to-include-success
+          - uid: mondoo-windows-security-audit-sensitive-privilege-use-is-set-to-success-and-failure
+          - uid: mondoo-windows-security-audit-shut-down-system-immediately-if-unable-to-log-security-audits
+          - uid: mondoo-windows-security-audit-special-logon-is-set-to-include-success
+          - uid: mondoo-windows-security-audit-system-integrity-is-set-to-success-and-failure
+          - uid: mondoo-windows-security-audit-user-account-management-is-set-to-success-and-failure
       - title: Logging
         filters: |
           asset.family.contains('windows')
@@ -150,11 +154,21 @@ queries:
       secpol.privilegerights['SeDebugPrivilege'] == empty
     docs:
       desc: |
-        This policy setting determines which user accounts will have the right to attach a debugger to any process or to the kernel, which provides complete access to sensitive and critical operating system components. Developers who are debugging their own applications do not need to be assigned this user right; however, developers who are debugging new system components will need it.
+        This check ensures that the 'Debug programs' privilege is not assigned to any user or group. This privilege allows attaching a debugger to any process or the kernel, providing complete access to sensitive and critical operating system components.
 
-        The recommended state for this setting is empty.
+        **Why this matters**
 
-        > Note: This user right is considered a "sensitive privilege" for the purposes of auditing.
+        The 'Debug programs' privilege is highly sensitive and should only be granted in exceptional cases:
+          •	It allows unrestricted access to all processes, including those running as SYSTEM, which can lead to privilege escalation.
+          •	Developers debugging their own applications do not require this privilege; it is only needed for debugging system-level components.
+          •	Assigning this privilege unnecessarily increases the attack surface and violates the principle of least privilege.
+
+        If this privilege is assigned, it can lead to:
+          •	Unauthorized access to critical system processes and data.
+          •	Privilege escalation attacks, where a compromised account can gain full control of the system.
+          •	Non-compliance with security benchmarks such as CIS Windows Benchmarks and NIST 800-53.
+
+        By ensuring that the 'Debug programs' privilege is not assigned, organizations can reduce the risk of privilege escalation, enhance system security, and maintain compliance with security best practices.
       remediation:
         - id: default
           desc: |-
@@ -189,33 +203,40 @@ queries:
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa', name: 'RunAsPPL' ).value == 1
     docs:
       desc: |
-        Local Security Authority (LSA) protection is a security feature in Microsoft Windows operating systems that helps to prevent credential theft and other types of attacks that can compromise system security.
+        This check ensures that additional LSA protection is enabled. This feature restricts access to the Local Security Authority (LSA) subsystem, safeguarding sensitive information such as passwords, user account details, and security tokens.
 
-        The LSA is responsible for enforcing security policies and managing various security-related tasks, such as authentication and authorization, on a local system. It stores sensitive information such as passwords, user account information, and security tokens.
+        **Why this matters**
 
-        LSA protection enhances the security of these sensitive information by restricting access to the LSA subsystem to authorized processes only. It prevents malicious software from accessing or manipulating the LSA, thereby reducing the risk of credential theft and other types of attacks.
+        Enabling LSA protection is critical for maintaining system security:
+          •	It prevents unauthorized processes from accessing or manipulating the LSA, reducing the risk of credential theft.
+          •	It enforces access controls and code integrity checks, ensuring only trusted processes can interact with the LSA subsystem.
+          •	It mitigates the risk of attacks that target sensitive system components.
 
-        LSA protection is implemented through the use of several techniques such as code integrity checks, access controls, and system call filtering. These techniques work together to prevent unauthorized access and ensure that only trusted processes can interact with the LSA subsystem.
+        If LSA protection is not enabled, it can lead to:
+          •	Unauthorized access to sensitive credentials and security tokens.
+          •	Increased vulnerability to credential theft and privilege escalation attacks.
+          •	Non-compliance with security benchmarks such as CIS Windows Benchmarks and NIST 800-53.
 
-        Overall, LSA protection is an important security feature that helps to secure Windows systems and protect against various types of attacks that can compromise system security.
+        By enabling LSA protection, organizations can enhance system security, reduce the attack surface, and protect against credential theft and other security threats.
       remediation:
         - id: default
-          desc: |-
+          desc: |
             #### Using Group Policy
 
-            Enable LSA protection via GPO:
+            To enable LSA protection via Group Policy:
 
-            - Open the Group Policy Management Console (GPMC).
-            - Create a new GPO that is linked at the domain level or that is linked to the organizational unit that contains your computer accounts. Or you can select a GPO that is already deployed.
-            - Right-click the GPO, and then select Edit to open the Group Policy Management Editor.
-            - Expand Computer Configuration, expand Preferences, and then expand Windows Settings.
-            - Right-click Registry, point to New, and then select Registry Item. The New Registry Properties dialog box appears.
-            - In the Hive list, select HKEY_LOCAL_MACHINE.
-            - In the Key Path list, browse to SYSTEM\CurrentControlSet\Control\Lsa.
-            - In the Value name box, type RunAsPPL.
-            - In the Value type box, select the REG_DWORD.
-            - In the Value data box, type 00000001.
-            - Select OK.
+            1. Open the Group Policy Management Console (GPMC).
+            2. Create a new GPO linked at the domain level or to the organizational unit containing your computer accounts, or select an existing GPO.
+            3. Right-click the GPO and select "Edit" to open the Group Policy Management Editor.
+            4. Navigate to `Computer Configuration > Preferences > Windows Settings`.
+            5. Right-click "Registry," point to "New," and select "Registry Item."
+            6. In the "New Registry Properties" dialog:
+                - Set "Hive" to `HKEY_LOCAL_MACHINE`.
+                - Set "Key Path" to `SYSTEM\CurrentControlSet\Control\Lsa`.
+                - Set "Value name" to `RunAsPPL`.
+                - Set "Value type" to `REG_DWORD`.
+                - Set "Value data" to `1`.
+            7. Select "OK" to save the configuration.
         - id: powershell
           desc: |
             #### Using PowerShell
@@ -242,9 +263,21 @@ queries:
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'fPromptForPassword' ).value == 1
     docs:
       desc: |-
-        This policy setting specifies whether Remote Desktop Services always prompts the client computer for a password upon connection. You can use this policy setting to enforce a password prompt for users who log on to Remote Desktop Services, even if they already provided the password in the Remote Desktop Connection client.
+        This check ensures that Remote Desktop Services always prompts the client computer for a password upon connection. This setting enforces a password prompt for users logging on to Remote Desktop Services, even if they have already provided the password in the Remote Desktop Connection client.
 
-        The recommended state for this setting is: `Enabled`.
+        **Why this matters**
+
+        Enforcing a password prompt enhances security by:
+          • Preventing unauthorized access to Remote Desktop Services sessions.
+          • Ensuring that credentials are verified at the time of connection, reducing the risk of credential theft or misuse.
+          • Aligning with security best practices and compliance requirements.
+
+        If this setting is not enabled, it can lead to:
+          • Increased risk of unauthorized access to sensitive systems.
+          • Potential exploitation of saved credentials in the Remote Desktop Connection client.
+          • Non-compliance with security benchmarks such as CIS Windows Benchmarks and NIST 800-53.
+
+        By enabling this setting, organizations can strengthen access controls, reduce the attack surface, and maintain compliance with security standards.
       remediation:
         - id: default
           desc: |-
@@ -292,13 +325,21 @@ queries:
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Application', name: 'Retention' ).value == '0'
     docs:
       desc: |-
-        This policy setting controls Event Log behavior when the log file reaches its maximum size.
+        This check ensures that the 'Control Event Log behavior when the log file reaches its maximum size' policy is set to 'Disabled'. This setting determines how the Event Log behaves when it reaches its maximum size.
 
-        The recommended state for this setting is: `Disabled`.
+        **Why this matters**
 
-        **Note:**
-        Old events may or may not be retained according to the _Backup log automatically when full_
-        policy setting.
+        Proper configuration of Event Log behavior is critical for maintaining system security and ensuring the availability of audit logs:
+          •	When the log file reaches its maximum size, retaining old events or overwriting them can impact the ability to analyze historical data.
+          •	Incorrect configuration may result in the loss of critical security events, hindering forensic investigations.
+          •	Ensuring this setting is disabled aligns with security best practices and compliance requirements.
+
+        If this setting is not configured correctly, it can lead to:
+          •	Loss of important security events due to overwriting or improper retention.
+          •	Non-compliance with security benchmarks such as CIS Windows Benchmarks and NIST 800-53.
+          •	Reduced ability to detect and respond to security incidents effectively.
+
+        By ensuring this policy is set to 'Disabled', organizations can maintain the integrity of their audit logs, enhance security monitoring, and comply with industry standards.
       remediation:
         - id: default
           desc: |-
@@ -346,9 +387,21 @@ queries:
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Application', name: 'MaxSize' ).value >= 32768
     docs:
       desc: |-
-        This policy setting specifies the maximum size of the log file in kilobytes. The maximum log file size can be configured between 1 megabyte (1,024 kilobytes) and 4 terabytes (4,194,240 kilobytes) in kilobyte increments.
+        This check ensures that the maximum size of the log file is configured to at least 32,768 kilobytes. This setting determines the maximum size of the log file in kilobytes, which can range from 1 megabyte (1,024 kilobytes) to 4 terabytes (4,194,240 kilobytes).
 
-        The recommended state for this setting is: `Enabled: 32,768 or greater`.
+        **Why this matters**
+
+        Proper configuration of log file size is critical for maintaining system security and ensuring the availability of audit logs:
+          •	It prevents the loss of critical security events due to insufficient log space.
+          •	It ensures that sufficient historical data is available for forensic investigations and compliance audits.
+          •	It aligns with security best practices and compliance requirements.
+
+        If the log file size is not configured appropriately, it can lead to:
+          •	Loss of important security events due to log overwrites or truncation.
+          •	Non-compliance with security benchmarks such as CIS Windows Benchmarks and NIST 800-53.
+          •	Reduced ability to detect and respond to security incidents effectively.
+
+        By ensuring that the maximum log file size is set to at least 32,768 kilobytes, organizations can maintain the integrity of their audit logs, enhance security monitoring, and comply with industry standards.
       remediation:
         - id: default
           desc: |-
@@ -400,19 +453,24 @@ queries:
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System', name: 'LocalAccountTokenFilterPolicy' ).value == 0
     docs:
       desc: |-
-        This setting controls whether local accounts can be used for remote administration via network logon (e.g., NET USE, connecting to C$, etc.). Local accounts are at high risk for credential theft when the same account and password is configured on multiple systems. Enabling this policy significantly reduces that risk.
+        This check ensures that local accounts are restricted from being used for remote administration via network logon. This setting applies UAC token-filtering to local accounts on network logons, disabling membership in powerful groups such as Administrators and removing powerful privileges from the resulting access token.
 
-        **Enabled:**
-        Applies UAC token-filtering to local accounts on network logons. Membership in powerful group such as Administrators is disabled and powerful privileges are removed from the resulting access token. This configures the `LocalAccountTokenFilterPolicy` registry value to `0`. This is the default behavior for Windows.
+        **Why this matters**
 
-        **Disabled:**
-        Allows local accounts to have full administrative rights when authenticating via network logon, by configuring the `LocalAccountTokenFilterPolicy` registry value to `1`.
+        Allowing local accounts to have full administrative rights during network logons poses significant security risks:
+          •	It increases the risk of credential theft, especially when the same account and password are configured on multiple systems.
+          •	It enables attackers to use compromised local accounts to escalate privileges and gain unauthorized access to sensitive resources.
+          •	It violates the principle of least privilege, exposing systems to potential exploitation.
 
-        For more information about local accounts and credential theft, review the [Mitigating Pass-the-Hash (PtH) Attacks and Other Credential Theft Techniques](https://www.microsoft.com/en-us/download/details.aspx?id=36036) documents.
+        If this setting is disabled, it can lead to:
+          •	Unauthorized access to administrative resources via local accounts.
+          •	Increased vulnerability to Pass-the-Hash (PtH) attacks and other credential theft techniques.
+          •	Non-compliance with security benchmarks such as CIS Windows Benchmarks and NIST 800-53.
 
-        For more information about `LocalAccountTokenFilterPolicy`, see Microsoft Knowledge Base article 951016: [Description of User Account Control and remote restrictions in Windows Vista](https://learn.microsoft.com/en-US/troubleshoot/windows-server/windows-security/user-account-control-and-remote-restriction).
-
-        The recommended state for this setting is: `Enabled`.
+        By enabling this setting, organizations can mitigate the risks associated with local account misuse, enhance system security, and maintain compliance with security best practices.
+      refs:
+        - url: https://www.microsoft.com/en-us/download/details.aspx?id=36036
+          title: Mitigating Pass-the-Hash (PtH) Attacks and Other Credential Theft Techniques
       remediation:
         - id: default
           desc: |-
@@ -485,11 +543,21 @@ queries:
       auditpol.where(subcategoryguid == "0CCE9217-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolFailure || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure1)
     docs:
       desc: |-
-        This subcategory reports when a user's account is locked out as a result of too many failed logon attempts. Events for this subcategory include:
+        This check ensures that account lockout events are audited. This setting tracks when a user's account is locked out due to multiple failed logon attempts, providing visibility into potential unauthorized access attempts.
 
-        - 4625: An account failed to log on.
+        **Why this matters**
 
-        The recommended state for this setting is to include: `Failure`.
+        Auditing account lockout events is essential for maintaining system security:
+          •	It helps identify potential brute force attacks or unauthorized access attempts.
+          •	It provides critical information for forensic investigations and incident response.
+          •	It ensures compliance with security benchmarks such as CIS Windows Benchmarks and NIST 800-53.
+
+        If account lockout events are not audited, it can lead to:
+          •	Undetected unauthorized access attempts or brute force attacks.
+          •	Limited visibility into account-related security incidents.
+          •	Non-compliance with security best practices and regulatory requirements.
+
+        By auditing account lockout events, organizations can enhance security monitoring, detect potential threats, and maintain compliance with industry standards.
       remediation:
         - id: default
           desc: |-
@@ -548,14 +616,25 @@ queries:
       auditpol.where(subcategoryguid == "0CCE9239-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure2)
     docs:
       desc: |-
-        This policy setting allows you to audit events generated by changes to application groups such as the following:
+        This check ensures that changes to application groups are audited, specifically looking for both success and failure events. Application groups are used by Windows Authorization Manager to implement role-based access control (RBAC) in applications.
 
-        - Application group is created, changed, or deleted.
-        - Member is added or removed from an application group.
+        **Why this matters**
 
-        Application groups are utilized by Windows Authorization Manager, which is a flexible framework created by Microsoft for integrating role-based access control (RBAC) into applications. More information on Windows Authorization Manager is available at [MSDN - Windows Authorization Manager](https://msdn.microsoft.com/en-us/library/bb897401.aspx).
+        Auditing both success and failure events for changes to application groups is essential for maintaining system security:
+          •	It helps track the creation, modification, or deletion of application groups, ensuring accountability.
+          •	It provides visibility into membership changes, such as adding or removing members from application groups.
+          •	It ensures that failed attempts to modify application groups are also logged, which can help detect potential unauthorized access attempts.
+          •	It supports compliance with security benchmarks and regulatory requirements.
 
-        The recommended state for this setting is: `Success and Failure`.
+        If changes to application groups are not audited for both success and failure events, it can lead to:
+          •	Undetected unauthorized modifications to application groups.
+          •	Reduced ability to investigate security incidents involving application group misuse.
+          •	Non-compliance with security best practices and standards.
+
+        By auditing both success and failure events for changes to application groups, organizations can enhance security monitoring, maintain accountability, and ensure compliance with industry standards.
+      refs:
+        - url: https://learn.microsoft.com/en-us/windows/win32/secauthz/authorization-manager-model
+          title: Authorization Manager Model
       remediation:
         - id: default
           desc: |-

--- a/core/mondoo-windows-security.mql.yaml
+++ b/core/mondoo-windows-security.mql.yaml
@@ -4281,7 +4281,7 @@ queries:
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'SecurityLayer' ).value == 2
     docs:
       desc: |-
-        This policy setting specifies whether to require the use of a specific security layer to secure communications between clients and RD Session Host servers during Remote Desktop Protocol (RDP) connections.
+        This check ensures that the 'Require use of specific security layer for remote (RDP) connections' setting is configured to 'Enabled: SSL'. This setting enforces the use of Transport Layer Security (TLS) version 1.0 to secure communications between clients and RD Session Host servers during Remote Desktop Protocol (RDP) connections.
 
         The recommended state for this setting is: `Enabled: SSL`.
 
@@ -4336,9 +4336,21 @@ queries:
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'UserAuthentication' ).value == 1
     docs:
       desc: |-
-        This policy setting allows you to specify whether to require user authentication for remote connections to the RD Session Host server by using Network Level Authentication.
+        This check ensures that the 'Require user authentication for remote connections by using Network Level Authentication' setting is configured to 'Enabled'. This setting enforces the use of Network Level Authentication (NLA) for remote connections to the RD Session Host server.
 
-        The recommended state for this setting is: `Enabled`.
+        **Why this matters**
+
+        Enabling NLA for remote connections is critical for the following reasons:
+          •	It ensures that users are authenticated before a remote desktop session is established, reducing the risk of unauthorized access.
+          •	It protects the RD Session Host server from denial-of-service attacks by unauthenticated users.
+          •	It aligns with security best practices and compliance requirements for secure remote access.
+
+        If NLA is not enabled, it can lead to:
+          •	Unauthorized access to the RD Session Host server.
+          •	Increased exposure to brute-force attacks on the RDP login interface.
+          •	Non-compliance with security benchmarks such as CIS Windows Benchmarks and NIST 800-53.
+
+        By ensuring that NLA is enabled, organizations can enhance the security of remote desktop connections, mitigate the risk of unauthorized access, and maintain compliance with security best practices.
       remediation:
         - id: default
           desc: |-
@@ -4388,7 +4400,7 @@ queries:
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Security', name: 'Retention' ).value == '0'
     docs:
       desc: |-
-        This policy setting controls Event Log behavior when the log file reaches its maximum size.
+        This check ensures that the 'Control Event Log behavior when the log file reaches its maximum size' setting is configured to 'Disabled'. This setting determines how the system handles event logs when they reach their maximum size.
 
         The recommended state for this setting is: `Disabled`.
 
@@ -4494,9 +4506,21 @@ queries:
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'MinEncryptionLevel' ).value == 3
     docs:
       desc: |-
-        This policy setting specifies whether to require the use of a specific encryption level to secure communications between client computers and RD Session Host servers during Remote Desktop Protocol (RDP) connections. This policy only applies when you are using native RDP encryption. However, native RDP encryption (as opposed to SSL encryption) is not recommended. This policy does not apply to SSL encryption.
+        This check ensures that the 'Set client connection encryption level' setting is configured to 'Enabled: High Level'. This setting ensures that communications between client computers and RD Session Host servers during Remote Desktop Protocol (RDP) connections are secured using a high encryption level.
 
-        The recommended state for this setting is: `Enabled: High Level`.
+        **Why this matters**
+
+        Configuring a high encryption level for RDP connections is important for the following reasons:
+          •	It ensures that data transmitted during RDP sessions is encrypted, protecting it from interception and unauthorized access.
+          •	It aligns with security best practices and compliance requirements for secure remote access.
+          •	It reduces the risk of sensitive information being exposed during remote sessions.
+
+        If a high encryption level is not enforced, it can lead to:
+          •	Interception of sensitive data during RDP sessions.
+          •	Unauthorized access to remote systems.
+          •	Non-compliance with security benchmarks such as CIS Windows Benchmarks and NIST 800-53.
+
+        By ensuring that the 'Set client connection encryption level' is configured to 'Enabled: High Level', organizations can enhance the security of remote connections, protect sensitive data, and maintain compliance with security best practices.
       remediation:
         - id: default
           desc: |-
@@ -4547,9 +4571,21 @@ queries:
       registrykey.property(path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'MaxIdleTime').value != 0
     docs:
       desc: |-
-        This policy setting allows you to specify the maximum amount of time that an active Remote Desktop Services session can be idle (without user input) before it is automatically disconnected.
+        This check ensures that the 'Set time limit for active but idle Remote Desktop Services sessions' setting is configured to 'Enabled: 15 minutes or less, but not Never (0)'. This setting ensures that idle Remote Desktop sessions are automatically disconnected after a specified period of inactivity.
 
-        The recommended state for this setting is: `Enabled: 15 minutes or less, but not Never (0)`.
+        **Why this matters**
+
+        Configuring a time limit for idle Remote Desktop sessions is important for the following reasons:
+          •	It prevents idle sessions from consuming system resources indefinitely.
+          •	It reduces the risk of unauthorized access to unattended sessions.
+          •	It aligns with security best practices and compliance requirements.
+
+        If idle sessions are not disconnected promptly, it can lead to:
+          •	Excessive resource consumption, impacting system performance.
+          •	Increased risk of unauthorized access to idle sessions.
+          •	Non-compliance with security benchmarks such as CIS Windows Benchmarks and NIST 800-53.
+
+        By ensuring that idle sessions are disconnected after 15 minutes or less, organizations can enhance system performance, improve security, and maintain compliance with security best practices.
       remediation:
         - id: default
           desc: |-
@@ -4596,9 +4632,21 @@ queries:
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'MaxDisconnectionTime' ).value == 60000
     docs:
       desc: |-
-        This policy setting allows you to configure a time limit for disconnected Remote Desktop Services sessions.
+        This check ensures that a time limit of 1 minute is configured for disconnected Remote Desktop Services sessions. This setting ensures that disconnected sessions are promptly terminated, freeing up system resources and reducing potential security risks.
 
-        The recommended state for this setting is: `Enabled: 1 minute`.
+        **Why this matters**
+
+        Configuring a time limit for disconnected sessions is important for the following reasons:
+          •	It prevents disconnected sessions from consuming system resources indefinitely.
+          •	It reduces the risk of unauthorized access to idle sessions.
+          •	It aligns with security best practices and compliance requirements.
+
+        If disconnected sessions are not terminated promptly, it can lead to:
+          •	Excessive resource consumption, impacting system performance.
+          •	Increased risk of unauthorized access to unattended sessions.
+          •	Non-compliance with security benchmarks such as CIS Windows Benchmarks and NIST 800-53.
+
+        By ensuring that disconnected sessions are terminated after 1 minute, organizations can enhance system performance, improve security, and maintain compliance with security best practices.
       remediation:
         - id: default
           desc: |-
@@ -4642,7 +4690,7 @@ queries:
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Setup', name: 'Retention' ).value == '0'
     docs:
       desc: |-
-        This policy setting controls Event Log behavior when the log file reaches its maximum size.
+        This check ensures that the 'Setup: Control Event Log behavior when the log file reaches its maximum size' setting is configured to 'Disabled'. This setting determines how the system handles event logs when they reach their maximum size.
 
         The recommended state for this setting is: `Disabled`.
 
@@ -4795,7 +4843,7 @@ queries:
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\System', name: 'Retention' ).value == '0'
     docs:
       desc: |-
-        This policy setting controls Event Log behavior when the log file reaches its maximum size.
+        This check ensures that the 'System: Control Event Log behavior when the log file reaches its maximum size' setting is configured to 'Disabled'. This setting determines how the system handles event logs when they reach their maximum size.
 
         The recommended state for this setting is: `Disabled`.
 
@@ -4847,9 +4895,21 @@ queries:
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\System', name: 'MaxSize' ).value >= 32768
     docs:
       desc: |-
-        This policy setting specifies the maximum size of the log file in kilobytes. The maximum log file size can be configured between 1 megabyte (1,024 kilobytes) and 4 terabytes (4,194,240 kilobytes) in kilobyte increments.
+        This check ensures that the maximum size of the 'System' event log file is configured to at least 32,768 kilobytes. This setting ensures sufficient space for logging critical system events without frequent overwrites.
 
-        The recommended state for this setting is: `Enabled: 32,768 or greater`.
+        **Why this matters**
+
+        Configuring an adequate maximum log file size is essential for the following reasons:
+          •	It ensures that critical system events are retained for a longer period, aiding in troubleshooting and forensic analysis.
+          •	Prevents frequent overwriting of logs, which can lead to the loss of important event data.
+          •	Aligns with security benchmarks and best practices for event log management.
+
+        If the maximum log file size is set too low, it can lead to:
+          •	Loss of critical event data due to frequent overwrites.
+          •	Difficulty in diagnosing system issues or investigating security incidents.
+          •	Non-compliance with security benchmarks such as CIS Windows Benchmarks and NIST 800-53.
+
+        By ensuring that the maximum log file size is set to 32,768 kilobytes or greater, organizations can enhance event log retention, improve system monitoring, and maintain compliance with security best practices.
       remediation:
         - id: default
           desc: |-
@@ -4899,10 +4959,22 @@ queries:
     mql: |
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient', name: 'EnableMulticast' ).value == 0
     docs:
-      desc: |-
-        LLMNR is a secondary name resolution protocol. With LLMNR, queries are sent using multicast over a local network link on a single subnet from a client computer to another client computer on the same subnet that also has LLMNR enabled. LLMNR does not require a DNS server or DNS client configuration, and provides name resolution in scenarios in which conventional DNS name resolution is not possible.
+      desc: |
+        This check ensures that the 'Turn off multicast name resolution' setting is enabled. This setting disables the Link-Local Multicast Name Resolution (LLMNR) protocol, which is used for name resolution on local networks.
 
-        The recommended state for this setting is: `Enabled`
+        **Why this matters**
+
+        Disabling LLMNR is important for the following reasons:
+          •	It prevents attackers from exploiting LLMNR to perform man-in-the-middle (MITM) attacks or capture sensitive information.
+          •	LLMNR is often unnecessary in environments where DNS is properly configured, and its use can introduce security vulnerabilities.
+          •	Disabling LLMNR reduces the attack surface and aligns with security best practices.
+
+        If LLMNR is enabled, it can lead to:
+          •	Unauthorized interception of network traffic and sensitive data.
+          •	Exploitation of name resolution vulnerabilities by attackers.
+          •	Non-compliance with security benchmarks such as CIS Windows Benchmarks and NIST 800-53.
+
+        By ensuring that LLMNR is disabled, organizations can enhance network security, mitigate the risk of MITM attacks, and maintain compliance with security best practices.
       remediation:
         - id: default
           desc: |-

--- a/core/mondoo-windows-security.mql.yaml
+++ b/core/mondoo-windows-security.mql.yaml
@@ -31,7 +31,7 @@ policies:
 
         ### Prerequisites
 
-        Remote scans of Windows hosts require an authentication method such as winRM or SSH keys.
+        Remote scans of Windows hosts require an authentication method such as WinRM or SSH keys.
 
         ### Scan a remote Windows device (SSH authentication)
 
@@ -144,7 +144,7 @@ policies:
           - uid: mondoo-windows-security-2.2.19-l1-ensure-debug-programs-is-empty
 queries:
   - uid: mondoo-windows-security-2.2.19-l1-ensure-debug-programs-is-empty
-    title: Ensure 'Debug programs' is set to ''
+    title: Ensure 'Debug programs' is not set
     impact: 100
     mql: |
       secpol.privilegerights['SeDebugPrivilege'] == empty
@@ -158,7 +158,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to "":
 
@@ -167,7 +167,7 @@ queries:
             ```
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -201,24 +201,24 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             Enable LSA protection via GPO:
 
-              - Open the Group Policy Management Console (GPMC).
-              - Create a new GPO that is linked at the domain level or that is linked to the organizational unit that contains your computer accounts. Or you can select a GPO that is already deployed.
-              - Right-click the GPO, and then select Edit to open the Group Policy Management Editor.
-              - Expand Computer Configuration, expand Preferences, and then expand Windows Settings.
-              - Right-click Registry, point to New, and then select Registry Item. The New Registry Properties dialog box appears.
-              - In the Hive list, select HKEY_LOCAL_MACHINE.
-              - In the Key Path list, browse to SYSTEM\CurrentControlSet\Control\Lsa.
-              - In the Value name box, type RunAsPPL.
-              - In the Value type box, select the REG_DWORD.
-              - In the Value data box, type 00000001.
-              - Select OK.
+            - Open the Group Policy Management Console (GPMC).
+            - Create a new GPO that is linked at the domain level or that is linked to the organizational unit that contains your computer accounts. Or you can select a GPO that is already deployed.
+            - Right-click the GPO, and then select Edit to open the Group Policy Management Editor.
+            - Expand Computer Configuration, expand Preferences, and then expand Windows Settings.
+            - Right-click Registry, point to New, and then select Registry Item. The New Registry Properties dialog box appears.
+            - In the Hive list, select HKEY_LOCAL_MACHINE.
+            - In the Key Path list, browse to SYSTEM\CurrentControlSet\Control\Lsa.
+            - In the Value name box, type RunAsPPL.
+            - In the Value type box, select the REG_DWORD.
+            - In the Value data box, type 00000001.
+            - Select OK.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -248,7 +248,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -268,7 +268,7 @@ queries:
             Users cannot automatically log on to Remote Desktop Services by supplying their passwords in the Remote Desktop Connection client. They will be prompted for a password to log on.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -302,7 +302,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Disabled`:
 
@@ -322,7 +322,7 @@ queries:
             None - this is the default behavior.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -352,7 +352,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled: 32,768 or greater`:
 
@@ -376,7 +376,7 @@ queries:
             Ideally, all specifically monitored events should be sent to a server that uses Microsoft System Center Operations Manager (SCOM) or some other automated monitoring tool. Such a configuration is particularly important because an attacker who successfully compromises a server could clear the Security log. If all events are sent to a monitoring server, then you will be able to gather forensic information about the attacker's activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -408,8 +408,7 @@ queries:
         **Disabled:**
         Allows local accounts to have full administrative rights when authenticating via network logon, by configuring the `LocalAccountTokenFilterPolicy` registry value to `1`.
 
-        For more information about local accounts and credential theft, review the " [Mitigating Pass-the-Hash (PtH) Attacks and Other Credential Theft Techniques](https://www.microsoft.com/en-us/download/details.aspx?id=36036)
-        " documents.
+        For more information about local accounts and credential theft, review the [Mitigating Pass-the-Hash (PtH) Attacks and Other Credential Theft Techniques](https://www.microsoft.com/en-us/download/details.aspx?id=36036) documents.
 
         For more information about `LocalAccountTokenFilterPolicy`, see Microsoft Knowledge Base article 951016: [Description of User Account Control and remote restrictions in Windows Vista](https://learn.microsoft.com/en-US/troubleshoot/windows-server/windows-security/user-account-control-and-remote-restriction).
 
@@ -417,7 +416,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -434,7 +433,7 @@ queries:
             None - this is the default behavior.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -494,7 +493,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Failure`:
 
@@ -507,7 +506,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -560,7 +559,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Success and Failure`:
 
@@ -573,7 +572,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -640,7 +639,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Success`:
 
@@ -653,7 +652,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -713,7 +712,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Success`:
 
@@ -726,7 +725,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -780,7 +779,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Success`:
 
@@ -793,7 +792,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -846,7 +845,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Success and Failure`:
 
@@ -859,7 +858,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -909,7 +908,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Failure`:
 
@@ -922,7 +921,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -973,7 +972,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Success and Failure`:
 
@@ -986,7 +985,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1011,7 +1010,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -1024,7 +1023,7 @@ queries:
             None - this is the default behavior.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1085,7 +1084,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Success`:
 
@@ -1098,7 +1097,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1158,7 +1157,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Success and Failure`:
 
@@ -1171,7 +1170,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1222,7 +1221,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Success`:
 
@@ -1235,7 +1234,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1288,7 +1287,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Success and Failure`:
 
@@ -1301,7 +1300,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1365,7 +1364,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Success and Failure`:
 
@@ -1378,7 +1377,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1437,7 +1436,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Success and Failure`:
 
@@ -1450,7 +1449,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1512,7 +1511,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Success and Failure`:
 
@@ -1525,7 +1524,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1583,7 +1582,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Failure`:
 
@@ -1596,7 +1595,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1658,7 +1657,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Success and Failure`:
 
@@ -1671,7 +1670,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1722,7 +1721,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Success`:
 
@@ -1735,7 +1734,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1789,7 +1788,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Success`:
 
@@ -1802,7 +1801,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1853,7 +1852,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Success and Failure`:
 
@@ -1866,7 +1865,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1931,7 +1930,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Success:`
 
@@ -1944,7 +1943,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -1997,7 +1996,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Success`:
 
@@ -2010,7 +2009,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2064,7 +2063,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Success`:
 
@@ -2077,7 +2076,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2145,7 +2144,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Success and Failure`:
 
@@ -2158,7 +2157,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2180,7 +2179,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Disabled`:
 
@@ -2193,7 +2192,7 @@ queries:
             None - this is the default behavior.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2253,7 +2252,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to include `Success`:
 
@@ -2266,7 +2265,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2325,7 +2324,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Success and Failure:`
 
@@ -2338,7 +2337,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2403,7 +2402,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Success and Failure`:
 
@@ -2416,7 +2415,7 @@ queries:
             If no audit settings are configured, or if audit settings are too lax on the computers in your organization, security incidents might not be detected or not enough evidence will be available for network forensic analysis after security incidents occur. However, if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected. Companies that operate in certain regulated industries may have legal obligations to log certain events or activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2439,7 +2438,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled: Disable driver (recommended)`:
 
@@ -2455,7 +2454,7 @@ queries:
             Some legacy OSes (e.g. Windows XP, Server 2003 or older), applications and appliances may no longer be able to communicate with the system once SMBv1 is disabled. We recommend careful testing be performed to determine the impact prior to configuring this as a widespread control, and where possible, remediate any incompatibilities found with the vendor of the incompatible system. Microsoft is also maintaining a thorough (although not comprehensive) list of known SMBv1 incompatibilities at this link: [SMB1 Product Clearinghouse \| Storage at Microsoft](https://blogs.technet.microsoft.com/filecab/2017/06/01/smb1-product-clearinghouse/)
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2485,7 +2484,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Disabled`:
 
@@ -2501,7 +2500,7 @@ queries:
             Some legacy OSes (e.g. Windows XP, Server 2003 or older), applications and appliances may no longer be able to communicate with the system once SMBv1 is disabled. We recommend careful testing be performed to determine the impact prior to configuring this as a widespread control, and where possible, remediate any incompatibilities found with the vendor of the incompatible system. Microsoft is also maintaining a thorough (although not comprehensive) list of known SMBv1 incompatibilities at this link: [SMB1 Product Clearinghouse \| Storage at Microsoft](https://blogs.technet.microsoft.com/filecab/2017/06/01/smb1-product-clearinghouse/)
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2531,7 +2530,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -2548,7 +2547,7 @@ queries:
             Users in a Remote Desktop Services session will not be able to redirect server data to local (client) COM ports.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2583,7 +2582,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -2600,7 +2599,7 @@ queries:
             Drive redirection will not be possible. In most situations, traditional network drive mapping to file shares (including administrative shares) performed manually by the connected user will serve as a capable substitute to still allow file transfers when needed.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2630,7 +2629,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -2647,7 +2646,7 @@ queries:
             Users in a Remote Desktop Services session will not be able to redirect server data to local (client) LPT ports.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2680,7 +2679,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -2697,7 +2696,7 @@ queries:
             The password saving checkbox will be disabled for Remote Desktop clients and users will not be able to save passwords.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2727,7 +2726,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -2744,7 +2743,7 @@ queries:
             Users in a Remote Desktop Services session will not be able to redirect their supported (local client) Plug and Play devices to the remote computer.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2774,7 +2773,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Disabled`:
 
@@ -2794,7 +2793,7 @@ queries:
             None - this is the default behavior.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2824,7 +2823,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -2842,7 +2841,7 @@ queries:
             After you enable SEHOP, existing versions of Cygwin, Skype, and Armadillo-protected applications may not work correctly.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2881,7 +2880,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `24 or more password(s)`:
 
@@ -2894,7 +2893,7 @@ queries:
             The major impact of this configuration is that users must create a new password every time they are required to change their old one. If users are required to change their passwords to new unique values, there is an increased risk of users who write their passwords somewhere so that they do not forget them. Another risk is that users may create passwords that change incrementally (for example, password01, password02, and so on) to facilitate memorization but make them easier to guess. Also, an excessively low value for the Minimum password age setting will likely increase administrative overhead, because users who forget their passwords might ask the help desk to reset them frequently.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2933,7 +2932,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `365 or fewer days, but not 0`:
 
@@ -2946,7 +2945,7 @@ queries:
             If the Maximum password age setting is too low, users are required to change their passwords very often. Such a configuration can reduce security in the organization, because users might write their passwords in an insecure location or lose them. If the value for this policy setting is too high, the level of security within an organization is reduced because it allows potential attackers more time in which to discover user passwords or to use compromised accounts.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -2981,7 +2980,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `1 or more day(s)`:
 
@@ -2994,7 +2993,7 @@ queries:
             If an administrator sets a password for a user but wants that user to change the password when the user first logs on, the administrator must select the User must change password at next logon check box, or the user will not be able to change the password until the next day.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3037,7 +3036,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `14 or more character(s)`:
 
@@ -3053,7 +3052,7 @@ queries:
             Older versions of Windows such as Windows 98 and Windows NT 4.0 do not support passwords that are longer than 14 characters. Computers that run these older operating systems are unable to authenticate with computers or domains that use accounts that require long passwords.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3092,7 +3091,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled: P-node (recommended)`:
 
@@ -3114,7 +3113,7 @@ queries:
             NetBIOS name resolution queries will require a defined and available WINS server for external NetBIOS name resolution. If a WINS server is not defined or not reachable, and the desired hostname is not defined in the local cache, local LMHOSTS or HOSTS files, NetBIOS name resolution will fail.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3144,7 +3143,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Disabled`:
 
@@ -3157,7 +3156,7 @@ queries:
             None - this is the default behavior.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3188,7 +3187,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -3201,7 +3200,7 @@ queries:
             None - this is the default behavior. It will be impossible to establish trusts with Windows NT 4.0-based domains. Also, client computers that run older versions of the Windows operating system such as Windows NT 3.51 and Windows 95 will experience problems when they try to use resources on the server.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3234,7 +3233,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -3247,7 +3246,7 @@ queries:
             It will be impossible to establish trusts with Windows NT 4.0-based domains. Also, client computers that run older versions of the Windows operating system such as Windows NT 3.51 and Windows 95 will experience problems when they try to use resources on the server. Users who access file and print servers anonymously will be unable to list the shared network resources on those servers; the users will have to authenticate before they can view the lists of shared folders and printers. However, even with this policy setting enabled, anonymous users will have access to resources with permissions that explicitly include the built-in group, `ANONYMOUS LOGON`.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3280,7 +3279,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -3293,7 +3292,7 @@ queries:
             Credential Manager will not store passwords and credentials on the computer. Users will be forced to enter passwords whenever they log on to their Passport account or other network resources that aren't accessible to their domain account. Testing has shown that clients running Windows Vista or Windows Server 2008 will be unable to connect to Distributed File System (DFS) shares in untrusted domains. Enabling this setting also makes it impossible to specify alternate credentials for scheduled tasks, this can cause a variety of problems. For example, some third party backup products will no longer work. This policy setting should have no impact on users who access network resources that are configured to allow access with their Active Directory-based domain account.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3323,7 +3322,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Disabled`:
 
@@ -3336,7 +3335,7 @@ queries:
             None - this is the default behavior.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3367,7 +3366,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `<blank>` (i.e. None):
 
@@ -3380,7 +3379,7 @@ queries:
             This configuration will disable null session access over named pipes, and applications that rely on this feature or on unauthenticated access to named pipes will no longer function.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3416,7 +3415,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -3442,7 +3441,7 @@ queries:
             Previous to the release of Windows Server 2003 with Service Pack 1 (SP1) these named pipes were allowed anonymous access by default, but with the increased hardening in Windows Server 2003 with SP1 these pipes must be explicitly added if needed.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3478,7 +3477,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Administrators: Remote Access: Allow`:
 
@@ -3491,7 +3490,7 @@ queries:
             None - this is the default behavior.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3521,7 +3520,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `<blank>` (i.e. None):
 
@@ -3534,7 +3533,7 @@ queries:
             None - this is the default behavior.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3567,7 +3566,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Classic - local users authenticate as themselves`:
 
@@ -3580,7 +3579,7 @@ queries:
             None - this is the default configuration for domain-joined computers.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3610,7 +3609,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -3623,7 +3622,7 @@ queries:
             Services running as Local System that use Negotiate when reverting to NTLM authentication will use the computer identity. This might cause some authentication requests between Windows operating systems to fail and log an error.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3653,7 +3652,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Disabled`:
 
@@ -3666,7 +3665,7 @@ queries:
             None - this is the default behavior. Any applications that require NULL sessions for LocalSystem will not work as designed.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3703,7 +3702,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Disabled`:
 
@@ -3716,7 +3715,7 @@ queries:
             None - this is the default configuration for domain-joined computers.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3750,7 +3749,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `AES128_HMAC_SHA1, AES256_HMAC_SHA1, Future encryption types`:
 
@@ -3778,7 +3777,7 @@ queries:
             [Azure Files on-premises AD DS Authentication support for AES 256 Kerberos encryption \| Microsoft Docs](https://learn.microsoftcom/en-us/azure/storage/files/storage-troubleshoot-windows-file-connection-problems#azure-files-on-premises-ad-ds-authentication-support-for-aes-256-kerberos-encryption)
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3811,7 +3810,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -3824,7 +3823,7 @@ queries:
             None - this is the default behavior. Earlier operating systems such as Windows 95, Windows 98, and Windows ME as well as some third-party applications will fail.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3862,7 +3861,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to: `Send NTLMv2 response only. Refuse LM & NTLM`:
 
@@ -3875,7 +3874,7 @@ queries:
             Clients use NTLMv2 authentication only and use NTLMv2 session security if the server supports it; Domain Controllers refuse LM and NTLM (accept only NTLMv2 authentication). Clients that do not support NTLMv2 authentication will not be able to authenticate in the domain and access domain resources by using LM and NTLM.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3909,7 +3908,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Negotiate signing` (configuring to `Require signing`
             also conforms to the benchmark):
@@ -3925,7 +3924,7 @@ queries:
             Group Policy, and logon scripts, because the caller will be told that the LDAP BIND command request failed.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -3959,7 +3958,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Require NTLMv2 session security, Require 128-bit encryption`:
 
@@ -3973,7 +3972,7 @@ queries:
             negotiated. Server applications that are enforcing these settings will be unable to communicate with older servers that do not support them.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4007,7 +4006,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Require NTLMv2 session security, Require 128-bit encryption`:
 
@@ -4021,7 +4020,7 @@ queries:
             negotiated. Client applications that are enforcing these settings will be unable to communicate with older servers that do not support them.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4071,7 +4070,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -4088,7 +4087,7 @@ queries:
             Also, the use of ALT key character combinations can greatly enhance the complexity of a password. However, such stringent password requirements can result in unhappy users and an extremely busy help desk. Alternatively, your organization could consider a requirement for all administrator passwords to use ALT characters in the 0128 - 0159 range. (ALT characters outside of this range can represent standard alphanumeric characters that would not add additional complexity to the password.)
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4120,7 +4119,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -4140,7 +4139,7 @@ queries:
             If very long passwords are required, mistyped passwords could cause account lockouts and increase the volume of help desk calls. If your organization has issues with forgotten passwords due to password length requirements, consider teaching your users about passphrases, which are often easier to remember and, due to the larger number of character combinations, much harder to discover.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4172,7 +4171,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -4189,7 +4188,7 @@ queries:
             Remote Desktop Services accepts requests from RPC clients that support secure requests, and does not allow unsecured communication with untrusted clients.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4222,7 +4221,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled: SSL`:
 
@@ -4245,7 +4244,7 @@ queries:
             Some third party two-factor authentication solutions (e.g. RSA Authentication Agent) can be negatively affected by this setting, as the SSL/TLS security layer will expect the user's Windows password upon initial connection attempt (before the RDP logon screen), and once successfully authenticated, pass the credential along to that Windows session on the RDP host (to complete the login). If a two-factor agent is present and expecting a different credential at the RDP logon screen, this initial connection may result in a failed logon attempt, and also effectively cause a “double logon” requirement for each and every new RDP session.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4275,7 +4274,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -4298,7 +4297,7 @@ queries:
             Some third party two-factor authentication solutions (e.g. RSA Authentication Agent) can be negatively affected by this setting, as Network Level Authentication will expect the user's Windows password upon initial connection attempt (before the RDP logon screen), and once successfully authenticated, pass the credential along to that Windows session on the RDP host (to complete the login). If a two-factor agent is present and expecting a different credential at the RDP logon screen, this initial connection may result in a failed logon attempt, and also effectively cause a “double logon” requirement for each and every new RDP session.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4332,7 +4331,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Disabled`:
 
@@ -4351,7 +4350,7 @@ queries:
             None - this is the default behavior.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4381,7 +4380,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled: 196,608 or greater`:
 
@@ -4405,7 +4404,7 @@ queries:
             Ideally, all specifically monitored events should be sent to a server that uses Microsoft System Center Operations Manager (SCOM) or some other automated monitoring tool. Such a configuration is particularly important because an attacker who successfully compromises a server could clear the Security log. If all events are sent to a monitoring server, then you will be able to gather forensic information about the attacker's activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4435,7 +4434,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled: High Level`:
 
@@ -4452,7 +4451,7 @@ queries:
             None - this is the default behavior.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4489,7 +4488,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled:``15 minutes or less, but not Never (0)`:
 
@@ -4509,7 +4508,7 @@ queries:
             Remote Desktop Services will automatically disconnect active but idle sessions after 15 minutes (or the specified amount of time). The user receives a warning two minutes before the session disconnects, which allows the user to press a key or move the mouse to keep the session active. Note that idle session time limits do not apply to console sessions.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4539,7 +4538,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled: 1 minute`:
 
@@ -4556,7 +4555,7 @@ queries:
             Disconnected Remote Desktop sessions are deleted from the server after 1 minute. Note that disconnected session time limits do not apply to console sessions.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4590,7 +4589,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Disabled`:
 
@@ -4610,7 +4609,7 @@ queries:
             None - this is the default behavior.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4640,7 +4639,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled: 32,768 or greater`:
 
@@ -4664,7 +4663,7 @@ queries:
             Ideally, all specifically monitored events should be sent to a server that uses Microsoft System Center Operations Manager (SCOM) or some other automated monitoring tool. Such a configuration is particularly important because an attacker who successfully compromises a server could clear the Security log. If all events are sent to a monitoring server, then you will be able to gather forensic information about the attacker's activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4700,7 +4699,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Disabled`:
 
@@ -4713,7 +4712,7 @@ queries:
             If your organization uses either the CHAP authentication protocol through remote access or IAS services or Digest Authentication in IIS, you must configure this policy setting to Enabled. This setting is extremely dangerous to apply through Group Policy on a user-by-user basis, because it requires the appropriate user account object to be opened in Active Directory Users and Computers.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4745,7 +4744,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Disabled`:
 
@@ -4765,7 +4764,7 @@ queries:
             None - this is the default behavior.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4795,7 +4794,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled: 32,768 or greater`:
 
@@ -4819,7 +4818,7 @@ queries:
             Ideally, all specifically monitored events should be sent to a server that uses Microsoft System Center Operations Manager (SCOM) or some other automated monitoring tool. Such a configuration is particularly important because an attacker who successfully compromises a server could clear the Security log. If all events are sent to a monitoring server, then you will be able to gather forensic information about the attacker's activities.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4849,7 +4848,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Enabled`:
 
@@ -4866,7 +4865,7 @@ queries:
             In the event DNS is unavailable a system will be unable to request it from other systems on the same subnet.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
@@ -4900,7 +4899,7 @@ queries:
       remediation:
         - id: default
           desc: |-
-            #### Group Policy Approach
+            #### Using Group Policy
 
             To establish the recommended configuration via GP, set the following UI path to `Disabled`:
 
@@ -4916,7 +4915,7 @@ queries:
             None - this is also the default configuration for Windows 8.1 and newer.
         - id: powershell
           desc: |
-            #### PowerShell Approach
+            #### Using PowerShell
 
             To establish the recommended configuration via PowerShell, run the following commands:
 

--- a/core/mondoo-windows-security.mql.yaml
+++ b/core/mondoo-windows-security.mql.yaml
@@ -290,8 +290,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Note #2:**
             In the Microsoft Windows Vista Administrative Templates, this setting was named _Always prompt client for password upon connection_, but it was renamed starting with the Windows Server 2008 (non-R2) Administrative Templates.
@@ -352,8 +351,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Note #2:**
             In older Microsoft Windows Administrative Templates, this setting was initially named _Retain old events_, but it was renamed starting with the Windows 8.0 & Server 2012 (non-R2) Administrative Templates.
@@ -414,8 +412,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Note #2:**
             In older Microsoft Windows Administrative Templates, this setting was initially named _Maximum Log Size (KB)_, but it was renamed starting with the Windows 8.0 & Server 2012 (non-R2) Administrative Templates.
@@ -2618,8 +2615,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Impact:**
 
@@ -2670,8 +2666,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Impact:**
 
@@ -2717,8 +2712,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Impact:**
 
@@ -2767,8 +2761,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Impact:**
 
@@ -2814,8 +2807,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Impact:**
 
@@ -2861,8 +2853,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Note #2:**
             In older Microsoft Windows Administrative Templates, this setting was named _Do not delete temp folder upon exit_, but it was renamed starting with the Windows 8.0 & Server 2012 (non-R2) Administrative Templates.
@@ -4259,8 +4250,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Impact:**
 
@@ -4309,8 +4299,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Impact:**
 
@@ -4362,8 +4351,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Note #2:**
             In the Microsoft Windows Vista Administrative Templates, this setting was initially named _Require user authentication using RDP 6.0 for remote connections_, but it was renamed starting with the Windows Server 2008 (non-R2) Administrative Templates.
@@ -4468,8 +4456,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Note #2:**
             In older Microsoft Windows Administrative Templates, this setting was initially named _Maximum Log Size (KB)_, but it was renamed starting with the Windows 8.0 & Server 2012 (non-R2) Administrative Templates.
@@ -4522,8 +4509,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Impact:**
 
@@ -4576,8 +4562,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Note #2:**
             In older Microsoft Windows Administrative Templates, this setting was named _Set time limit for active but idle Terminal Services sessions_, but it was renamed starting with the Windows 7 & Server 2008 R2 Administrative Templates.
@@ -4626,8 +4611,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `TerminalServer.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Impact:**
 
@@ -4677,8 +4661,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Note #2:**
             In older Microsoft Windows Administrative Templates, this setting was initially named _Retain old events_, but it was renamed starting with the Windows 8.0 & Server 2012 (non-R2) Administrative Templates.
@@ -4727,8 +4710,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Note #2:**
             In older Microsoft Windows Administrative Templates, this setting was initially named _Maximum Log Size (KB)_, but it was renamed starting with the Windows 8.0 & Server 2012 (non-R2) Administrative Templates.
@@ -4818,8 +4800,7 @@ queries:
         The recommended state for this setting is: `Disabled`.
 
         **Note:**
-        Old events may or may not be retained according to the _Backup log automatically when full_
-        policy setting.
+        Old events may or may not be retained according to the _Backup log automatically when full_ policy setting.
       remediation:
         - id: default
           desc: |-
@@ -4832,8 +4813,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Note #2:**
             In older Microsoft Windows Administrative Templates, this setting was initially named _Retain old events_, but it was renamed starting with the Windows 8.0 & Server 2012 (non-R2) Administrative Templates.
@@ -4882,8 +4862,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml`
-            that is included with all versions of the Microsoft Windows Administrative Templates.
+            This Group Policy path is provided by the Group Policy template `EventLog.admx/adml` that is included with all versions of the Microsoft Windows Administrative Templates.
 
             **Note #2:**
             In older Microsoft Windows Administrative Templates, this setting was initially named _Maximum Log Size (KB)_, but it was renamed starting with the Windows 8.0 & Server 2012 (non-R2) Administrative Templates.
@@ -4970,7 +4949,7 @@ queries:
       desc: |-
         When WDigest authentication is enabled, Lsass.exe retains a copy of the user's plaintext password in memory, where it can be at risk of theft. If this setting is not configured, WDigest authentication is disabled in Windows 8.1 and in Windows Server 2012 R2; it is enabled by default in earlier versions of Windows and Windows Server.
 
-        For more information about local accounts and credential theft, review the " [Mitigating Pass-the-Hash (PtH) Attacks and Other Credential Theft Techniques](https://www.microsoft.com/en-us/download/details.aspx?id=36036)" documents.
+        For more information about local accounts and credential theft, review the [Mitigating Pass-the-Hash (PtH) Attacks and Other Credential Theft Techniques](https://www.microsoft.com/en-us/download/details.aspx?id=36036).
 
         For more information about `UseLogonCredential`, see Microsoft Knowledge Base article 2871997: [Microsoft Security Advisory Update to improve credentials protection and management May 13, 2014](https://support.microsoft.com/en-us/topic/microsoft-security-advisory-update-to-improve-credentials-protection-and-management-may-13-2014-93434251-04ac-b7f3-52aa-9f951c14b649)
 


### PR DESCRIPTION
- Spell WinRM correctly
- Use the same format for remediation headings we use elsewhere
- Rename a confusing check name that does not render correctly in the console