### PR TITLE
Add descriptions to MS365 policy and remove references to Office 365

### DIFF
--- a/core/mondoo-dns-security.mql.yaml
+++ b/core/mondoo-dns-security.mql.yaml
@@ -38,7 +38,7 @@ policies:
           - uid: mondoo-dns-security-google-workspaces-mx-records
           - uid: mondoo-dns-security-no-cname-for-root-domain
           - uid: mondoo-dns-security-no-ip-for-ns-mx-records
-          - uid: mondoo-dns-security-no-legacy-office-365-mx-records
+          - uid: mondoo-dns-security-no-legacy-ms-365-mx-records
           - uid: mondoo-dns-security-dnssec-enabled
           - uid: mondoo-dns-security-no-wildcard
 queries:

--- a/core/mondoo-dns-security.mql.yaml
+++ b/core/mondoo-dns-security.mql.yaml
@@ -100,8 +100,8 @@ queries:
           2. Update the MX records in your DNS settings to point to these FQDNs, ensuring the correct priority values are set.
           3. Remove any MX records pointing to IP addresses or outdated servers to avoid misrouting or security risks.
           4. Test the configuration by sending and receiving emails to confirm proper functionality.
-  - uid: mondoo-dns-security-no-legacy-office-365-mx-records
-    title: Ensure legacy MX records are not used with Office 365
+  - uid: mondoo-dns-security-no-legacy-ms-365-mx-records
+    title: Ensure legacy MX records are not used with Microsoft 365
     impact: 80
     mql: |
       dns.mx.all( domainName.downcase != "mail.outlook.com." )
@@ -110,7 +110,7 @@ queries:
       dns.mx.all( domainName.downcase != "mail.global.bigfish.com." )
     docs:
       desc: |
-        This check ensures that legacy MX records, often associated with outdated email hosting configurations, are not used in domains configured for Microsoft Office 365 email services.
+        This check ensures that legacy MX records, often associated with outdated email hosting configurations, are not used in domains configured for Microsoft 365 email services.
 
         **Why this matters**
 
@@ -118,20 +118,27 @@ queries:
 
         - **Email delivery problems**: Outdated MX records may route email to obsolete or incorrect mail servers, causing delivery failures or delays.
         - **Security vulnerabilities**: Misconfigured MX records can expose email traffic to spoofing, phishing, or interception attacks if routed through untrusted servers.
-        - **Incompatibility with Office 365**: Microsoft Office 365 requires specific MX record configurations (e.g., *.mail.protection.outlook.com) to ensure proper email routing and security features like spam filtering and encryption.
+        - **Incompatibility with Microsoft 365**: Microsoft 365 requires specific MX record configurations (e.g., *.mail.protection.outlook.com) to ensure proper email routing and security features like spam filtering and encryption.
         - **Increased administrative complexity**: Retaining legacy MX records adds unnecessary complexity, increasing the risk of mismanagement during troubleshooting or migrations.
 
         By removing legacy MX records, the system ensures:
-          - Reliable email delivery through Microsoft Office 365
+          - Reliable email delivery through Microsoft 365
           - Enhanced security by preventing exposure to outdated or untrusted mail servers
-          - Compliance with Office 365 requirements and best practices
+          - Compliance with Microsoft 365 requirements and best practices
 
         Without these protections, legacy MX records could undermine email reliability and security, exposing the organization to unnecessary risks.
       remediation: |
-        Replace all legacy MX records with the correct Office 365 MX records provided in the Microsoft 365 Admin Center. Regularly audit DNS settings to ensure all MX records align with Office 365 requirements.
+        Replace all legacy MX records with the correct Microsoft 365 MX records provided in the Microsoft 365 Admin Center. Regularly audit DNS settings to ensure all MX records align with Office 365 requirements.
+
+        Steps to remediate:
+          1. Log in to your DNS hosting provider's control panel.
+          2. Locate the DNS settings for your domain.
+          3. Add or update the MX records to match the provided Microsoft 365 configuration, ensuring the correct priorities are set.
+          4. Remove any legacy or non-Microsoft MX records to avoid misrouting or security vulnerabilities.
+          5. Save the changes and verify the configuration using DNS checking tools websites.
     refs:
-      - url: https://techcommunity.microsoft.com/t5/exchange-team-blog/best-practices-for-using-assigned-office-365-dns-records/ba-p/607907
-        title: Best practices for using assigned Office 365 DNS records
+      - url: https://learn.microsoft.com/en-us/microsoft-365/admin/get-help-with-domains/create-dns-records-at-any-dns-hosting-provider?view=o365-worldwide
+        title: Add DNS records to connect your domain
   - uid: mondoo-dns-security-google-workspaces-mx-records
     title: Ensure the correct MX records are used with Google Workspaces
     impact: 80
@@ -221,5 +228,4 @@ queries:
       remediation: |
         * Avoid using wildcard DNS records (*.example.com) unless absolutely necessary for a specific and well-documented use case.
         * Replace wildcard records with explicit DNS records for each required subdomain to maintain precise control over DNS resolution.
-        * Conduct regular audits of DNS configurations to identify and remove any unintended or unnecessary wildcard records.
         * If wildcard records are required, ensure they are monitored and secured to prevent misuse or exploitation.

--- a/core/mondoo-dns-security.mql.yaml
+++ b/core/mondoo-dns-security.mql.yaml
@@ -128,7 +128,7 @@ queries:
 
         Without these protections, legacy MX records could undermine email reliability and security, exposing the organization to unnecessary risks.
       remediation: |
-        Replace all legacy MX records with the correct Microsoft 365 MX records provided in the Microsoft 365 Admin Center. Regularly audit DNS settings to ensure all MX records align with Office 365 requirements.
+        Replace all legacy MX records with the correct Microsoft 365 MX records provided in the Microsoft 365 Admin Center.
 
         Steps to remediate:
           1. Log in to your DNS hosting provider's control panel.

--- a/core/mondoo-ms365-security.mql.yaml
+++ b/core/mondoo-ms365-security.mql.yaml
@@ -63,50 +63,38 @@ queries:
       microsoft.security.latestSecureScores.controlScores.where(controlName == 'SigninRiskPolicy').all(_['score'] == 7)
     docs:
       desc: |
