### PR TITLE
Revert "Quickfix for innit containers (#554)"

### DIFF
--- a/core/mondoo-kubernetes-security.mql.yaml
+++ b/core/mondoo-kubernetes-security.mql.yaml
@@ -5376,7 +5376,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     mql: |
-      k8s.pod.initContainers.any( resources['limits']['cpu'] != empty )
+      k8s.pod.initContainers.all( resources['limits']['cpu'] != empty )
       k8s.pod.containers.all( resources['limits']['cpu'] != empty )
     docs:
       desc: |
@@ -5429,7 +5429,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     mql: |
-      k8s.cronjob.initContainers.any( resources['limits']['cpu'] != empty )
+      k8s.cronjob.initContainers.all( resources['limits']['cpu'] != empty )
       k8s.cronjob.containers.all( resources['limits']['cpu'] != empty )
     docs:
       desc: |
@@ -5482,7 +5482,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     mql: |
-      k8s.statefulset.initContainers.any( resources['limits']['cpu'] != empty )
+      k8s.statefulset.initContainers.all( resources['limits']['cpu'] != empty )
       k8s.statefulset.containers.all( resources['limits']['cpu'] != empty )
     docs:
       desc: |
@@ -5535,7 +5535,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     mql: |
-      k8s.deployment.initContainers.any( resources['limits']['cpu'] != empty )
+      k8s.deployment.initContainers.all( resources['limits']['cpu'] != empty )
       k8s.deployment.containers.all( resources['limits']['cpu'] != empty )
     docs:
       desc: |
@@ -5588,7 +5588,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     mql: |
-      k8s.job.initContainers.any( resources['limits']['cpu'] != empty )
+      k8s.job.initContainers.all( resources['limits']['cpu'] != empty )
       k8s.job.containers.all( resources['limits']['cpu'] != empty )
     docs:
       desc: |
@@ -5641,7 +5641,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     mql: |
-      k8s.replicaset.initContainers.any( resources['limits']['cpu'] != empty )
+      k8s.replicaset.initContainers.all( resources['limits']['cpu'] != empty )
       k8s.replicaset.containers.all( resources['limits']['cpu'] != empty )
     docs:
       desc: |
@@ -5694,7 +5694,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     mql: |
-      k8s.daemonset.initContainers.any( resources['limits']['cpu'] != empty )
+      k8s.daemonset.initContainers.all( resources['limits']['cpu'] != empty )
       k8s.daemonset.containers.all( resources['limits']['cpu'] != empty )
     docs:
       desc: |
@@ -5747,7 +5747,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     mql: |
-      k8s.pod.initContainers.any( resources['limits']['memory'] != empty )
+      k8s.pod.initContainers.all( resources['limits']['memory'] != empty )
       k8s.pod.containers.all( resources['limits']['memory'] != empty )
     docs:
       desc: |
@@ -5797,7 +5797,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     mql: |
-      k8s.cronjob.initContainers.any( resources['limits']['memory'] != empty )
+      k8s.cronjob.initContainers.all( resources['limits']['memory'] != empty )
       k8s.cronjob.containers.all( resources['limits']['memory'] != empty )
     docs:
       desc: |
@@ -5836,7 +5836,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     mql: |
-      k8s.statefulset.initContainers.any( resources['limits']['memory'] != empty )
+      k8s.statefulset.initContainers.all( resources['limits']['memory'] != empty )
       k8s.statefulset.containers.all( resources['limits']['memory'] != empty )
     docs:
       desc: |
@@ -5886,7 +5886,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     mql: |
-      k8s.deployment.initContainers.any( resources['limits']['memory'] != empty )
+      k8s.deployment.initContainers.all( resources['limits']['memory'] != empty )
       k8s.deployment.containers.all( resources['limits']['memory'] != empty )
     docs:
       desc: |
@@ -5936,7 +5936,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     mql: |
-      k8s.job.initContainers.any( resources['limits']['memory'] != empty )
+      k8s.job.initContainers.all( resources['limits']['memory'] != empty )
       k8s.job.containers.all( resources['limits']['memory'] != empty )
     docs:
       desc: |
@@ -5986,7 +5986,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     mql: |
-      k8s.replicaset.initContainers.any( resources['limits']['memory'] != empty )
+      k8s.replicaset.initContainers.all( resources['limits']['memory'] != empty )
       k8s.replicaset.containers.all( resources['limits']['memory'] != empty )
     docs:
       desc: |
@@ -6036,7 +6036,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     mql: |
-      k8s.daemonset.initContainers.any( resources['limits']['memory'] != empty )
+      k8s.daemonset.initContainers.all( resources['limits']['memory'] != empty )
       k8s.daemonset.containers.all( resources['limits']['memory'] != empty )
     docs:
       desc: |


### PR DESCRIPTION
I don't understand what this change is fixing but it definitely breaks stuff. I have a pod with no init containers and this check is failing:
```coffee
cnspec> k8s.deployment.initContainers
k8s.deployment.initContainers: []
cnspec> k8s.deployment.initContainers.any( resources['limits']['cpu'] != empty )
[failed] [].any()
  actual:   []
```

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  generation: 1
  labels:
    admission-result: pass
  name: passing-deployment
  namespace: mondoo-operator
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      admission-result: pass
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        admission-result: pass
    spec:
      automountServiceAccountToken: false
      containers:
      - args:
        - exit 0
        command:
        - /bin/sh
        - -c
        image: ubuntu:20.04
        imagePullPolicy: Always
        livenessProbe:
          exec:
            command:
            - /bin/sh
            - -c
            - exit 0
          failureThreshold: 3
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 1
        name: ubuntu
        readinessProbe:
          exec:
            command:
            - /bin/sh
            - -c
            - exit 0
          failureThreshold: 3
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 1
        resources:
          limits:
            cpu: 100m
            memory: 100Mi
          requests:
            cpu: 100m
            memory: 100Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - NET_RAW
          privileged: false
          readOnlyRootFilesystem: true
          runAsNonRoot: true
          runAsUser: 1000
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
```