+        This check ensures that policies are in place to detect risky sign-ins in real-time and offline. Risky sign-ins refer to attempts that may be performed by unauthorized individuals trying to access user accounts.
+
+        **Why this matters**
+
+        Risky sign-ins are a key indicator of potential account compromise. Detecting and responding to these events promptly is critical to safeguarding sensitive data and maintaining the security of user accounts. Policies that monitor and flag risky sign-ins help organizations identify suspicious activities, such as sign-ins from unfamiliar locations, unusual devices, or atypical behavior patterns.
+
+        Without such policies, organizations may fail to detect unauthorized access attempts, leaving accounts vulnerable to compromise. This can lead to data breaches, unauthorized access to sensitive information, and potential compliance violations.
+
+        Implementing policies to detect risky sign-ins supports a proactive security posture and aligns with best practices for identity and access management. It also helps organizations meet compliance requirements for standards such as:
+          - ISO/IEC 27001 (A.9.4.2: Secure log-on procedures)
+          - NIST 800-53 (AC-7: Unsuccessful Login Attempts)
+          - CIS Controls (CIS Control 16: Account Monitoring and Control)
+
+        Ensuring these policies are in place strengthens account security and contributes to an organization's overall defense-in-depth strategy for protecting user identities and access to critical resources.
         This check ensures that there are some policies in place which can detect risky sign-in in real-time and offline. A risky sign-in mainly means a sign-in attempt which might be performed by illegitimate owner of a user account.
-      audit: |
-        __cnspec run__
+      remediation: |
+        **To configure a Sign-In risk policy, use the following steps:**
 
-        To audit Microsoft 365 with `cnspec run`:
+        1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
+        2. Select expand `Protection` > `Conditional Access` select `Policies`.
+        3. Create a new policy by selecting `New policy`.
+        4. Set the following conditions within the policy.
+          - Under `Users or workload identities` choose `All users`
+          - Under `Cloud apps or actions` choose `All cloud apps`
+          - Under `Conditions` choose `Sign-in risk` then `Yes` and check the risk level boxes `High` and `Medium`
+          - Under `Access Controls` select `Grant` then in the right pane select `Grant access` then select `Require multifactor authentication`.
+          - Under `Session` select `Sign-in Frequency` and set to `Every time`.
+        5. Select `Select`
+        6. You may opt to begin in a state of `Report Only` as you step through implementation however, the policy will need to be set to `On` to be in effect.
+        7. Select `Create`.
 
-        Run this query:
-
-          ```mql
-          cnspec run ms365 -c "microsoft.security.latestSecureScores.controlScores.where(_['controlName'] == 'SigninRiskPolicy') {*}" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-        __cnspec shell__
-
-        To audit Microsoft 365 with `cnspec shell`:
-
-        1. Launch `cnspec shell`:
-
-          ```bash
-          cnspec shell ms365 --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-
-        2. Run this query:
-
-          ```mql
-          microsoft.security.latestSecureScores.controlScores.where(_['controlName'] == 'SigninRiskPolicy') {*}
-          ```
-      remediation:
-        - desc: |-
-            **To configure a Sign-In risk policy, use the following steps:**
-
-            1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
-            2. Select expand `Protection` > `Conditional Access` select `Policies`.
-            3. Create a new policy by selecting `New policy`.
-            4. Set the following conditions within the policy.
-             - Under `Users or workload identities` choose `All users`
-             - Under `Cloud apps or actions` choose `All cloud apps`
-             - Under `Conditions` choose `Sign-in risk` then `Yes` and check the risk level boxes `High` and `Medium`
-             - Under `Access Controls` select `Grant` then in the right pane select `Grant access` then select `Require multifactor authentication`.
-             - Under `Session` select `Sign-in Frequency` and set to `Every time`.
-            5. Select `Select`
-            6. You may opt to begin in a state of `Report Only` as you step through implementation however, the policy will need to be set to `On` to be in effect.
-            7. Select `Create`.
-
-            **NOTE:** for more information regarding risk levels refer to [Microsoft's Identity Protection & Risk Doc](https://docs.microsoft.com/en-us/azure/active-directory/identity-protection/concept-identity-protection-risks)
+        **NOTE:** for more information regarding risk levels refer to [Microsoft's Identity Protection & Risk Doc](https://docs.microsoft.com/en-us/azure/active-directory/identity-protection/concept-identity-protection-risks)
   - uid: mondoo-m365-security-enable-azure-ad-identity-protection-user-risk-policies
     title: Enable Azure AD Identity Protection user risk policies
     impact: 100
@@ -114,50 +102,37 @@ queries:
       microsoft.security.latestSecureScores.controlScores.where(controlName == 'UserRiskPolicy').all(_['score'] == 7)
     docs:
       desc: |
-        This check ensures that there are some policies in place which can detect risky sign-in in real-time and offline. A risky sign-in mainly means a sign-in attempt which might be performed by illegitimate owner of a user account.
-      audit: |
-        __cnspec run__
+        This check ensures that policies are in place to detect risky sign-ins in real-time and offline. Risky sign-ins refer to attempts that may be performed by unauthorized individuals trying to access user accounts.
 
-        To audit Microsoft 365 with `cnspec run`:
+        **Why this matters**
 
-        Run this query:
+        Risky sign-ins are a key indicator of potential account compromise. Detecting and responding to these events promptly is critical to safeguarding sensitive data and maintaining the security of user accounts. Policies that monitor and flag risky sign-ins help organizations identify suspicious activities, such as sign-ins from unfamiliar locations, unusual devices, or atypical behavior patterns.
 
-          ```mql
-          cnspec run ms365 -c "microsoft.security.latestSecureScores.controlScores.where(_['controlName'] == 'UserRiskPolicy') {*}" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-        __cnspec shell__
+        Without such policies, organizations may fail to detect unauthorized access attempts, leaving accounts vulnerable to compromise. This can lead to data breaches, unauthorized access to sensitive information, and potential compliance violations.
 
-        To audit Microsoft 365 with `cnspec shell`:
+        Implementing policies to detect risky sign-ins supports a proactive security posture and aligns with best practices for identity and access management. It also helps organizations meet compliance requirements for standards such as:
+          - ISO/IEC 27001 (A.9.4.2: Secure log-on procedures)
+          - NIST 800-53 (AC-7: Unsuccessful Login Attempts)
+          - CIS Controls (CIS Control 16: Account Monitoring and Control)
 
-        1. Launch `cnspec shell`:
+        Ensuring these policies are in place strengthens account security and contributes to an organization's overall defense-in-depth strategy for protecting user identities and access to critical resources.
+      remediation: |
+        **To configure a User risk policy, use the following steps:**
 
-          ```bash
-          cnspec shell ms365 --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
+        1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
+        2. Select expand `Protection` > `Conditional Access` select `Policies`.
+        3. Create a new policy by selecting `New policy`.
+        4. Set the following conditions within the policy:
+          - Under `Users or workload identities` choose `All users`
+          - Under `Cloud apps or actions` choose `All cloud apps`
+          - Under `Conditions` choose `User risk` then `Yes` and select the user risk level `High`.
+          - Under `Access Controls` select `Grant` then in the right pane select `Grant access` then select `Require multifactor authentication` and `Require password change`.
+          - Under `Session` ensure `Sign-in frequency` is set to `Every time`.
+        5. Select `Select`.
+        6. You may opt to begin in a state of `Report Only` as you step through implementation however, the policy will need to be set to `On` to be in effect.
+        7. Select `Create`.
 
-        2. Run this query:
-
-          ```mql
-          microsoft.security.latestSecureScores.controlScores.where(_['controlName'] == 'UserRiskPolicy') {*}
-          ```
-      remediation:
-        - desc: |-
-            **To configure a User risk policy, use the following steps:**
-
-            1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
-            2. Select expand `Protection` > `Conditional Access` select `Policies`.
-            3. Create a new policy by selecting `New policy`.
-            4. Set the following conditions within the policy:
-             - Under `Users or workload identities` choose `All users`
-             - Under `Cloud apps or actions` choose `All cloud apps`
-             - Under `Conditions` choose `User risk` then `Yes` and select the user risk level `High`.
-             - Under `Access Controls` select `Grant` then in the right pane select `Grant access` then select `Require multifactor authentication` and `Require password change`.
-             - Under `Session` ensure `Sign-in frequency` is set to `Every time`.
-            5. Select `Select`.
-            6. You may opt to begin in a state of `Report Only` as you step through implementation however, the policy will need to be set to `On` to be in effect.
-            7. Select `Create`.
-
-            **NOTE:** for more information regarding risk levels refer to [Microsoft's Identity Protection & Risk Doc](https://docs.microsoft.com/en-us/azure/active-directory/identity-protection/concept-identity-protection-risks)
+        **NOTE:** for more information regarding risk levels refer to [Microsoft's Identity Protection & Risk Doc](https://docs.microsoft.com/en-us/azure/active-directory/identity-protection/concept-identity-protection-risks)
   - uid: mondoo-m365-security-enable-conditional-access-policies-to-block-legacy-authentication
     title: Enable Conditional Access policies to block legacy authentication
     impact: 80
@@ -165,159 +140,118 @@ queries:
       microsoft.security.latestSecureScores.controlScores.where(controlName == 'BlockLegacyAuthentication').all(_['score'] == 8)
     docs:
       desc: |
-        This check ensures that the legacy authentication protocols has been disabled in office 365.
+        This check ensures that legacy authentication protocols are disabled in Office 365.
 
-        To give your users easy access to your cloud apps, Azure Active Directory (Azure AD) supports a broad variety of authentication protocols including legacy authentication. However, legacy authentication doesn't support things like multi-factor authentication (MFA). MFA is a common requirement to improve security posture in organizations.
-      audit: |
-        __cnspec run__
+        **Why this matters**
 
-        To audit Microsoft 365 with `cnspec run`:
+        Legacy authentication protocols, such as POP, IMAP, and SMTP, do not support modern security features like multi-factor authentication (MFA). These protocols are often targeted by attackers as they provide an easier entry point for unauthorized access to user accounts.
 
-        Run this query:
+        Disabling legacy authentication reduces the attack surface by preventing the use of outdated protocols that lack robust security measures. This helps protect sensitive data, prevent unauthorized access, and align with best practices for securing cloud environments.
 
-          ```mql
-          cnspec run ms365 -c "microsoft.security.latestSecureScores.controlScores.where(_['controlName'] == 'BlockLegacyAuthentication') {*}" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-        __cnspec shell__
+        Without disabling legacy authentication, organizations risk exposing their accounts to brute force attacks, credential stuffing, and other malicious activities. This can lead to data breaches, compliance violations, and reputational damage.
 
-        To audit Microsoft 365 with `cnspec shell`:
+        Ensuring legacy authentication is disabled strengthens the security posture of an organization and supports compliance with standards such as:
+          - ISO/IEC 27001 (A.9.4.2: Secure log-on procedures)
+          - NIST 800-53 (AC-7: Unsuccessful Login Attempts)
+          - CIS Controls (CIS Control 16: Account Monitoring and Control)
 
-        1. Launch `cnspec shell`:
+        Disabling legacy authentication is a critical step in implementing a modern, secure authentication framework for Office 365.
+      remediation: |
+        **To setup a conditional access policy to block legacy authentication, use the following steps:**
 
-          ```bash
-          cnspec shell ms365 --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-
-        2. Run this query:
-
-          ```mql
-          microsoft.security.latestSecureScores.controlScores.where(_['controlName'] == 'BlockLegacyAuthentication') {*}
-          ```
-      remediation:
-        - desc: |-
-            **To setup a conditional access policy to block legacy authentication, use the following steps:**
-
-            1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
-            2. Select expand `Protection` > `Conditional Access` select `Policies`.
-            3. Create a new policy by selecting `New policy`.
-            4. Set the following conditions within the policy.
-             - Select `Conditions` then `Client apps` enable the settings for and `Exchange ActiveSync clients` and `other clients`.
-             - Under `Access controls` set the `Grant` section to `Block access`
-             - Under `Assignments` enable `All users`
-             - Under `Assignments` and `Users and groups` set the `Exclude` to be at least one low risk account or directory role. This is required as a best practice.
+        1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
+        2. Select expand `Protection` > `Conditional Access` select `Policies`.
+        3. Create a new policy by selecting `New policy`.
+        4. Set the following conditions within the policy.
+          - Select `Conditions` then `Client apps` enable the settings for and `Exchange ActiveSync clients` and `other clients`.
+          - Under `Access controls` set the `Grant` section to `Block access`
+          - Under `Assignments` enable `All users`
+          - Under `Assignments` and `Users and groups` set the `Exclude` to be at least one low risk account or directory role. This is required as a best practice.
   - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-administrative-roles
-    title: Ensure multifactor authentication is enabled for all users in administrative roles
+    title: Ensure multi-factor authentication (MFA) is enabled for all users in administrative roles
     impact: 100
     mql: |
       microsoft.security.latestSecureScores.controlScores.where(controlName == 'AdminMFAV2').all(_['score'] == 10)
     docs:
       desc: |
-        Enable multi-factor authentication for all users in administrative roles!
-      audit: |
-        __cnspec run__
+        This check ensures that multi-factor authentication (MFA) is enabled for all users in administrative roles within the Microsoft 365 tenant.
 
-         To audit Microsoft 365 with `cnspec run`:
+        **Why this matters**
 
-         Run this query:
+        Enabling MFA for administrative roles adds an essential layer of security to protect privileged accounts from unauthorized access. Administrative accounts are high-value targets for attackers, as they have elevated permissions that can be exploited to compromise the entire environment.
 
-           ```mql
-           cnspec run ms365 -c "microsoft.security.latestSecureScores.controlScores.where(_['controlName'] == 'AdminMFAV2') {*}" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-           ```
+        Without MFA, administrative accounts are more vulnerable to credential theft, phishing attacks, and brute force attempts. This can lead to unauthorized access, data breaches, and potential compliance violations.
 
-         __cnspec shell__
+        Implementing MFA for administrative roles aligns with security best practices and compliance requirements, such as:
+          - ISO/IEC 27001 (A.9.4.2: Secure log-on procedures)
+          - NIST 800-53 (IA-2: Identification and Authentication)
+          - CIS Controls (CIS Control 16: Account Monitoring and Control)
 
-         To audit Microsoft 365 with `cnspec shell`:
+        Ensuring MFA is enabled for administrative roles strengthens the security posture of the organization and reduces the risk of unauthorized access to critical resources.
+      remediation: |
+        **To enable multi-factor authentication (MFA) for administrators:**
 
-         1. Launch `cnspec shell`:
+        1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
+        2. Select expand `Protection` > `Conditional Access` select `Policies`.
+        3. Select `New policy`.
+        4. Go to `Assignments` > `Users and groups` > `Include` > `Select users and groups` > check `Directory roles`.
+        5. At a minimum, select the `Directory roles listed` below in this section of the document.
+        6. Go to `Cloud apps or actions` > `Cloud apps` > `Include` > select `All cloud apps (and don't exclude any apps)`.
+        7. Under `Access controls` > `Grant` > select `Grant access` > check `Require multi-factor authentication` (and nothing else).
+        8. Leave all other conditions blank.
+        9. Make sure the policy is enabled.
+        10. Create.
 
-           ```bash
-           cnspec shell ms365 --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-           ```
+        **At minimum these directory roles should be included for MFA:**
 
-         2. Run this query:
-
-           ```mql
-           microsoft.security.latestSecureScores.controlScores.where(_['controlName'] == 'AdminMFAV2') {*}
-           ```
-      remediation:
-        - desc: |-
-            **To enable multifactor authentication for administrators:**
-
-            1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
-            2. Select expand `Protection` > `Conditional Access` select `Policies`.
-            3. Select `New policy`.
-            4. Go to `Assignments` > `Users and groups` > `Include` > `Select users and groups` > check `Directory roles`.
-            5. At a minimum, select the `Directory roles listed` below in this section of the document.
-            6. Go to `Cloud apps or actions` > `Cloud apps` > `Include` > select `All cloud apps (and don't exclude any apps)`.
-            7. Under `Access controls` > `Grant` > select `Grant access` > check `Require multi-factor authentication` (and nothing else).
-            8. Leave all other conditions blank.
-            9. Make sure the policy is enabled.
-            10. Create.
-
-            **At minimum these directory roles should be included for MFA:**
-
-            - Application administrator
-            - Authentication administrator
-            - Billing administrator
-            - Cloud application administrator
-            - Conditional Access administrator
-            - Exchange administrator
-            - Global administrator
-            - Global reader
-            - Helpdesk administrator
-            - Password administrator
-            - Privileged authentication administrator
-            - Privileged role administrator
-            - Security administrator
-            - SharePoint administrator
-            - User administrator
+        - Application administrator
+        - Authentication administrator
+        - Billing administrator
+        - Cloud application administrator
+        - Conditional Access administrator
+        - Exchange administrator
+        - Global administrator
+        - Global reader
+        - Helpdesk administrator
+        - Password administrator
+        - Privileged authentication administrator
+        - Privileged role administrator
+        - Security administrator
+        - SharePoint administrator
+        - User administrator
   - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-all-roles
-    title: Ensure multifactor authentication is enabled for all users
+    title: Ensure multi-factor authentication (MFA) is enabled for all users
     impact: 100
     mql: |
       microsoft.security.latestSecureScores.controlScores.where(controlName == 'MFARegistrationV2').all(_['score'] == 9)
     docs:
       desc: |
-        This check ensures that the MFA has been enabled for all users in the Microsoft 365 tenant.
-      audit: |
-        __cnspec run__
+        This check ensures that multi-factor authentication (MFA) is enabled for all users in the Microsoft 365 tenant.
 
-        To audit Microsoft 365 with `cnspec run`:
+        **Why this matters**
 
-        Run this query:
+        Enabling MFA for all users adds an essential layer of security to protect user accounts from unauthorized access. User accounts are often targeted by attackers, as they can be exploited to gain access to sensitive data and systems.
 
-          ```mql
-          cnspec run ms365 -c "microsoft.security.latestSecureScores.controlScores.where(_['controlName'] == 'MFARegistrationV2') {*}" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
+        Without MFA, user accounts are more vulnerable to credential theft, phishing attacks, and brute force attempts. This can lead to unauthorized access, data breaches, and potential compliance violations.
 
-        __cnspec shell__
+        Implementing MFA for all users aligns with security best practices and compliance requirements, such as:
+          - ISO/IEC 27001 (A.9.4.2: Secure log-on procedures)
+          - NIST 800-53 (IA-2: Identification and Authentication)
+          - CIS Controls (CIS Control 16: Account Monitoring and Control)
 
-        To audit Microsoft 365 with `cnspec shell`:
+        Ensuring MFA is enabled for all users strengthens the security posture of the organization and reduces the risk of unauthorized access to critical resources.
+      remediation: |
+        **To enable multi-factor authentication (MFA) for all users:**
 
-        1. Launch `cnspec shell`:
-
-          ```bash
-          cnspec shell ms365 --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-
-        2. Run this query:
-
-          ```mql
-          microsoft.security.latestSecureScores.controlScores.where(_['controlName'] == 'MFARegistrationV2') {*}
-          ```
-      remediation:
-        - desc: |-
-            **To enable multifactor authentication for all users:**
-
-            1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
-            2. Select expand `Protection` > `Conditional Access` select `Policies`.
-            3. Select `New policy`.
-            4. Go to `Assignments` > `Users and groups` > `Include` > select `All users` (and do not exclude any user).
-            5. Select `Cloud apps or actions` > `All cloud apps` (and don't exclude any apps).
-            6. `Access Controls` > `Grant` > `Require multi-factor authentication` (and nothing else).
-            7. Leave all other conditions blank.
-            8. Make sure the policy is Enabled/On.
-            9. Create.
+        1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
+        2. Select expand `Protection` > `Conditional Access` select `Policies`.
+        3. Select `New policy`.
+        4. Go to `Assignments` > `Users and groups` > `Include` > select `All users` (and do not exclude any user).
+        5. Select `Cloud apps or actions` > `All cloud apps` (and don't exclude any apps).
+        6. `Access Controls` > `Grant` > `Require multi-factor authentication` (and nothing else).
+        7. Leave all other conditions blank.
+        8. Make sure the policy is Enabled/On.
+        9. Create.
   - uid: mondoo-m365-security-ensure-security-defaults-is-disabled-on-azure-active-directory
     title: Ensure Security Defaults is disabled on Azure Active Directory
     impact: 80
@@ -327,54 +261,41 @@ queries:
       desc: |
         This check ensures that the security defaults (which are enabled by default) are disabled in Azure Active Directory.
 
+        **Why this matters**
+
+        Security defaults are a set of basic identity security mechanisms provided by Microsoft to protect organizations from common identity-related attacks. While they offer a good starting point for securing identities, they may not meet the specific needs of all organizations.
+
+        Disabling security defaults allows organizations to implement custom Conditional Access policies tailored to their unique security requirements. This enables more granular control over access to resources, such as enforcing multi-factor authentication (MFA) for specific users or applications, blocking legacy authentication protocols, and applying risk-based access controls.
+
+        Without disabling security defaults, organizations may face limitations in implementing advanced security configurations. This can hinder their ability to align with best practices and compliance requirements, such as:
+          - ISO/IEC 27001 (A.9.4.2: Secure log-on procedures)
+          - NIST 800-53 (AC-7: Unsuccessful Login Attempts)
+          - CIS Controls (CIS Control 16: Account Monitoring and Control)
+
+        Disabling security defaults and implementing custom Conditional Access policies strengthens the organization's security posture and provides greater flexibility in managing access to critical resources.
+
         Note: Using security defaults prohibits custom settings. Many best security practices require custom settings.
-      audit: |
-        __cnspec run__
+      remediation: |
+        **To disable security defaults:**
 
-        To audit Microsoft 365 with `cnspec run`:
+        1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
+        2. Select to expand `Identity` select `Overview`
+        3. Select `Properties`.
+        4. Select `Manage security defaults`.
+        5. Set the `Security defaults` dropdown to `Disabled`.
+        6. Select Save.
 
-        Run this query:
+        **To configure security defaults using Microsoft Graph PowerShell:**
 
-          ```mql
-          cnspec run ms365 -c "microsoft.policies.identitySecurityDefaultsEnforcementPolicy" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-        __cnspec shell__
+        1. Connect to the Microsoft Graph service using `Connect-MgGraph -Scopes "Policy.ReadWrite.ConditionalAccess"`.
+        2. Run the following Microsoft Graph PowerShell command:
 
-        To audit Microsoft 365 with `cnspec shell`:
+        ```powershell
+        $params = @{ IsEnabled = $false }
+        Update-MgPolicyIdentitySecurityDefaultEnforcementPolicy -BodyParameter $params
+        ```
 
-        1. Launch `cnspec shell`:
-
-          ```bash
-          cnspec shell ms365 --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-
-        2. Run this query:
-
-          ```mql
-          microsoft.policies.identitySecurityDefaultsEnforcementPolicy
-          ```
-      remediation:
-        - desc: |-
-            **To disable security defaults:**
-
-            1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
-            2. Select to expand `Identity` select `Overview`
-            3. Select `Properties`.
-            4. Select `Manage security defaults`.
-            5. Set the `Security defaults` dropdown to `Disabled`.
-            6. Select Save.
-
-            **To configure security defaults using Microsoft Graph PowerShell:**
-
-            1. Connect to the Microsoft Graph service using `Connect-MgGraph -Scopes "Policy.ReadWrite.ConditionalAccess"`.
-            2. Run the following Microsoft Graph PowerShell command:
-
-            ```powershell
-            $params = @{ IsEnabled = $false }
-            Update-MgPolicyIdentitySecurityDefaultEnforcementPolicy -BodyParameter $params
-            ```
-
-            **WARNING:** It is recommended not to disable security defaults until you are ready to implement conditional access rules in the benchmark. Rules such as requiring MFA for all users and blocking legacy protocols are required in CA in order to make up the gap by disabling defaults. Plan accordingly. See the reference section for more details on what coverage Security Defaults provide.
+        **WARNING:** It is recommended not to disable security defaults until you are ready to implement conditional access rules in the benchmark. Rules such as requiring MFA for all users and blocking legacy protocols are required in CA in order to make up the gap by disabling defaults. Plan accordingly. See the reference section for more details on what coverage Security Defaults provide.
   - uid: mondoo-m365-security-ensure-that-between-two-and-four-global-admins-are-designated
     title: Ensure that between two and four global admins are designated
     impact: 80
@@ -383,53 +304,32 @@ queries:
     docs:
       desc: |
         This check ensures that there are enough Global Admins in a single tenant.
+
+        **Why this matters**
+
         When it comes to designating global admins, it's important to consider the size and complexity of the organization, as well as the level of responsibility and authority required for the role. As a general rule, it's a good idea to have at least three global admins to ensure that there is redundancy and coverage in case one admin is unavailable or leaves the organization.
 
         At the same time, having too many global admins can lead to confusion and inefficiency, as multiple people may be making decisions or taking actions without proper coordination. Therefore, it's recommended to keep the number of global admins to no more than four, unless the organization is particularly large or complex and requires more administrators to properly manage its operations.
-      audit: |
-        __cnspec run__
 
-        To audit Microsoft 365 with `cnspec run`:
+        Ensuring the appropriate number of global admins strengthens the organization's ability to manage its operations effectively while maintaining security and operational efficiency.
+      remediation: |
+        **To correct the number of global tenant administrators:**
 
-        Run this query:
-
-          ```mql
-          cnspec run ms365 -c "microsoft.rolemanagement.roleDefinitions.where(displayName == "Global Administrator") {*}" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-        __cnspec shell__
-
-        To audit Microsoft 365 with `cnspec shell`:
-
-        1. Launch `cnspec shell`:
-
-          ```bash
-          cnspec shell ms365 --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-
-        2. Run this query:
-
-          ```mql
-          microsoft.rolemanagement.roleDefinitions.where(displayName == "Global Administrator") {*}
-          ```
-      remediation:
-        - desc: |-
-            **To correct the number of global tenant administrators:**
-
-            1. Navigate to the `Microsoft 365 admin center` https://admin.microsoft.com
-            2. Select `Users` > `Active Users`.
-            3. In the `Search` field enter the name of the user to be made a Global Administrator.
-            4. To create a new Global Admin:
-             1. Select the user's name.
-             2. A window will appear to the right.
-             3. Select `Manage roles`.
-             4. Select `Admin center access`.
-             4. Check `Global Administrator`.
-             5. Select `Save changes`.
-            5. To remove Global Admins:
-             1. Select User.
-             2. Under `Roles` select `Manage roles`
-             3. De-Select the appropriate role.
-             4. Select `Save changes`.
+        1. Navigate to the `Microsoft 365 admin center` https://admin.microsoft.com
+        2. Select `Users` > `Active Users`.
+        3. In the `Search` field enter the name of the user to be made a Global Administrator.
+        4. To create a new Global Admin:
+          1. Select the user's name.
+          2. A window will appear to the right.
+          3. Select `Manage roles`.
+          4. Select `Admin center access`.
+          4. Check `Global Administrator`.
+          5. Select `Save changes`.
+        5. To remove Global Admins:
+          1. Select User.
+          2. Under `Roles` select `Manage roles`
+          3. De-Select the appropriate role.
+          4. Select `Save changes`.
   - uid: mondoo-m365-security-ensure-that-mobile-device-encryption-is-enabled-to-prevent-unauthorized-access-to-mobile-data
     title: Ensure that Android mobile device encryption is enabled
     impact: 80
@@ -437,33 +337,18 @@ queries:
       microsoft.devicemanagement.deviceConfigurations.where( properties['@odata.type'] == "#microsoft.graph.androidGeneralDeviceConfiguration").all(properties.storageRequireDeviceEncryption == true)
     docs:
       desc: |
-        This check ensures that encryption in android mobile devices has been enabled to prevent any unauthorized access to the data
-      audit: |
-        __cnspec run__
+        This check ensures that encryption in Android mobile devices has been enabled to prevent any unauthorized access to the data.
 
-        To audit Microsoft 365 with `cnspec run`:
+        **Why this matters**
 
-        Run this query:
+        Encryption ensures that sensitive data stored on mobile devices is protected from unauthorized access, even if the device is lost or stolen. Without encryption, attackers can easily access data by bypassing basic security measures.
 
-          ```mql
-          cnspec run ms365 -c "microsoft.devicemanagement.deviceConfigurations.where( properties['@odata.type'] == "#microsoft.graph.androidGeneralDeviceConfiguration") {*}" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
+        Implementing encryption aligns with security best practices and compliance requirements, such as:
+          - ISO/IEC 27001 (A.10.1.1: Policy on the use of cryptographic controls)
+          - NIST 800-53 (SC-12: Cryptographic Key Establishment and Management)
+          - CIS Controls (CIS Control 13: Data Protection)
 
-        __cnspec shell__
-
-        To audit Microsoft 365 with `cnspec shell`:
-
-        1. Launch `cnspec shell`:
-
-          ```bash
-          cnspec shell ms365 --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-
-        2. Run this query:
-
-          ```mql
-          microsoft.devicemanagement.deviceConfigurations.where( properties['@odata.type'] == "#microsoft.graph.androidGeneralDeviceConfiguration") {*}
-          ```
+        Enabling encryption on mobile devices strengthens the organization's security posture and reduces the risk of data breaches.
       remediation: |
         ### Microsoft 365 Console
 
@@ -483,39 +368,18 @@ queries:
       microsoft.devicemanagement.deviceConfigurations.where( properties["@odata.type"] == "#microsoft.graph.androidWorkProfileGeneralDeviceConfiguration").all(properties['passwordMinimumLength'] >= 8)
     docs:
       desc: |
-        This check ensures that there is minimum password length - at least eight characters - for mobile devices
+        This check ensures that there is a minimum password length - at least eight characters - for mobile devices.
 
-        According to NIST (SP 800-63-2), permitted the use of randomly generated PINs with 6 or more digits while requiring user-chosen memorized secrets to be a minimum of 8 characters long.
-      audit: |
-        __cnspec run__
+        **Why this matters**
 
-        To audit Microsoft 365 with `cnspec run`:
+        According to NIST (SP 800-63-2), user-chosen memorized secrets should be a minimum of 8 characters long. Enforcing a minimum password length helps protect against brute force attacks and ensures stronger security for mobile devices.
 
-        Run this query:
+        Without a minimum password length, attackers can exploit weak passwords, increasing the risk of unauthorized access to sensitive data. Implementing this policy aligns with security best practices and compliance requirements, such as:
+          - ISO/IEC 27001 (A.9.4.3: Password management system)
+          - NIST 800-53 (IA-5: Authenticator Management)
+          - CIS Controls (CIS Control 16: Account Monitoring and Control)
 
-          ```mql
-          cnspec run ms365 -c " microsoft.devicemanagement.deviceConfigurations.where( properties["@odata.type"] == "#microsoft.graph.windows10GeneralConfiguration") {*}" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-
-        __cnspec shell__
-
-        To audit Microsoft 365 with `cnspec shell`:
-
-        1. Launch `cnspec shell`:
-
-          ```bash
-          cnspec shell ms365 --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-
-        2. Run this query:
-
-          ```mql
-          microsoft.devicemanagement.deviceConfigurations.where( properties["@odata.type"] == "#microsoft.graph.windows10GeneralConfiguration")
-          microsoft.devicemanagement.deviceConfigurations.where( properties["@odata.type"] == "#microsoft.graph.macOSGeneralDeviceConfiguration")
-          microsoft.devicemanagement.deviceConfigurations.where( properties["@odata.type"] == "#microsoft.graph.iosGeneralDeviceConfiguration")
-          microsoft.devicemanagement.deviceConfigurations.where( properties["@odata.type"] == "#microsoft.graph.androidGeneralDeviceConfiguration")
-          microsoft.devicemanagement.deviceConfigurations.where( properties["@odata.type"] == "#microsoft.graph.androidWorkProfileGeneralDeviceConfiguration")
-          ```
+        Ensuring a minimum password length strengthens the security posture of the organization and reduces the risk of data breaches.
       remediation: |
         ### Microsoft 365 Console
 
@@ -532,51 +396,35 @@ queries:
       microsoft.domains.all(passwordValidityPeriodInDays == 2147483647)
     docs:
       desc: |
-        This check ensures to make sure the Office 365 passwords never expires. Based on the new research from several Organizations, it has been confirmed that forcing users to change their password, make the password less secure!
-      audit: |
-        __cnspec run__
+        This check ensures that Office 365 passwords are set to never expire. Based on new research from several organizations, it has been confirmed that forcing users to change their passwords frequently can lead to weaker password practices and reduced security.
 
-        To audit Microsoft 365 with `cnspec run`:
+        **Why this matters**
 
-        Run this query:
+        Forcing users to change their passwords regularly often results in predictable patterns or weaker passwords, as users may resort to minor variations of their previous passwords. This behavior can make it easier for attackers to guess or compromise passwords.
 
-          ```mql
-          cnspec run ms365 -c "microsoft.domains.all(passwordValidityPeriodInDays == 2147483647)" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
+        Allowing passwords to never expire, combined with strong password policies and multi-factor authentication (MFA), provides a more secure and user-friendly approach. This aligns with modern security best practices and compliance requirements, such as:
+          - ISO/IEC 27001 (A.9.4.3: Password management system)
+          - NIST 800-63 (IA-5: Authenticator Management)
+          - CIS Controls (CIS Control 16: Account Monitoring and Control)
 
-        __cnspec shell__
+        Ensuring that passwords do not expire unnecessarily strengthens the organization's security posture while reducing the burden on users.
+      remediation: |
+        **To set Office 365 passwords to never expire:**
 
-        To audit Microsoft 365 with `cnspec shell`:
+        1. Navigate to the `Microsoft 365 admin center` at https://admin.microsoft.com.
+        2. Go to `Settings` > `Org settings`.
+        3. Under the `Security & privacy` tab, locate and select `Password expiration policy`.
+        4. Check the box for `Set passwords to never expire (recommended)`.
+        5. Select `Save changes`.
 
-        1. Launch `cnspec shell`:
+        **To set Office 365 passwords to never expire using the Microsoft Graph PowerShell module:**
 
-          ```bash
-          cnspec shell ms365 --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
+        1. Connect to the Microsoft Graph service using `Connect-MgGraph -Scopes "Domain.ReadWrite.All"`.
+        2. Run the following Microsoft Graph PowerShell command:
 
-        2. Run this query:
-
-          ```mql
-          microsoft.domains {*}
-          ```
-      remediation:
-        - desc: |-
-            **To set Office 365 passwords are set to never expire:**
-
-            1. Navigate to `Microsoft 365 admin center` https://admin.microsoft.com.
-            2. Expand `Settings` and select `Org Settings`.
-            3. Select `Security & privacy`.
-            4. Check the `Set passwords to never expire (recommended)` box.
-            5. Select `Save`.
-
-            **To set Office 365 Passwords Are Not Set to Expire, use the Microsoft Graph PowerShell module:**
-
-            1. Connect to the Microsoft Graph service using `Connect-MgGraph -Scopes "Domain.ReadWrite.All"`.
-            2. Run the following Microsoft Graph PowerShell command:
-
-            ```powershell
-            Update-MgDomain -DomainId <Domain> -PasswordValidityPeriodInDays 2147483647 -PasswordNotificationWindowInDays 30
-            ```
+        ```powershell
+        Update-MgDomain -DomainId <Domain> -PasswordValidityPeriodInDays 2147483647 -PasswordNotificationWindowInDays 30
+        ```
   - uid: mondoo-m365-security-ensure-that-spf-records-are-published-for-all-exchange-domains
     title: Ensure that SPF records are published for all Exchange Domains
     impact: 60
@@ -585,81 +433,58 @@ queries:
       microsoft.domains.all(serviceConfigurationRecords.where(supportedService == "Email" && recordType == "Txt").all(properties.text == "v=spf1 include:spf.protection.outlook.com -all"))
     docs:
       desc: |
-        This check ensures that SPF records is created for each domain in Exchange.
-      audit: |
-        __cnspec run__
+        This check ensures that SPF records are created for each domain in Exchange.
 
-        To audit Microsoft 365 with `cnspec run`:
+        **Why this matters**
 
-        Run this query:
+        Sender Policy Framework (SPF) records are a critical component of email authentication. They help prevent email spoofing by specifying which mail servers are authorized to send emails on behalf of a domain. Without SPF records, attackers can impersonate your domain to send fraudulent emails, leading to phishing attacks, reputational damage, and potential data breaches.
 
-          ```mql
-          cnspec run ms365 -c "microsoft.domains.all(serviceConfigurationRecords.where(supportedService == "Email" && recordType == "Txt" )" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-        __cnspec shell__
+        Implementing SPF records aligns with security best practices and compliance requirements, such as:
+          - ISO/IEC 27001 (A.13.2.3: Electronic messaging)
+          - NIST 800-53 (SC-7: Boundary Protection)
+          - CIS Controls (CIS Control 9: Email and Web Browser Protections)
 
-        To audit Microsoft 365 with `cnspec shell`:
+        Ensuring SPF records are published for all Exchange domains strengthens email security, reduces the risk of spoofing, and enhances trust in email communications.
+      remediation: |
+        **To setup SPF records for Exchange Online accepted domains, perform the following steps:**
 
-        1. Launch `cnspec shell`:
+        1. If all email in your domain is sent from and received by Exchange Online, add the following TXT record for each Accepted Domain:
 
-          ```bash
-          cnspec shell ms365 --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
+        ```
+        v=spf1 include:spf.protection.outlook.com -all
+        ```
 
-        2. Run this query:
+        2. If there are other systems that send email in the environment, ensure the SPF record includes all authorized email-sending systems. For example:
 
-          ```mql
-          microsoft.domains.all(serviceConfigurationRecords.where(supportedService == "Email" && recordType == "Txt" )
-          ```
-      remediation:
-        - desc: |-
-            **To setup SPF records for Exchange Online accepted domains, perform the following steps:**
+        ```
+        v=spf1 include:spf.protection.outlook.com include:<other-system> -all
+        ```
 
-            1. If all email in your domain is sent from and received by Exchange Online, add the following TXT record for each Accepted Domain:
-
-            ```dns
-            v=spf1 include:spf.protection.outlook.com -all
-            ```
-
-            2. If there are other systems that send email in the environment, refer to this article for the proper SPF configuration: [https://docs.microsoft.com/en-us/office365/SecurityCompliance/set-up-spf-in-office-365-to-help-prevent-spoofing](https://docs.microsoft.com/en-us/office365/SecurityCompliance/set-up-spf-in-office-365-to-help-prevent-spoofing).
+        3. Use the Microsoft 365 Defender portal to validate your SPF record configuration. Refer to this article for detailed guidance: [https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/how-office-365-uses-spf-to-prevent-spoofing](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/how-office-365-uses-spf-to-prevent-spoofing).
   - uid: mondoo-m365-security-ensure-third-party-integrated-applications-are-not-allowed
     title: Ensure that no third party integrated applications are allowed
     impact: 80
     mql: microsoft.policies.authorizationPolicy.defaultUserRolePermissions.allowedToCreateApps == false
     docs:
       desc: |
-        This check ensures that no third party integrated applications can connect to your services.
-      audit: |
-        __cnspec run__
+        This check ensures that no third-party integrated applications can connect to your services.
 
-        To audit Microsoft 365 with `cnspec run`:
+        **Why this matters**
 
-        Run this query:
+        Allowing third-party integrated applications to connect to your services can introduce security risks, such as unauthorized access, data leakage, or exploitation of vulnerabilities in the third-party applications. Restricting third-party integrations helps maintain control over your organization's data and reduces the attack surface.
 
-          ```mql
-          cnspec run ms365 -c "microsoft.policies.authorizationPolicy.defaultUserRolePermissions.allowedToCreateApps" --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
+        By preventing third-party applications from connecting, organizations can ensure that only trusted and approved applications are used. This aligns with security best practices and compliance requirements, such as:
+          - ISO/IEC 27001 (A.13.1.1: Network controls)
+          - NIST 800-53 (AC-3: Access Enforcement)
+          - CIS Controls (CIS Control 14: Controlled Access Based on the Need to Know)
 
-        __cnspec shell__
-
-        To audit Microsoft 365 with `cnspec shell`:
-
-        1. Launch `cnspec shell`:
-
-          ```bash
-          cnspec shell ms365 --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id>
-          ```
-
-        2. Run this query:
-
-          ```mql
-          microsoft.policies.authorizationPolicy.defaultUserRolePermissions.allowedToCreateApps
-          ```
+        Ensuring that third-party integrated applications are not allowed strengthens the organization's security posture and minimizes the risk of unauthorized access or data breaches.
       remediation: |
         ### Microsoft 365 Console
 
         To update via the Microsoft 365 portal:
-        1. Log in as Global Administrator to the Microsoft 365 portal at https://admin.microsoft.com
-        2. Select "Azure Active Directory" once in the "Admin Centers"
-        3. Users --> User settings -->  App registrations set to NO
-        4. Save
+        1. Log in as Global Administrator to the Microsoft 365 portal at https://admin.microsoft.com.
+        2. Navigate to "Azure Active Directory" in the "Admin Centers."
+        3. Go to "Users" > "User settings."
+        4. Under "App registrations," set "Users can register applications" to "No."
+        5. Save your changes.

--- a/core/mondoo-ms365-security.mql.yaml
+++ b/core/mondoo-ms365-security.mql.yaml
@@ -51,7 +51,7 @@ policies:
           - uid: mondoo-m365-security-ensure-that-between-two-and-four-global-admins-are-designated
           - uid: mondoo-m365-security-ensure-that-mobile-device-encryption-is-enabled-to-prevent-unauthorized-access-to-mobile-data
           - uid: mondoo-m365-security-ensure-that-mobile-devices-require-a-minimum-password-length-to-prevent-brute-force-attacks
-          - uid: mondoo-m365-security-ensure-that-office-365-passwords-are-not-set-to-expire
+          - uid: mondoo-m365-security-ensure-that-ms-365-passwords-are-not-set-to-expire
           - uid: mondoo-m365-security-ensure-that-spf-records-are-published-for-all-exchange-domains
           - uid: mondoo-m365-security-ensure-third-party-integrated-applications-are-not-allowed
     scoring_system: highest impact
@@ -140,7 +140,7 @@ queries:
       microsoft.security.latestSecureScores.controlScores.where(controlName == 'BlockLegacyAuthentication').all(_['score'] == 8)
     docs:
       desc: |
-        This check ensures that legacy authentication protocols are disabled in Office 365.
+        This check ensures that legacy authentication protocols are disabled in Microsoft 365.
 
         **Why this matters**
 
@@ -155,7 +155,7 @@ queries:
           - NIST 800-53 (AC-7: Unsuccessful Login Attempts)
           - CIS Controls (CIS Control 16: Account Monitoring and Control)
 
-        Disabling legacy authentication is a critical step in implementing a modern, secure authentication framework for Office 365.
+        Disabling legacy authentication is a critical step in implementing a modern, secure authentication framework for Microsoft 365.
       remediation: |
         **To setup a conditional access policy to block legacy authentication, use the following steps:**
 
@@ -389,14 +389,14 @@ queries:
          2. Endpoint Manager --> Devices --> Policy --> Configuration profiles
          3. Ensure that a profile exists for each Platform with following conditions:
             * Password section --> Device restrictions --> Minimum password length is set to 8
-  - uid: mondoo-m365-security-ensure-that-office-365-passwords-are-not-set-to-expire
+  - uid: mondoo-m365-security-ensure-that-ms-365-passwords-are-not-set-to-expire
     title: Ensure the 'Password expiration policy' is set to 'Set passwords to never expire (recommended)'
     impact: 60
     mql: |
       microsoft.domains.all(passwordValidityPeriodInDays == 2147483647)
     docs:
       desc: |
-        This check ensures that Office 365 passwords are set to never expire. Based on new research from several organizations, it has been confirmed that forcing users to change their passwords frequently can lead to weaker password practices and reduced security.
+        This check ensures that Microsoft 365 passwords are set to never expire. Based on new research from several organizations, it has been confirmed that forcing users to change their passwords frequently can lead to weaker password practices and reduced security.
 
         **Why this matters**
 
@@ -409,7 +409,7 @@ queries:
 
         Ensuring that passwords do not expire unnecessarily strengthens the organization's security posture while reducing the burden on users.
       remediation: |
-        **To set Office 365 passwords to never expire:**
+        **To set Microsoft 365 passwords to never expire:**
 
         1. Navigate to the `Microsoft 365 admin center` at https://admin.microsoft.com.
         2. Go to `Settings` > `Org settings`.
@@ -417,7 +417,7 @@ queries:
         4. Check the box for `Set passwords to never expire (recommended)`.
         5. Select `Save changes`.
 
-        **To set Office 365 passwords to never expire using the Microsoft Graph PowerShell module:**
+        **To set Microsoft 365 passwords to never expire using the Microsoft Graph PowerShell module:**
 
         1. Connect to the Microsoft Graph service using `Connect-MgGraph -Scopes "Domain.ReadWrite.All"`.
         2. Run the following Microsoft Graph PowerShell command:


### PR DESCRIPTION
- Replace legacy references to Office 365
- Improve descriptions to explain why changes are important
- Remove audit steps that are just a repeat of the MQL queries